### PR TITLE
Add Minimum-Java-Version to Manifest

### DIFF
--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiManifest.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiManifest.groovy
@@ -83,6 +83,7 @@ class JpiManifest extends Manifest {
         mainAttributes.putValue('Plugin-Version', version.toString())
 
         mainAttributes.putValue('Jenkins-Version', conv.coreVersion)
+        mainAttributes.putValue('Minimum-Java-Version', javaPluginConvention.targetCompatibility.toString())
 
         mainAttributes.putValue('Mask-Classes', conv.maskClasses)
 

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/AbstractManifestIntegrationSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/AbstractManifestIntegrationSpec.groovy
@@ -140,6 +140,35 @@ abstract class AbstractManifestIntegrationSpec extends Specification {
         actual['Compatible-Since-Version'] == expected
     }
 
+    def 'should populate Minimum-Java-Version from targetCompatibility (case: #input)'(String input, String expected) {
+        given:
+        build << """\
+            targetCompatibility = $input
+            """.stripIndent()
+
+        expect:
+        def actual = generateManifestThroughGradle()
+        actual['Minimum-Java-Version'] == expected
+
+        where:
+        input                     | expected
+        '\'1.8\''                 | '1.8'
+        'JavaVersion.VERSION_1_8' | '1.8'
+        '\'11\''                  | '11'
+        'JavaVersion.VERSION_11'  | '11'
+    }
+
+    def 'should populate Minimum-Java-Version from implicit targetCompatibility'() {
+        given:
+        String expected = System.getProperty("java.specification.version")
+
+        when:
+        def actual = generateManifestThroughGradle()
+
+        then:
+        actual['Minimum-Java-Version'] == expected
+    }
+
     def 'should populate Mask-Classes if defined'() {
         given:
         String expected = 'org.example.test org.example2.test'


### PR DESCRIPTION
Using Gradle's built-in [targetCompatibility property](https://docs.gradle.org/current/userguide/java_plugin.html#other_convention_properties) to populate this value for [Jenkins Java 11 Support](https://wiki.jenkins.io/display/JENKINS/Java+11+Developer+Guidelines).

This updates the generated `META-INF/MANIFEST.MF` to contain entries like:
`Minimum-Java-Version: 1.8` or `Minimum-Java-Version: 11`.

Related PRs:
* jenkinsci/jenkins#3016
* https://github.com/jenkinsci/jenkins/pull/3842

@jenkinsci/java11-support would you be able to take a look at this PR?