### PR TITLE
Add new configuration to install plugins for server task

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,14 @@ If your plugin depends on other Jenkins plugins you can specify the dependencies
 		jenkinsPlugins 'org.jenkinsci.plugins:git:1.1.15'
 		optionalJenkinsPlugins 'org.jenkins-ci.plugins:ant:1.2'
 		jenkinsTest 'org.jenkins-ci.main:maven-plugin:1.480'
+		jenkinsServer 'org.jenkins-ci.plugins:ant:1.2'
 	}
 
 Adding the dependency to the `jenkinsPlugins` configuration will make all classes available during compilation and
 also add the dependency to the manifest of your plugin. To define an optional dependency on a plugin then use
 the `optionalJenkinsPlugins` configuration and to use a plugin only for testing, add a dependency to the `jenkinsTest`
 configuration.
+`jenkinsServer` can be used to install extra plugins for the `server` task (see below)
 
 ## Usage
 

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
@@ -82,6 +82,11 @@ class JpiPlugin implements Plugin<Project> {
      */
     public static final String JENKINS_TEST_DEPENDENCY_CONFIGURATION_NAME = 'jenkinsTest'
 
+    /**
+     * Represents the extra dependencies on other Jenkins plugins for the server task.
+     */
+    public static final String JENKINS_SERVER_DEPENDENCY_CONFIGURATION_NAME = 'jenkinsServer'
+
     public static final String JPI_TASK_NAME = 'jpi'
     public static final String SOURCES_JAR_TASK_NAME = 'sourcesJar'
     public static final String JAVADOC_JAR_TASK_NAME = 'javadocJar'
@@ -197,6 +202,7 @@ class JpiPlugin implements Plugin<Project> {
             [
                     PLUGINS_DEPENDENCY_CONFIGURATION_NAME,
                     OPTIONAL_PLUGINS_DEPENDENCY_CONFIGURATION_NAME,
+                    JENKINS_SERVER_DEPENDENCY_CONFIGURATION_NAME,
                     JENKINS_TEST_DEPENDENCY_CONFIGURATION_NAME,
             ].each {
                 project.configurations.getByName(it).dependencies.each {
@@ -273,6 +279,10 @@ class JpiPlugin implements Plugin<Project> {
         Configuration optionalPlugins = project.configurations.create(OPTIONAL_PLUGINS_DEPENDENCY_CONFIGURATION_NAME)
         optionalPlugins.visible = false
         optionalPlugins.description = 'Optional Jenkins plugins dependencies which your plugin is built against'
+
+        Configuration serverPlugins = project.configurations.create(JENKINS_SERVER_DEPENDENCY_CONFIGURATION_NAME)
+        serverPlugins.visible = false
+        serverPlugins.description = 'Jenkins plugins which will be installed by the server task'
 
         Configuration test = project.configurations.create(JENKINS_TEST_DEPENDENCY_CONFIGURATION_NAME)
                 .exclude(group: 'org.jenkins-ci.modules', module: 'ssh-cli-auth')

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/ServerTask.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/ServerTask.groovy
@@ -78,6 +78,9 @@ class ServerTask extends DefaultTask {
         project.configurations.getByName(JpiPlugin.PLUGINS_DEPENDENCY_CONFIGURATION_NAME).dependencies.each {
             project.dependencies.add(plugins.name, "${it.group}:${it.name}:${it.version}")
         }
+        project.configurations.getByName(JpiPlugin.JENKINS_SERVER_DEPENDENCY_CONFIGURATION_NAME).dependencies.each {
+            project.dependencies.add(plugins.name, "${it.group}:${it.name}:${it.version}")
+        }
 
         // copy the resolved HPI/JPI files to the plugins directory
         def workDir = project.extensions.getByType(JpiExtension).workDir


### PR DESCRIPTION
A new jenkinsServer configuration is introduced that allows to install
extra plugins with the use of the server task.