### PR TITLE
avoid deprecation warning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     compile gradleApi()
     compile('org.jvnet.localizer:maven-localizer-plugin:1.13',
             'org.jenkins-ci:version-number:1.0')
-    groovy localGroovy()
+    compile localGroovy()
 }
 
 artifacts {


### PR DESCRIPTION
This gets rid of the groovy configuration deprecation warning.
