### PR TITLE
Added configurePublishing Option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
     ([JENKINS-17129](https://issues.jenkins-ci.org/browse/JENKINS-17129))
   * added `configureRepositories` option to be able to skip configuration of repositories
     ([JENKINS-17130](https://issues.jenkins-ci.org/browse/JENKINS-17130))
+  * added `configurePublishing` option to be able to skip configuration of publications or repositories for the Maven
+    Publishing plugin
 
 ## 0.9.1 (2015-02-17)
 

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtension.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtension.groovy
@@ -257,6 +257,11 @@ class JpiExtension {
      */
     boolean configureRepositories = true
 
+    /**
+     * If false, no publications or repositories for the Maven Publishing plugin will be configured.
+     */
+    boolean configurePublishing = true
+
     Developers developers = new Developers()
 
     def developers(Closure closure) {


### PR DESCRIPTION
Added `configurePublishing` option to be able to skip configuration of publications or repositories for the Maven Publishing plugin.