### PR TITLE
Add local repo option

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,12 +120,18 @@ gradle.taskGraph.whenReady { taskGraph ->
         uploadArchives {
             repositories {
                 mavenDeployer {
-                    def credentials = loadCredentialsForJenkinsCommunityRepository()
-                    repository(url: 'http://maven.jenkins-ci.org:8081/content/repositories/releases') {
-                        authentication(credentials)
-                    }
-                    snapshotRepository(url: 'http://maven.jenkins-ci.org:8081/content/repositories/snapshots') {
-                        authentication(credentials)
+                    if(project.version.endsWith('-LOCAL')) {
+                        repository(url: "file://${projectDir}/build/repo")
+                    } else if(project.version.endsWith('-SNAPSHOT')) {
+                        def credentials = loadCredentialsForJenkinsCommunityRepository()
+                        repository(url: 'http://maven.jenkins-ci.org:8081/content/repositories/snapshots') {
+                            authentication(credentials)
+                        }
+                    } else {
+                        def credentials = loadCredentialsForJenkinsCommunityRepository()
+                        repository(url: 'http://maven.jenkins-ci.org:8081/content/repositories/releases') {
+                            authentication(credentials)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The problem this addresses is to allow people without jenkins repo access to build and modify the plugin

in the gradle.properties file change the line to

```
version=0.6.1-LOCAL
```

for example

```
./gradlew uploadArchives
```

will add the jar to build/repo

In a corresponding build.gradle in your actual jenkins plugin you can add

```
buildscript {
    repositories {
        maven {
            name "jenkins-local"
            delegate.url( "file://path/to/gradle-jpi-plugin/build/repo" )
        }
        maven {
            name "jenkins"
            delegate.url("http://repo.jenkins-ci.org/releases/")
        }
        mavenCentral()
    }
    dependencies {
        classpath 'org.jenkins-ci.tools:gradle-jpi-plugin:0.6.1-LOCAL'
    }
}
```
