### PR TITLE
Added configureRepositories Option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
     configuration to recognize a non-default value
   * add a JAR dependency for each HPI/JPI dependency to the `testCompile` configuration
     ([JENKINS-17129](https://issues.jenkins-ci.org/browse/JENKINS-17129))
+  * added `configureRepositories` option to be able to skip configuration of repositories
+    ([JENKINS-17130](https://issues.jenkins-ci.org/browse/JENKINS-17130))
 
 ## 0.9.1 (2015-02-17)
 

--- a/config/codenarc/rules.groovy
+++ b/config/codenarc/rules.groovy
@@ -18,6 +18,8 @@ ruleset {
         // does not necessarily lead to better code
         exclude 'DuplicateMapLiteral'
         // does not necessarily lead to better code
+        exclude 'DuplicateNumberLiteral'
+        // does not necessarily lead to better code
         exclude 'DuplicateStringLiteral'
     }
 

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtension.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtension.groovy
@@ -141,15 +141,6 @@ class JpiExtension {
         }
 
         if (this.coreVersion) {
-            project.repositories {
-                mavenCentral()
-                mavenLocal()
-                maven {
-                    name 'jenkins'
-                    delegate.url('http://repo.jenkins-ci.org/public/')
-                }
-            }
-
             project.dependencies {
                 jenkinsCore(
                         [group: 'org.jenkins-ci.main', name: 'jenkins-core', version: v, ext: 'jar', transitive: true],
@@ -260,6 +251,11 @@ class JpiExtension {
      * If true, verify that all the jelly scripts have the Jelly XSS PI in them.
      */
     boolean requirePI = true
+
+    /**
+     * Set to false to disable configuration of Maven Central, the local Maven cache and the Jenkins Maven repository.
+     */
+    boolean configureRepositories = true
 
     Developers developers = new Developers()
 

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
@@ -130,6 +130,7 @@ class JpiPlugin implements Plugin<Project> {
             from gradleProject.javadoc.destinationDir
         }
 
+        configureRepositories(gradleProject)
         configureConfigurations(gradleProject)
         configurePublishing(gradleProject)
 
@@ -168,6 +169,21 @@ class JpiPlugin implements Plugin<Project> {
         }
         javaConvention.sourceSets.main.java.srcDir { localizer.destinationDir }
         project.tasks[javaConvention.sourceSets.main.compileJavaTaskName].dependsOn(localizer)
+    }
+
+    private static configureRepositories(Project project) {
+        project.afterEvaluate {
+            if (project.extensions.getByType(JpiExtension).configureRepositories) {
+                project.repositories {
+                    mavenCentral()
+                    mavenLocal()
+                    maven {
+                        name 'jenkins'
+                        url('http://repo.jenkins-ci.org/public/')
+                    }
+                }
+            }
+        }
     }
 
     private static configureConfigurations(Project project) {

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiManifestSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiManifestSpec.groovy
@@ -1,6 +1,7 @@
 package org.jenkinsci.gradle.plugins.jpi
 
 import org.gradle.api.Project
+import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
@@ -81,6 +82,7 @@ class JpiManifestSpec extends Specification {
                 jenkinsPlugins 'org.jenkins-ci.plugins:ant:1.2@jar'
             }
         }
+        (project as ProjectInternal).evaluate()
 
         when:
         Manifest manifest = new JpiManifest(project)
@@ -103,6 +105,7 @@ class JpiManifestSpec extends Specification {
                 jenkinsPlugins 'org.jenkins-ci.plugins:ant:1.2@jar'
             }
         }
+        (project as ProjectInternal).evaluate()
 
         when:
         Manifest manifest = new JpiManifest(project)
@@ -124,6 +127,7 @@ class JpiManifestSpec extends Specification {
                 optionalJenkinsPlugins 'org.jenkins-ci.plugins:ant:1.2@jar'
             }
         }
+        (project as ProjectInternal).evaluate()
 
         when:
         Manifest manifest = new JpiManifest(project)
@@ -146,6 +150,7 @@ class JpiManifestSpec extends Specification {
                 optionalJenkinsPlugins 'org.jenkins-ci.plugins:ant:1.2@jar'
             }
         }
+        (project as ProjectInternal).evaluate()
 
         when:
         Manifest manifest = new JpiManifest(project)
@@ -170,6 +175,7 @@ class JpiManifestSpec extends Specification {
                 optionalJenkinsPlugins 'org.jenkins-ci.plugins:credentials:1.9.4@jar'
             }
         }
+        (project as ProjectInternal).evaluate()
 
         when:
         Manifest manifest = new JpiManifest(project)

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPomCustomizerSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPomCustomizerSpec.groovy
@@ -2,6 +2,7 @@ package org.jenkinsci.gradle.plugins.jpi
 
 import org.custommonkey.xmlunit.XMLUnit
 import org.gradle.api.Project
+import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
 
@@ -21,6 +22,7 @@ class JpiPomCustomizerSpec extends Specification {
                 coreVersion = '1.580.1'
             }
         }
+        (project as ProjectInternal).evaluate()
 
         when:
         new JpiPomCustomizer(project).customizePom(pom)
@@ -53,6 +55,7 @@ class JpiPomCustomizerSpec extends Specification {
                 }
             }
         }
+        (project as ProjectInternal).evaluate()
 
         when:
         new JpiPomCustomizer(project).customizePom(pom)
@@ -70,6 +73,7 @@ class JpiPomCustomizerSpec extends Specification {
                 gitHubUrl = 'https://bitbucket.org/lorem/ipsum'
             }
         }
+        (project as ProjectInternal).evaluate()
 
         when:
         new JpiPomCustomizer(project).customizePom(pom)
@@ -89,6 +93,7 @@ class JpiPomCustomizerSpec extends Specification {
                 mavenLocal()
             }
         }
+        (project as ProjectInternal).evaluate()
 
         when:
         new JpiPomCustomizer(project).customizePom(pom)
@@ -108,6 +113,7 @@ class JpiPomCustomizerSpec extends Specification {
                 mavenCentral()
             }
         }
+        (project as ProjectInternal).evaluate()
 
         when:
         new JpiPomCustomizer(project).customizePom(pom)

--- a/src/test/resources/org/jenkinsci/gradle/plugins/jpi/complex-pom.xml
+++ b/src/test/resources/org/jenkinsci/gradle/plugins/jpi/complex-pom.xml
@@ -20,12 +20,12 @@
     </developers>
     <repositories>
         <repository>
-            <id>jenkins</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
-        </repository>
-        <repository>
             <id>lorem-ipsum</id>
             <url>https://repo.lorem-ipsum.org/</url>
+        </repository>
+        <repository>
+            <id>jenkins</id>
+            <url>http://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
 </project>


### PR DESCRIPTION
Added `configureRepositories` option to be able to skip configuration of repositories.

See [JENKINS-17130](https://issues.jenkins-ci.org/browse/JENKINS-17130).