### PR TITLE
Put work directory inside project directory

### DIFF
--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtension.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtension.groovy
@@ -211,7 +211,7 @@ class JpiExtension {
     private File workDir
 
     File getWorkDir() {
-        workDir ?: new File(project.rootDir, 'work')
+        workDir ?: new File(project.projectDir, 'work')
     }
 
     /**

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtensionSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtensionSpec.groovy
@@ -114,7 +114,18 @@ class JpiExtensionSpec extends Specification {
         jpiExtension.workDir = null
 
         then:
-        jpiExtension.workDir == new File(project.rootDir, 'work')
+        jpiExtension.workDir == new File(project.projectDir, 'work')
+    }
+
+    def 'work directory defaults to work in child project the extension is applied to if not set'() {
+        when:
+        Project parent = ProjectBuilder.builder().build()
+        Project project = ProjectBuilder.builder().withParent(parent).build()
+        JpiExtension jpiExtension = new JpiExtension(project)
+        jpiExtension.workDir = null
+
+        then:
+        jpiExtension.workDir == new File(project.projectDir, 'work')
     }
 
     def 'work directory is used when set'() {


### PR DESCRIPTION
Previously the rootDir was used as parent for the work directory. This
led to the situation where a subproject containing a jenkins plugin put
the work directory at the top of the project hierarchy. This becomes
especially problematic when several jenkins plugins are managed from one
root projects.

This change uses `project.projectDir` instead which will be the same as
`project.rootDir` for projects without sub projcts but will be the
actual project directory for nested projects.