### PR TITLE
copy plugin dependencies to test-dependencies directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.16.1 (unreleased)
 
+  * copy plugin dependencies to `test-dependencies` directory instead of `plugins` directory to mimic the behavior of
+    the Maven HPI plugin
+    ([#74](https://github.com/jenkinsci/gradle-jpi-plugin/pull/74))
+
 ## 0.16.0 (2016-03-22)
 
   * updated Gradle to version 2.8

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/TestDependenciesTask.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/TestDependenciesTask.groovy
@@ -1,0 +1,35 @@
+package org.jenkinsci.gradle.plugins.jpi
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+
+import static org.gradle.util.GFileUtils.copyFile
+
+class TestDependenciesTask extends DefaultTask {
+    public static final String TASK_NAME = 'resolveTestDependencies'
+
+    @InputFiles
+    Configuration pluginsConfiguration
+
+    @OutputDirectory
+    File testDependenciesDir
+
+    TestDependenciesTask() {
+        JavaPluginConvention javaConvention = project.convention.getPlugin(JavaPluginConvention)
+        testDependenciesDir = new File(javaConvention.sourceSets.test.output.resourcesDir, 'test-dependencies')
+    }
+
+    @TaskAction
+    void resolveTestDependencies() {
+        List<String> artifacts = []
+        pluginsConfiguration.resolvedConfiguration.resolvedArtifacts.findAll { it.extension in ['hpi', 'jpi'] }.each {
+            copyFile(it.file, new File(testDependenciesDir, "${it.name}.${it.extension}"))
+            artifacts << it.name
+        }
+        new File(testDependenciesDir, 'index').setText(artifacts.join('\n'), 'UTF-8')
+    }
+}

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/TestDependenciesTaskIntegrationSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/TestDependenciesTaskIntegrationSpec.groovy
@@ -1,0 +1,51 @@
+package org.jenkinsci.gradle.plugins.jpi
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class TestDependenciesTaskIntegrationSpec extends Specification {
+    @Rule
+    final TemporaryFolder project = new TemporaryFolder()
+
+    def 'resolves test dependencies'() {
+        given:
+        prepareFile('build.gradle') << getClass().getResource('resolveTestDependencies.gradle').text
+
+        when:
+        def result = GradleRunner.create()
+                .withProjectDir(project.root)
+                .withPluginClasspath(pluginClasspath)
+                .withArguments('processTestResources')
+                .build()
+
+        then:
+        result.task(':resolveTestDependencies').outcome == TaskOutcome.SUCCESS
+        result.task(':processTestResources').outcome == TaskOutcome.UP_TO_DATE
+        File dir = new File(project.root, 'build/resources/test/test-dependencies')
+        dir.directory
+        new File(dir, 'index').text == 'structs\nconfig-file-provider\ncloudbees-folder\ntoken-macro\ncredentials'
+        new File(dir, 'structs.hpi').exists()
+        new File(dir, 'config-file-provider.hpi').exists()
+        new File(dir, 'cloudbees-folder.hpi').exists()
+        new File(dir, 'token-macro.hpi').exists()
+        new File(dir, 'credentials.hpi').exists()
+    }
+
+    private File prepareFile(String relativeFilePath) {
+        def newFile = new File(project.root, relativeFilePath)
+        newFile.parentFile.mkdirs()
+        newFile.createNewFile()
+        newFile
+    }
+
+    private List<File> getPluginClasspath() {
+        getClass()
+                .classLoader
+                .getResource('plugin-classpath.txt')
+                .readLines()
+                .collect { new File(it) }
+    }
+}

--- a/src/test/resources/org/jenkinsci/gradle/plugins/jpi/resolveTestDependencies.gradle
+++ b/src/test/resources/org/jenkinsci/gradle/plugins/jpi/resolveTestDependencies.gradle
@@ -1,0 +1,9 @@
+plugins {
+    id 'org.jenkins-ci.jpi'
+}
+
+dependencies {
+    jenkinsPlugins 'org.jenkins-ci.plugins:structs:1.1@jar'
+    optionalJenkinsPlugins 'org.jenkins-ci.plugins:config-file-provider:2.8.1@jar'
+    jenkinsTest 'org.jenkins-ci.plugins:cloudbees-folder:4.4@jar'
+}


### PR DESCRIPTION
... instead copying to the `plugins` directory to mimic the behavior of the Maven HPI plugin