### PR TITLE
Use defaultDependencies for testCompile.

### DIFF
--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
@@ -271,7 +271,7 @@ class JpiPlugin implements Plugin<Project> {
                 setVisible(false).
                 setDescription('Jenkins war that corresponds to the Jenkins core')
 
-        cc.getByName(JavaPlugin.TEST_COMPILE_CONFIGURATION_NAME).incoming.beforeResolve {
+        cc.getByName(JavaPlugin.TEST_COMPILE_CONFIGURATION_NAME).defaultDependencies {
             jenkinsTestConfiguration.resolvedConfiguration.resolvedArtifacts.each { ResolvedArtifact ra ->
                 if (ra.extension == 'hpi' || ra.extension == 'jpi') {
                     project.dependencies.add(JavaPlugin.TEST_COMPILE_CONFIGURATION_NAME, "${ra.moduleVersion.id}@jar")


### PR DESCRIPTION
For most of the projects I touch, we have to use Gradle's Idea plugin
(instead of importing a project into IntelliJ). Unfortunately, the
plugin fails to apply in my Jenkins plugin project with the message:

```
:*************:ideaModule (Thread[main,5,main]) completed.
Took 1.104 secs.

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':*************:ideaModule'.
> Cannot change dependencies of configuration ':*************:testCompile'after it has been included in dependency resolution. Use 'defaultDependencies' instead of 'beforeResolve' to specify default dependencies for a configuration.
```

Fortunately enough, Gradle's advice worked like a charm!