### PR TITLE
Added http://bits.netbeans.org/maven2/ dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,10 @@ repositories {
         name "jenkins"
         delegate.url("http://repo.jenkins-ci.org/releases")
     }
+    maven {
+      name "netbeans"
+      url("http://bits.netbeans.org/maven2/")
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Prevents 'gradle test' to fail with "Artifact 'org.netbeans.modules:org-netbeans-insane:RELEASE72@jar' not found" error. Tested with coreVersion = '1.509.1'.
