### PR TITLE
Making configurePublishing() protected

### DIFF
--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
@@ -197,7 +197,7 @@ class JpiPlugin implements Plugin<Project> {
                 setDescription('Jenkins war that corresponds to the Jenkins core')
     }
 
-    private static configurePublishing(Project project) {
+    protected static configurePublishing(Project project) {
         PublishingExtension publishingExtension = project.extensions.getByType(PublishingExtension)
         JpiExtension jpiExtension = project.extensions.getByType(JpiExtension)
 


### PR DESCRIPTION
... so that it can be overridden.

E.g. turning publishing off so that a custom publishing can be implemented.