### PR TITLE
JENKINS-51622: Backwards-Compatible Changes for Gradle 4.8

### DIFF
--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.XmlProvider
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.ResolvableDependencies
+import org.gradle.api.execution.TaskExecutionGraph
 import org.gradle.api.plugins.BasePlugin
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.JavaPluginConvention
@@ -37,7 +38,6 @@ import org.gradle.api.tasks.bundling.War
 import org.gradle.api.tasks.compile.GroovyCompile
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.testing.Test
-import org.gradle.execution.TaskGraphExecuter
 
 import static org.gradle.api.artifacts.Configuration.State.UNRESOLVED
 import static org.gradle.api.logging.LogLevel.INFO
@@ -368,7 +368,7 @@ class JpiPlugin implements Plugin<Project> {
         }
 
         // load credentials only when publishing
-        project.gradle.taskGraph.whenReady { TaskGraphExecuter taskGraph ->
+        project.gradle.taskGraph.whenReady { TaskExecutionGraph taskGraph ->
             if (jpiExtension.configurePublishing && taskGraph.hasTask(project.tasks.publish)) {
                 def credentials = loadDotJenkinsOrg()
                 PublishingExtension publishingExtension = project.extensions.getByType(PublishingExtension)

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/LicenseTask.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/LicenseTask.groovy
@@ -7,12 +7,12 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.ResolvedArtifact
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
-import org.gradle.internal.component.local.model.DefaultProjectComponentIdentifier
 
 class LicenseTask extends DefaultTask {
     @Internal
@@ -83,7 +83,7 @@ class LicenseTask extends DefaultTask {
 
     private Dependency[] collectDependencies() {
         collectArtifacts().findAll { ResolvedArtifact artifact ->
-            !(artifact.id.componentIdentifier instanceof DefaultProjectComponentIdentifier)
+            !(artifact.id.componentIdentifier instanceof ProjectComponentIdentifier)
         }.collect { ResolvedArtifact artifact ->
             ModuleVersionIdentifier id = artifact.moduleVersion.id
             project.dependencies.create("${id.group}:${id.name}:${id.version}@pom")

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPomCustomizerSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPomCustomizerSpec.groovy
@@ -13,6 +13,7 @@ import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.internal.publication.MavenPomInternal
 import org.gradle.api.publish.maven.internal.tasks.MavenPomFileGenerator
 import org.gradle.testfixtures.ProjectBuilder
+import org.gradle.util.GradleVersion
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import org.xmlunit.builder.DiffBuilder
@@ -266,7 +267,11 @@ class JpiPomCustomizerSpec extends Specification {
         VersionSelectorScheme versionSelectorScheme = new DefaultVersionSelectorScheme(versionComparator)
         VersionRangeMapper versionRangeMapper = new MavenVersionRangeMapper(versionSelectorScheme)
         MavenPomFileGenerator pomGenerator = new MavenPomFileGenerator(pomInternal.projectIdentity, versionRangeMapper)
-        pomGenerator.packaging = pomInternal.packaging
+        if (GradleVersion.version(project.gradle.gradleVersion) > GradleVersion.version('4.7')) {
+            pomGenerator.model.packaging = pomInternal.packaging
+        } else {
+            pomGenerator.packaging = pomInternal.packaging
+        }
         pomInternal.runtimeDependencies.each { pomGenerator.addRuntimeDependency(it) }
         pomGenerator.withXml(pomInternal.xmlAction)
 


### PR DESCRIPTION
This PR addresses [JENKINS-51622](https://issues.jenkins-ci.org/browse/JENKINS-51622)
* `org.gradle.execution.TaskGraphExecuter` is no longer present in Gradle 4.8. I've replaced it with [`org.gradle.api.execution.TaskExecutionGraph`](https://docs.gradle.org/current/javadoc/org/gradle/api/execution/TaskExecutionGraph.html)
* `org.gradle.internal.component.local.model.DefaultProjectComponentIdentifier` has moved as of Gradle 4.8. I've replaced this with the public [`org.gradle.api.artifacts.component.ProjectComponentIdentifier`](https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/component/ProjectComponentIdentifier.html)
* MavenPomFileGenerator has a changed API after Gradle 4.7, so this works in both scenarios.