### PR TITLE
[Jenkins-48353] removes junit-dep on newer releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ gradle-app.setting
 *.iml
 /.idea
 /classes
+/out

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtension.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtension.groovy
@@ -176,8 +176,10 @@ class JpiExtension {
                 }
 
                 jenkinsTest("org.jenkins-ci.main:jenkins-test-harness:${testHarnessVersion}")
-                jenkinsTest("org.jenkins-ci.main:ui-samples-plugin:${uiSamplesVersion}",
-                        'junit:junit-dep:4.10')
+                jenkinsTest("org.jenkins-ci.main:ui-samples-plugin:${uiSamplesVersion}")
+                if (new VersionNumber(this.coreVersion) < new VersionNumber('1.505')) {
+                    jenkinsTest('junit:junit-dep:4.10')
+                }
             }
         }
     }

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtensionSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtensionSpec.groovy
@@ -241,6 +241,26 @@ class JpiExtensionSpec extends Specification {
         'org.jenkins-ci.main:jenkins-war:1.509.3' in dependencies
     }
 
+    def 'jenkinsTest dependencies before 1.505'() {
+        setup:
+        Project project = ProjectBuilder.builder().build()
+
+        when:
+        project.with {
+            apply plugin: 'jpi'
+            jenkinsPlugin {
+                coreVersion = '1.504'
+            }
+        }
+
+        then:
+        def dependencies = collectDependencies(project, 'jenkinsTest')
+        'org.jenkins-ci.main:jenkins-test-harness:1.504' in dependencies
+        'org.jenkins-ci.main:ui-samples-plugin:1.504' in dependencies
+        'org.jenkins-ci.main:jenkins-war:1.504' in dependencies
+        'junit:junit-dep:4.10' in dependencies
+    }
+    
     def 'jenkinsTest dependencies before 1.533'() {
         setup:
         Project project = ProjectBuilder.builder().build()
@@ -258,7 +278,6 @@ class JpiExtensionSpec extends Specification {
         'org.jenkins-ci.main:jenkins-test-harness:1.532' in dependencies
         'org.jenkins-ci.main:ui-samples-plugin:1.532' in dependencies
         'org.jenkins-ci.main:jenkins-war:1.532' in dependencies
-        'junit:junit-dep:4.10' in dependencies
     }
 
     def 'jenkinsTest dependencies for 1.533 or later'() {
@@ -278,7 +297,6 @@ class JpiExtensionSpec extends Specification {
         'org.jenkins-ci.main:jenkins-test-harness:1.533' in dependencies
         'org.jenkins-ci.main:ui-samples-plugin:2.0' in dependencies
         'org.jenkins-ci.main:jenkins-war:1.533' in dependencies
-        'junit:junit-dep:4.10' in dependencies
     }
 
     def 'jenkinsTest dependencies for 1.645 or later'() {
@@ -298,7 +316,6 @@ class JpiExtensionSpec extends Specification {
         'org.jenkins-ci.main:jenkins-test-harness:2.0' in dependencies
         'org.jenkins-ci.main:ui-samples-plugin:2.0' in dependencies
         'org.jenkins-ci.main:jenkins-war:1.645' in dependencies
-        'junit:junit-dep:4.10' in dependencies
     }
 
     def 'jenkinsTest dependencies for 2.64 or later'() {
@@ -317,7 +334,6 @@ class JpiExtensionSpec extends Specification {
         def dependencies = collectDependencies(project, 'jenkinsTest')
         'org.jenkins-ci.main:jenkins-test-harness:2.0' in dependencies
         'org.jenkins-ci.main:ui-samples-plugin:2.0' in dependencies
-        'junit:junit-dep:4.10' in dependencies
         project.configurations.jenkinsWar in project.configurations.jenkinsTest.extendsFrom
     }
 


### PR DESCRIPTION
[JENKINS-48353](https://issues.jenkins-ci.org/browse/JENKINS-48353)

junit-dep is long since deprecated and causes issue when using newer junit 4.12 that now has 
the Timeout.seconds method.