### PR TITLE
Don't apply MavenPublishPlugin if configurePublishing is false.

### DIFF
--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
@@ -92,7 +92,6 @@ class JpiPlugin implements Plugin<Project> {
     void apply(final Project gradleProject) {
         gradleProject.plugins.apply(JavaPlugin)
         gradleProject.plugins.apply(WarPlugin)
-        gradleProject.plugins.apply(MavenPublishPlugin)
         gradleProject.plugins.apply(GroovyPlugin)
 
         // never run war as it's useless
@@ -290,7 +289,6 @@ class JpiPlugin implements Plugin<Project> {
     }
 
     private static configurePublishing(Project project) {
-        PublishingExtension publishingExtension = project.extensions.getByType(PublishingExtension)
         JpiExtension jpiExtension = project.extensions.getByType(JpiExtension)
 
         AbstractArchiveTask jpi = project.tasks.getByName(Jpi.TASK_NAME) as AbstractArchiveTask
@@ -312,6 +310,8 @@ class JpiPlugin implements Plugin<Project> {
         // delay configuration until all settings are available (groupId, shortName, ...)
         project.afterEvaluate {
             if (jpiExtension.configurePublishing) {
+                project.plugins.apply(MavenPublishPlugin)
+                PublishingExtension publishingExtension = project.extensions.getByType(PublishingExtension)
                 publishingExtension.publications {
                     mavenJpi(MavenPublication) {
                         artifactId jpiExtension.shortName

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPluginSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPluginSpec.groovy
@@ -1,6 +1,7 @@
 package org.jenkinsci.gradle.plugins.jpi
 
 import org.gradle.api.Project
+import org.gradle.api.UnknownDomainObjectException
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.plugins.BasePlugin
@@ -114,12 +115,12 @@ class JpiPluginSpec extends Specification {
             }
         }
         (project as ProjectInternal).evaluate()
+        project.extensions.getByType(PublishingExtension)
 
         then:
-        PublishingExtension publishingExtension = project.extensions.getByType(PublishingExtension)
-        publishingExtension.publications.size() == 0
-        publishingExtension.repositories.size() == 0
         project.components.size() == 3
+        UnknownDomainObjectException ex = thrown()
+        ex.message.contains("Extension of type 'PublishingExtension' does not exist.")
     }
 
     def 'localizer task has been setup'(Object outputDir, String expectedOutputDir) {


### PR DESCRIPTION
I already have a task called "install" on my Gradle task graph, and I don't need the "install" task from this plugin when I have configured publishing to false.