### PR TITLE
Skip Jenkins wizard in server task

### DIFF
--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/ServerTask.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/ServerTask.groovy
@@ -51,6 +51,7 @@ class ServerTask extends DefaultTask {
         setSystemPropertyIfEmpty('stapler.trace', 'true')
         setSystemPropertyIfEmpty('stapler.jelly.noCache', 'true')
         setSystemPropertyIfEmpty('debug.YUI', 'true')
+        setSystemPropertyIfEmpty('hudson.Main.development', 'true')
 
         List<String> args = []
         String port = project.properties[HTTP_PORT] ?: System.properties[HTTP_PORT]


### PR DESCRIPTION
Otherwise when running `gradle server` the first time with Jenkins 2.x,
the user has to follow manual setup steps in the browser.

That's also the default setting in plugin-pom:
- https://github.com/jenkinsci/plugin-pom/blob/plugin-3.32/pom.xml#L93-L94
- https://github.com/jenkinsci/plugin-pom/blob/plugin-3.32/pom.xml#L678-L680