### PR TITLE
Migration to maven-publish plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## 0.8.0 (unreleased)
 
   * updated Gradle to version 2.1
+  * migrated to the maven-publish plugin
+    * use the `publish` and `publishToMavenLocal` tasks for publishing, the `install`, `deploy` and `uploadArchives`
+      tasks are no longer available
+    * the generated POM no longer contains a reference to the Jenkins plugin parent POM and all dependencies have the
+      runtime scope
 
 ## 0.7.2 (2014-12-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
   * migrated to the maven-publish plugin
     * use the `publish` and `publishToMavenLocal` tasks for publishing, the `install`, `deploy` and `uploadArchives`
       tasks are no longer available
-    * the generated POM no longer contains a reference to the Jenkins plugin parent POM and all dependencies have the
-      runtime scope
+    * all dependencies in the generated POM have the runtime scope
 
 ## 0.7.2 (2014-12-19)
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     testCompile('org.spockframework:spock-core:0.7-groovy-2.0') {
         exclude module: 'groovy-all' // use the version that is distributed with Gradle
     }
+    testCompile 'xmlunit:xmlunit:1.5'
 }
 
 artifacts {

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiComponent.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiComponent.groovy
@@ -1,0 +1,33 @@
+package org.jenkinsci.gradle.plugins.jpi
+
+import org.gradle.api.artifacts.DependencySet
+import org.gradle.api.artifacts.ModuleDependency
+import org.gradle.api.artifacts.PublishArtifact
+import org.gradle.api.internal.component.SoftwareComponentInternal
+import org.gradle.api.internal.component.Usage
+
+class JpiComponent implements SoftwareComponentInternal {
+    private final Usage jpiUsage = new JpiUsage()
+    private final Set<PublishArtifact> jpiArtifacts
+    private final Iterable<DependencySet> jpiDependencies
+
+    final String name = 'jpi'
+    final Set<Usage> usages = [jpiUsage]
+
+    JpiComponent(PublishArtifact jpiArtifact, Iterable<DependencySet> jpiDependencies) {
+        this.jpiArtifacts = [jpiArtifact]
+        this.jpiDependencies = jpiDependencies
+    }
+
+    private class JpiUsage implements Usage {
+        final String name = 'jpi'
+
+        Set<PublishArtifact> getArtifacts() {
+            jpiArtifacts
+        }
+
+        Set<ModuleDependency> getDependencies() {
+            jpiDependencies*.withType(ModuleDependency).flatten()
+        }
+    }
+}

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiDeveloper.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiDeveloper.groovy
@@ -25,7 +25,7 @@ import org.gradle.util.ConfigureUtil
  * @author Andrew Bayer
  */
 class JpiDeveloper {
-    private final static LEGAL_FIELDS = ['id', 'name', 'email', 'url', 'organization', 'organizationUrl', 'timezone']
+    final static LEGAL_FIELDS = ['id', 'name', 'email', 'url', 'organization', 'organizationUrl', 'timezone']
 
     private final fields = [:]
 

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtension.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtension.groovy
@@ -285,5 +285,9 @@ class JpiExtension {
         def getProperties() {
             developerMap
         }
+
+        boolean isEmpty() {
+            developerMap.isEmpty()
+        }
     }
 }

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
@@ -108,7 +108,6 @@ class JpiPlugin implements Plugin<Project> {
         def jpi = gradleProject.tasks.create(Jpi.TASK_NAME, Jpi)
         jpi.description = 'Generates the JPI package'
         jpi.group = BasePlugin.BUILD_GROUP
-        gradleProject.extensions.getByType(DefaultArtifactPublicationSet).addCandidate(new ArchivePublishArtifact(jpi))
 
         def server = gradleProject.tasks.create(ServerTask.TASK_NAME, ServerTask)
         server.description = 'Run Jenkins in place with the plugin being developed'

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPomCustomizer.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPomCustomizer.groovy
@@ -1,0 +1,78 @@
+package org.jenkinsci.gradle.plugins.jpi
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+
+/**
+ * Adds metadata to the JPI's POM.
+ *
+ * The POM is parsed by the <a href="https://github.com/jenkinsci/backend-update-center2">Jenkins Update Center
+ * Generator</a> to extract the following information:
+ * <ul>
+ *     <li>The URL to the wiki page (<code>/project/url</code>)
+ *     <li>The SCM Host (<code>/project/scm/connection</code>)
+ *     <li>The project name (<code>/project/name</code>)
+ *     <li>An excerpt (<code>/project/description</code>)
+ * </ul>
+ */
+class JpiPomCustomizer {
+    private final Project project
+    private final JpiExtension jpiExtension
+
+    JpiPomCustomizer(Project project) {
+        this.project = project
+        this.jpiExtension = project.extensions.findByType(JpiExtension)
+    }
+
+    void customizePom(Node pom) {
+        pom.appendNode('name', jpiExtension.displayName)
+        if (jpiExtension.url) {
+            pom.appendNode('url', jpiExtension.url)
+        }
+        if (project.description) {
+            pom.appendNode('description', project.description)
+        }
+        if (jpiExtension.gitHubUrl) {
+            pom.append(makeScmNode())
+        }
+        if (!jpiExtension.developers.isEmpty()) {
+            pom.appendNode('developers', jpiExtension.developers.collect { JpiDeveloper d -> makeDeveloperNode(d) })
+        }
+        if (repositories) {
+            pom.appendNode('repositories', repositories.collect { makeRepositoryNode(it) })
+        }
+    }
+
+    private Node makeScmNode() {
+        Node scmNode = new Node(null, 'scm')
+        scmNode.appendNode('url', jpiExtension.gitHubUrl)
+        if (jpiExtension.gitHubUrl =~ /^https:\/\/github\.com/) {
+            scmNode.appendNode('connection', jpiExtension.gitHubUrl.replaceFirst(~/https:/, 'scm:git:git:') + '.git')
+        }
+        scmNode
+    }
+
+    private List<MavenArtifactRepository> getRepositories() {
+        project.repositories.withType(MavenArtifactRepository).findAll {
+            it.name != 'MavenRepo' && it.name != 'MavenLocal'
+        }
+    }
+
+    private static Node makeRepositoryNode(MavenArtifactRepository repository) {
+        Node repositoryNode = new Node(null, 'repository')
+        repositoryNode.appendNode('id', repository.name)
+        repositoryNode.appendNode('url', repository.url)
+        repositoryNode
+    }
+
+    private static Node makeDeveloperNode(JpiDeveloper developer) {
+        Node developerNode = new Node(null, 'developer')
+        JpiDeveloper.LEGAL_FIELDS.each { String key ->
+            def value = developer[key]
+            if (value) {
+                developerNode.appendNode(key, value)
+            }
+        }
+        developerNode
+    }
+}

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPomCustomizer.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPomCustomizer.groovy
@@ -3,6 +3,9 @@ package org.jenkinsci.gradle.plugins.jpi
 import org.gradle.api.Project
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 
+import static org.gradle.api.artifacts.ArtifactRepositoryContainer.DEFAULT_MAVEN_CENTRAL_REPO_NAME
+import static org.gradle.api.artifacts.ArtifactRepositoryContainer.DEFAULT_MAVEN_LOCAL_REPO_NAME
+
 /**
  * Adds metadata to the JPI's POM.
  *
@@ -63,7 +66,7 @@ class JpiPomCustomizer {
 
     private List<MavenArtifactRepository> getRepositories() {
         project.repositories.withType(MavenArtifactRepository).findAll {
-            !(it.name =~ /MavenRepo\d*/ || it.name =~ /MavenLocal\d*/)
+            !(it.name =~ "${DEFAULT_MAVEN_CENTRAL_REPO_NAME}\\d*" || it.name =~ "${DEFAULT_MAVEN_LOCAL_REPO_NAME}\\d*")
         }
     }
 

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPomCustomizer.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPomCustomizer.groovy
@@ -25,6 +25,7 @@ class JpiPomCustomizer {
     }
 
     void customizePom(Node pom) {
+        pom.append(makeParentNode())
         pom.appendNode('name', jpiExtension.displayName)
         if (jpiExtension.url) {
             pom.appendNode('url', jpiExtension.url)
@@ -43,6 +44,14 @@ class JpiPomCustomizer {
         }
     }
 
+    private Node makeParentNode() {
+        Node parentNode = new Node(null, 'parent')
+        parentNode.appendNode('groupId', 'org.jenkins-ci.plugins')
+        parentNode.appendNode('artifactId', 'plugin')
+        parentNode.appendNode('version', jpiExtension.coreVersion)
+        parentNode
+    }
+
     private Node makeScmNode() {
         Node scmNode = new Node(null, 'scm')
         scmNode.appendNode('url', jpiExtension.gitHubUrl)
@@ -54,7 +63,7 @@ class JpiPomCustomizer {
 
     private List<MavenArtifactRepository> getRepositories() {
         project.repositories.withType(MavenArtifactRepository).findAll {
-            it.name != 'MavenRepo' && it.name != 'MavenLocal'
+            !(it.name =~ /MavenRepo\d*/ || it.name =~ /MavenLocal\d*/)
         }
     }
 

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPomCustomizerSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPomCustomizerSpec.groovy
@@ -15,7 +15,12 @@ class JpiPomCustomizerSpec extends Specification {
 
     def 'minimal POM'() {
         setup:
-        project.apply plugin: 'jpi'
+        project.with {
+            apply plugin: 'jpi'
+            jenkinsPlugin {
+                coreVersion = '1.580.1'
+            }
+        }
 
         when:
         new JpiPomCustomizer(project).customizePom(pom)
@@ -30,6 +35,7 @@ class JpiPomCustomizerSpec extends Specification {
             apply plugin: 'jpi'
             description = 'lorem ipsum'
             jenkinsPlugin {
+                coreVersion = '1.580.1'
                 url = 'https://lorem-ipsum.org'
                 gitHubUrl = 'https://github.com/lorem/ipsum'
                 developers {
@@ -60,6 +66,7 @@ class JpiPomCustomizerSpec extends Specification {
         project.with {
             apply plugin: 'jpi'
             jenkinsPlugin {
+                coreVersion = '1.580.1'
                 gitHubUrl = 'https://bitbucket.org/lorem/ipsum'
             }
         }
@@ -75,6 +82,9 @@ class JpiPomCustomizerSpec extends Specification {
         setup:
         project.with {
             apply plugin: 'jpi'
+            jenkinsPlugin {
+                coreVersion = '1.580.1'
+            }
             repositories {
                 mavenLocal()
             }
@@ -91,6 +101,9 @@ class JpiPomCustomizerSpec extends Specification {
         setup:
         project.with {
             apply plugin: 'jpi'
+            jenkinsPlugin {
+                coreVersion = '1.580.1'
+            }
             repositories {
                 mavenCentral()
             }

--- a/src/test/resources/org/jenkinsci/gradle/plugins/jpi/bitbucket-pom.xml
+++ b/src/test/resources/org/jenkinsci/gradle/plugins/jpi/bitbucket-pom.xml
@@ -1,6 +1,17 @@
 <project>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>1.580.1</version>
+    </parent>
     <name>test</name>
     <scm>
         <url>https://bitbucket.org/lorem/ipsum</url>
     </scm>
+    <repositories>
+        <repository>
+            <id>jenkins</id>
+            <url>http://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
 </project>

--- a/src/test/resources/org/jenkinsci/gradle/plugins/jpi/bitbucket-pom.xml
+++ b/src/test/resources/org/jenkinsci/gradle/plugins/jpi/bitbucket-pom.xml
@@ -1,0 +1,6 @@
+<project>
+    <name>test</name>
+    <scm>
+        <url>https://bitbucket.org/lorem/ipsum</url>
+    </scm>
+</project>

--- a/src/test/resources/org/jenkinsci/gradle/plugins/jpi/complex-pom.xml
+++ b/src/test/resources/org/jenkinsci/gradle/plugins/jpi/complex-pom.xml
@@ -1,0 +1,22 @@
+<project>
+    <name>test</name>
+    <url>https://lorem-ipsum.org</url>
+    <description>lorem ipsum</description>
+    <scm>
+        <url>https://github.com/lorem/ipsum</url>
+        <connection>scm:git:git://github.com/lorem/ipsum.git</connection>
+    </scm>
+    <developers>
+        <developer>
+            <id>abayer</id>
+            <name>Andrew Bayer</name>
+            <email>andrew.bayer@gmail.com</email>
+        </developer>
+    </developers>
+    <repositories>
+        <repository>
+            <id>lorem-ipsum</id>
+            <url>https://repo.lorem-ipsum.org/</url>
+        </repository>
+    </repositories>
+</project>

--- a/src/test/resources/org/jenkinsci/gradle/plugins/jpi/complex-pom.xml
+++ b/src/test/resources/org/jenkinsci/gradle/plugins/jpi/complex-pom.xml
@@ -1,4 +1,9 @@
 <project>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>1.580.1</version>
+    </parent>
     <name>test</name>
     <url>https://lorem-ipsum.org</url>
     <description>lorem ipsum</description>
@@ -14,6 +19,10 @@
         </developer>
     </developers>
     <repositories>
+        <repository>
+            <id>jenkins</id>
+            <url>http://repo.jenkins-ci.org/public/</url>
+        </repository>
         <repository>
             <id>lorem-ipsum</id>
             <url>https://repo.lorem-ipsum.org/</url>

--- a/src/test/resources/org/jenkinsci/gradle/plugins/jpi/minimal-pom.xml
+++ b/src/test/resources/org/jenkinsci/gradle/plugins/jpi/minimal-pom.xml
@@ -1,0 +1,3 @@
+<project>
+    <name>test</name>
+</project>

--- a/src/test/resources/org/jenkinsci/gradle/plugins/jpi/minimal-pom.xml
+++ b/src/test/resources/org/jenkinsci/gradle/plugins/jpi/minimal-pom.xml
@@ -1,3 +1,14 @@
 <project>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>1.580.1</version>
+    </parent>
     <name>test</name>
+    <repositories>
+        <repository>
+            <id>jenkins</id>
+            <url>http://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
 </project>


### PR DESCRIPTION
Upcoming changes in Gradle 2.3 ([GRADLE-2999](https://issues.gradle.org/browse/GRADLE-2999)) will allow to publish a second artifact without classifier. This enables the Gradle JPI Plugin to publish the plugin JAR together with the JPI file ([JENKINS-25007](https://issues.jenkins-ci.org/browse/JENKINS-25007)).

Publishing a second artifact is only possible with the maven-publish plugin. This pull requests migrates to the maven-publish plugin.

As a consequence the `install`, `deploy` and `uploadArchives` tasks are no longer available for publishing JPI files and have been replaced by the `publishToMavenLocal` and `publish` tasks.

The generated POM also differs. ~~It no longer contains a reference to the Jenkins plugin parent POM and~~ all dependencies have the runtime scope. That should not matter as long as only the JPI file is published because the POM is only consumed by the [Jenkins Update Center Generator](https://github.com/jenkinsci/backend-update-center2) and the POM contains all relevant information used by the Jenkins Update Center Generator. The POM needs to be adapted when publishing the JAR file.