### PR TITLE
JENKINS-27994 Adding the manifest in the JAR

### DIFF
--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/Jpi.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/Jpi.groovy
@@ -17,7 +17,7 @@ package org.jenkinsci.gradle.plugins.jpi
 
 import org.gradle.api.tasks.bundling.War
 
-import java.util.jar.Attributes
+import static org.jenkinsci.gradle.plugins.jpi.JpiManifest.attributesToMap
 
 /**
  * Assembles an hpi archive.
@@ -39,8 +39,4 @@ class Jpi extends War {
     }
 
     public static final String TASK_NAME = 'jpi'
-
-    private static Map<String, ?> attributesToMap(Attributes attributes) {
-        attributes.collectEntries { k, v -> [k.toString(), v] }
-    }
 }

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiManifest.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiManifest.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.plugins.JavaPluginConvention
 
 import java.text.SimpleDateFormat
+import java.util.jar.Attributes
 import java.util.jar.Manifest
 
 import static java.util.jar.Attributes.Name.MANIFEST_VERSION
@@ -133,5 +134,9 @@ class JpiManifest extends Manifest {
             return YesNoMaybe.MAYBE
         }
         YesNoMaybe.YES
+    }
+
+    static Map<String, ?> attributesToMap(Attributes attributes) {
+        attributes.collectEntries { k, v -> [k.toString(), v] }
     }
 }

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
@@ -40,6 +40,7 @@ import org.gradle.api.tasks.testing.Test
 import org.gradle.execution.TaskGraphExecuter
 
 import static org.gradle.util.GFileUtils.copyFile
+import static org.jenkinsci.gradle.plugins.jpi.JpiManifest.attributesToMap
 
 /**
  * Loads HPI related tasks into the current project.
@@ -134,6 +135,15 @@ class JpiPlugin implements Plugin<Project> {
 
         configureRepositories(gradleProject)
         configureConfigurations(gradleProject)
+
+        // manifest in the JAR file
+        gradleProject.afterEvaluate {
+            Jar jar = gradleProject.tasks.getByName(JavaPlugin.JAR_TASK_NAME) as Jar
+            jar.manifest {
+                attributes(attributesToMap(new JpiManifest(gradleProject).mainAttributes))
+            }
+        }
+
         configureTestResources(gradleProject)
         configurePublishing(gradleProject)
 

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiManifestSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiManifestSpec.groovy
@@ -2,6 +2,7 @@ package org.jenkinsci.gradle.plugins.jpi
 
 import org.gradle.api.Project
 import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.jvm.tasks.Jar
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
@@ -32,6 +33,28 @@ class JpiManifestSpec extends Specification {
 
         then:
         manifest == readManifest('basics.mf')
+    }
+
+    def 'basics for JAR'() {
+        setup:
+        project.with {
+            apply plugin: 'jpi'
+            group = 'org.example'
+            version = '1.2'
+            jenkinsPlugin {
+                coreVersion = '1.509.3'
+            }
+        }
+        (project as ProjectInternal).evaluate()
+
+        when:
+        Jar jar = project.tasks.jar as Jar
+        def manifest = jar.manifest
+
+        then:
+        manifest.attributes.collectEntries { k, v -> [k.toString(), v] } == JpiManifest.attributesToMap(
+                readManifest('basics.mf').mainAttributes
+        )
     }
 
     def 'plugin class'() {


### PR DESCRIPTION
In order to make the Job DSL plug-in useable from other plug-ins, especially in their integration tests using the JenkinsRule, the JAR needs the Manifest information.

See [JENKINS-27994](https://issues.jenkins-ci.org/browse/JENKINS-27994) for more context.