### PR TITLE
Add support for Gradle 4.0 split classes dirs

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-bin.zip

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/GenerateTestHpl.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/GenerateTestHpl.groovy
@@ -2,7 +2,6 @@ package org.jenkinsci.gradle.plugins.jpi
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/GenerateTestHpl.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/GenerateTestHpl.groovy
@@ -1,0 +1,21 @@
+package org.jenkinsci.gradle.plugins.jpi
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+class GenerateTestHpl extends DefaultTask {
+    @OutputFile
+    DirectoryProperty hplDir
+
+    GenerateTestHpl() {
+        this.hplDir = newOutputDirectory()
+    }
+
+    @TaskAction
+    void generateTestHpl() {
+        hplDir.file('the.hpl').get().asFile.withOutputStream { new JpiHplManifest(project).write(it) }
+    }
+}

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiManifest.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiManifest.groovy
@@ -56,7 +56,11 @@ class JpiManifest extends Manifest {
         }
 
         if (pluginImpls.size() > 1) {
-            throw new GradleException(String.format("Found multiple directories containing Jenkins plugin implementations ('%s'). Use joint compilation to work around this problem.", pluginImpls*.path.join("', '")))
+            throw new GradleException(
+                    'Found multiple directories containing Jenkins plugin implementations ' +
+                            "('${pluginImpls*.path.join("', '")}'). " +
+                            'Use joint compilation to work around this problem.'
+            )
         }
 
         def pluginImpl = pluginImpls.find()

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
@@ -347,15 +347,9 @@ class JpiPlugin implements Plugin<Project> {
         SourceSet testSourceSet = javaConvention.sourceSets.getByName(TEST_SOURCE_SET_NAME)
 
         // generate test hpl manifest for the current plugin, to be used during unit test
-        Task generateTestHpl = project.task('generate-test-hpl') {
-            ext.hpl = new File(testSourceSet.output.classesDir, 'the.hpl')
-            outputs.file hpl
-            doLast {
-                hpl.parentFile.mkdirs()
-                hpl.withOutputStream { new JpiHplManifest(project).write(it) }
-            }
-        }
-        project.tasks.test.dependsOn(generateTestHpl)
+        GenerateTestHpl generateTestHpl = project.tasks.create('generate-test-hpl', GenerateTestHpl)
+        generateTestHpl.hplDir.set(project.layout.buildDirectory.dir('generated-resources/test'))
+        testSourceSet.getOutput().dir(generateTestHpl.hplDir)
     }
 
     private static void resolvePluginDependencies(Project project) {

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
@@ -349,7 +349,7 @@ class JpiPlugin implements Plugin<Project> {
         // generate test hpl manifest for the current plugin, to be used during unit test
         GenerateTestHpl generateTestHpl = project.tasks.create('generate-test-hpl', GenerateTestHpl)
         generateTestHpl.hplDir.set(project.layout.buildDirectory.dir('generated-resources/test'))
-        testSourceSet.getOutput().dir(generateTestHpl.hplDir)
+        testSourceSet.output.dir(generateTestHpl.hplDir)
     }
 
     private static void resolvePluginDependencies(Project project) {

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiHplManifestSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiHplManifestSpec.groovy
@@ -16,7 +16,7 @@ class JpiHplManifestSpec extends Specification {
         }
         def libraries = [
                 new File(project.projectDir, 'src/main/resources'),
-                new File(project.buildDir, 'classes/main'),
+                new File(project.buildDir, 'classes/java/main'),
                 new File(project.buildDir, 'resources/main'),
         ]
         libraries*.mkdirs()


### PR DESCRIPTION
Starting from Gradle 4.0, the classes for Java and Groovy are compiled into two different classes directories. The Gradle JPI plugin has problems when the Plugin classes are split between those two directories.
This PR aims to fix the problems. It would require plugin users to also use Gradle 4.+.