### PR TITLE
[DONT MERGE] Fix incremental build test on windows

### DIFF
--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiManifestSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiManifestSpec.groovy
@@ -181,6 +181,7 @@ version = '1.2'"""
 
         when:
         buildFile.text = PROJECT.replace('1.2', '1.3')
+        sleep(2000)
         result = runner.build()
 
         then:


### PR DESCRIPTION
The Windows file system only has a two seconds time stamp granularity.
The easiest fix is to wait two seconds for Gradle to pick up changes.