### PR TITLE
set buildDirectory system property for Jenkins test harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.8.1 (unreleased)
 
-  * create (for coreVersions >= 1.545 and < 1.592) and clean `target` directory used by
-    `org.jvnet.hudson.test.WarExploder` as a workaround for
+  * create `target` directory (for coreVersions >= 1.545 and < 1.592), clean `target` directory (for coreVersions
+    < 1.598) and set `buildDirectory` system property for Jenkins test harness
     [JENKINS-26331](https://issues.jenkins-ci.org/browse/JENKINS-26331)
 
 ## 0.8.0 (2015-01-06)

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtension.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtension.groovy
@@ -19,6 +19,7 @@ import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.plugins.WarPlugin
+import org.gradle.api.tasks.Delete
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.GradleException
 import org.gradle.util.ConfigureUtil
@@ -129,12 +130,16 @@ class JpiExtension {
             uiSamplesVersion = '2.0'
         }
 
+        // workarounds for JENKINS-26331
         if (new VersionNumber(this.coreVersion) >= new VersionNumber('1.545') &&
                 new VersionNumber(this.coreVersion) < new VersionNumber('1.592')) {
-            // workaround for JENKINS-26331
             project.tasks.test.doFirst {
                 project.file('target').mkdirs()
             }
+        }
+        if (new VersionNumber(this.coreVersion) < new VersionNumber('1.598')) {
+            Delete clean = project.tasks.clean as Delete
+            clean.delete('target')
         }
 
         if (this.coreVersion) {

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
@@ -32,9 +32,9 @@ import org.gradle.api.plugins.GroovyPlugin
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
-import org.gradle.api.tasks.Delete
 import org.gradle.api.tasks.bundling.AbstractArchiveTask
 import org.gradle.api.tasks.bundling.Jar
+import org.gradle.api.tasks.testing.Test
 import org.gradle.execution.TaskGraphExecuter
 
 /**
@@ -123,9 +123,9 @@ class JpiPlugin implements Plugin<Project> {
 
         gradleProject.tasks.compileJava.dependsOn(StaplerGroovyStubsTask.TASK_NAME)
 
-        // workaround for JENKINS-26331
-        Delete clean = gradleProject.tasks.clean as Delete
-        clean.delete('target')
+        // set build directory for Jenkins test harness, JENKINS-26331
+        Test test = gradleProject.tasks.test as Test
+        test.systemProperty('buildDirectory', gradleProject.buildDir.absolutePath)
 
         def localizer = gradleProject.tasks.create(LocalizerTask.TASK_NAME, LocalizerTask)
         localizer.description = 'Generates the Java source for the localizer.'


### PR DESCRIPTION
The `buildDirectory` system property is set for all versions since JenkinsRule and HudsonTestCase also use that property for other purposes.

The fix for [JENKINS-26331](https://issues.jenkins-ci.org/browse/JENKINS-26331) will be included in 1.597, so we need to care about the `target` directory only for coreVersions < 1.597.
