### PR TITLE
[JENKINS-45126] fixed incremental build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.23.0 (unreleased)
 
+  * fixed incremental build
+    ([JENKINS-45126](https://issues.jenkins-ci.org/browse/JENKINS-45126))
+
 ## 0.22.0 (2017-02-23)
 
   * fixed compatibility with Gradle 3.4

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiHplManifest.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiHplManifest.groovy
@@ -16,6 +16,7 @@
 package org.jenkinsci.gradle.plugins.jpi
 
 import org.gradle.api.Project
+import org.gradle.api.java.archives.Attributes
 import org.gradle.api.plugins.WarPlugin
 import org.gradle.api.plugins.WarPluginConvention
 import org.gradle.api.tasks.bundling.War
@@ -26,16 +27,23 @@ import org.gradle.api.tasks.bundling.War
 class JpiHplManifest extends JpiManifest {
     JpiHplManifest(Project project) {
         super(project)
+    }
+
+    @Override
+    Attributes getAttributes() {
+        Attributes mainAttributes = super.attributes
 
         def conv = project.extensions.getByType(JpiExtension)
         War war = project.tasks.getByName(WarPlugin.WAR_TASK_NAME) as War
 
         // src/main/webApp
         def warconv = project.convention.getPlugin(WarPluginConvention)
-        mainAttributes.putValue('Resource-Path', warconv.webAppDir.absolutePath)
+        mainAttributes['Resource-Path'] = warconv.webAppDir.absolutePath
 
         // add resource directories directly so that we can pick up the source, then add all the jars and class path
         Set<File> libraries = conv.mainSourceTree().resources.srcDirs + war.classpath.files
-        mainAttributes.putValue('Libraries', libraries.findAll { it.exists() }.join(','))
+        mainAttributes['Libraries'] = libraries.findAll { it.exists() }.join(',')
+
+        mainAttributes
     }
 }

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
@@ -41,7 +41,6 @@ import org.gradle.execution.TaskGraphExecuter
 
 import static org.gradle.api.logging.LogLevel.INFO
 import static org.gradle.api.tasks.SourceSet.TEST_SOURCE_SET_NAME
-import static org.jenkinsci.gradle.plugins.jpi.JpiManifest.attributesToMap
 
 /**
  * Loads HPI related tasks into the current project.
@@ -151,9 +150,7 @@ class JpiPlugin implements Plugin<Project> {
 
         War war = project.tasks[WarPlugin.WAR_TASK_NAME] as War
         war.description = 'Generates the JPI package'
-        war.doFirst {
-            war.manifest.attributes(attributesToMap(new JpiManifest(project).mainAttributes))
-        }
+        war.manifest = new JpiManifest(project)
 
         project.afterEvaluate {
             war.archiveName = "${jpiExtension.shortName}.${jpiExtension.fileExtension}"
@@ -169,9 +166,7 @@ class JpiPlugin implements Plugin<Project> {
     private static configureJar(Project project) {
         // add manifest to the JAR file
         Jar jarTask = project.tasks.getByName(JavaPlugin.JAR_TASK_NAME) as Jar
-        jarTask.doFirst {
-            jarTask.manifest.attributes(attributesToMap(new JpiManifest(project).mainAttributes))
-        }
+        jarTask.manifest = new JpiManifest(project)
     }
 
     private static configureTestDependencies(Project project) {
@@ -344,7 +339,7 @@ class JpiPlugin implements Plugin<Project> {
             outputs.file hpl
             doLast {
                 hpl.parentFile.mkdirs()
-                hpl.withOutputStream { new JpiHplManifest(project).write(it) }
+                hpl.withOutputStream { new JpiHplManifest(project).writeTo(it) }
             }
         }
         project.tasks.test.dependsOn(generateTestHpl)

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/ServerTask.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/ServerTask.groovy
@@ -69,7 +69,7 @@ class ServerTask extends DefaultTask {
 
         def hpl = new File(conv.workDir, "plugins/${conv.shortName}.hpl")
         hpl.parentFile.mkdirs()
-        hpl.withOutputStream { m.write(it) }
+        hpl.withOutputStream { m.writeTo(it) }
     }
 
     private copyPluginDependencies() {

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiHplManifestSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiHplManifestSpec.groovy
@@ -22,7 +22,7 @@ class JpiHplManifestSpec extends Specification {
         libraries*.mkdirs()
 
         when:
-        Manifest manifest = new JpiHplManifest(project)
+        Manifest manifest = new JpiHplManifest(project).toJavaManifest()
 
         then:
         manifest.mainAttributes.getValue('Resource-Path') == new File(project.projectDir, 'src/main/webapp').path
@@ -36,7 +36,7 @@ class JpiHplManifestSpec extends Specification {
         }
 
         when:
-        JpiHplManifest manifest = new JpiHplManifest(project)
+        Manifest manifest = new JpiHplManifest(project).toJavaManifest()
 
         then:
         manifest.mainAttributes.getValue('Resource-Path') == new File(project.projectDir, 'src/main/webapp').path


### PR DESCRIPTION
@wolfs please take a look.

The manifest depends on the output of the compile tasks, so it can't be configured in the configuration phase. I created a "dynamic" manifest that computes it's values on demand by implementing Gradle's Manifest interface. I don't see a better solution without accessing internal classes. Suggestions for a nicer solution are welcome.