### PR TITLE
Set classpath on IsolatedAntBuilder

### DIFF
--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/LocalizerTask.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/LocalizerTask.groovy
@@ -39,14 +39,10 @@ class LocalizerTask extends DefaultTask {
     def generateLocalized() {
         def p = project
 
-        def isolatedAnt = services.get(IsolatedAntBuilder)
+        def isolatedAnt = services.get(IsolatedAntBuilder).withClasspath(p.buildscript.configurations.classpath)
         isolatedAnt.execute {
             mkdir(dir: destinationDir.canonicalPath)
-            taskdef(name: 'generator', classname: 'org.jvnet.localizer.GeneratorTask') {
-                classpath {
-                    pathelement(path: p.buildscript.configurations.classpath.asPath)
-                }
-            }
+            taskdef(name: 'generator', classname: 'org.jvnet.localizer.GeneratorTask')
             sourceDirs.findAll { it.exists() }.each { rsrcDir ->
                 generator(todir: destinationDir.canonicalPath, dir: rsrcDir)
             }

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/StaplerGroovyStubsTask.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/StaplerGroovyStubsTask.groovy
@@ -32,14 +32,10 @@ class StaplerGroovyStubsTask extends DefaultTask {
     @TaskAction
     def generateStubs() {
         def p = project
-        def isolatedAnt = services.get(IsolatedAntBuilder)
+        def isolatedAnt = services.get(IsolatedAntBuilder).withClasspath(p.sourceSets.main.compileClasspath)
         isolatedAnt.execute {
             mkdir(dir: destinationDir.canonicalPath)
-            taskdef(name: 'generatestubs', classname: 'org.codehaus.groovy.ant.GenerateStubsTask') {
-                classpath {
-                    pathelement path: p.sourceSets.main.compileClasspath.asPath
-                }
-            }
+            taskdef(name: 'generatestubs', classname: 'org.codehaus.groovy.ant.GenerateStubsTask')
 
             generatestubs(destdir: destinationDir.canonicalPath) {
                 configuration(targetByteCode: '1.6')


### PR DESCRIPTION
Setting the classpath in the Ant script seems to be broken/unsupported in Gradle 2.2.
