### PR TITLE
Fix for JENKINS-24298

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,5 @@
     [JENKINS-23603](https://issues.jenkins-ci.org/browse/JENKINS-23603)
   * set up the build to use http://repo.jenkins-ci.org/public/ similar to the Maven POMs
     [JENKINS-19942](https://issues.jenkins-ci.org/browse/JENKINS-19942)
+  * register input files for the localizer task to avoid that the task is skipped when the inputs change
+    [JENKINS-24298](https://issues.jenkins-ci.org/browse/JENKINS-24298)

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
@@ -104,6 +104,7 @@ public class JpiPlugin implements Plugin<Project> {
             task.destinationDir = ext.getStaplerStubDir()
         }
         gradleProject.tasks.withType(LocalizerTask) { LocalizerTask task ->
+            task.sourceDirs = gradleProject.sourceSets.main.resources.srcDirs
             task.destinationDir = ext.getLocalizerDestDir()
         }
 

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/LocalizerTask.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/LocalizerTask.groovy
@@ -17,10 +17,9 @@
 package org.jenkinsci.gradle.plugins.jpi
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.OutputDirectory
-
-import org.jvnet.localizer.GeneratorTask
 
 /**
  * Generates Java source based on localization properties files.
@@ -32,6 +31,9 @@ class LocalizerTask extends DefaultTask {
 
     @OutputDirectory
     File destinationDir
+
+    @InputFiles
+    Set<File> sourceDirs
 
     @TaskAction
     def generateLocalized() {
@@ -45,7 +47,7 @@ class LocalizerTask extends DefaultTask {
                     pathelement(path: p.buildscript.configurations.classpath.asPath)
                 }
             }
-            p.sourceSets.main.getResources().getSrcDirs().each { rsrcDir ->
+            sourceDirs.each { rsrcDir ->
                 generator(todir: destinationDir.canonicalPath, dir: rsrcDir)
             }
         }


### PR DESCRIPTION
Register input files for localizer task to avoid that the task is skipped when the inputs change.

https://issues.jenkins-ci.org/browse/JENKINS-24298
