### PR TITLE
[JENKINS-47988] update test harness version on core version >= 2.64

### DIFF
--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtension.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtension.groovy
@@ -147,6 +147,10 @@ class JpiExtension {
             servletApiVersion = '3.1.0'
         }
 
+        if (new VersionNumber(this.coreVersion) >= new VersionNumber('2.64')) {
+            testHarnessVersion = '2.31'
+        }
+
         // workarounds for JENKINS-26331
         if (new VersionNumber(this.coreVersion) >= new VersionNumber('1.545') &&
                 new VersionNumber(this.coreVersion) < new VersionNumber('1.592')) {

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtensionSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtensionSpec.groovy
@@ -315,7 +315,7 @@ class JpiExtensionSpec extends Specification {
 
         then:
         def dependencies = collectDependencies(project, 'jenkinsTest')
-        'org.jenkins-ci.main:jenkins-test-harness:2.0' in dependencies
+        'org.jenkins-ci.main:jenkins-test-harness:2.31' in dependencies
         'org.jenkins-ci.main:ui-samples-plugin:2.0' in dependencies
         'junit:junit-dep:4.10' in dependencies
         project.configurations.jenkinsWar in project.configurations.jenkinsTest.extendsFrom


### PR DESCRIPTION
This will resolve the issue reported in [JENKINS-47988](https://issues.jenkins-ci.org/browse/JENKINS-47988)