### PR TITLE
fixed an issue with gradle 2.x compatibility

### DIFF
--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtension.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtension.groovy
@@ -256,7 +256,7 @@ class JpiExtension {
      */
     FileCollection getRuntimeClasspath() {
         def providedRuntime = project.configurations.getByName(WarPlugin.PROVIDED_RUNTIME_CONFIGURATION_NAME)
-        def groovyRuntime = project.configurations.getByName(GroovyBasePlugin.GROOVY_CONFIGURATION_NAME)
+        def groovyRuntime = project.configurations.getByName('compile')
         mainSourceTree().runtimeClasspath - providedRuntime - groovyRuntime
     }
 


### PR DESCRIPTION
This fix works and is backwards compatible to gradle 1.x with one caveat: it must be built with the version of gradle that it is intended to be used for.  For the plugin to function with gradle 2.x, it needs to be built with gradle 2.x.  Similarly, it must be built with gradle 1.x to function with gradle 1.x.

Tested with gradle 2.1 and 1.11
