### PR TITLE
[JENKINS-54064] Bundle classes as JAR file into HPI file

### DIFF
--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
@@ -189,12 +189,15 @@ class JpiPlugin implements Plugin<Project> {
     private static configureJpi(Project project) {
         JpiExtension jpiExtension = project.extensions.getByType(JpiExtension)
 
+        def jar = project.tasks.named(JavaPlugin.JAR_TASK_NAME)
         def war = project.tasks.named(WarPlugin.WAR_TASK_NAME)
         project.afterEvaluate {
             war.configure {
                 it.description = 'Generates the JPI package'
                 it.archiveName = "${jpiExtension.shortName}.${jpiExtension.fileExtension}"
                 it.extension = jpiExtension.fileExtension
+                it.classpath -= project.sourceSets.main.output
+                it.classpath(jar)
             }
         }
 

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiIntegrationSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiIntegrationSpec.groovy
@@ -111,6 +111,13 @@ class JpiIntegrationSpec extends IntegrationSpec {
         given:
         def jarPathInHpi = "WEB-INF/lib/${projectName}-${projectVersion}.jar" as String
 
+        build << '''\
+            repositories { mavenCentral() }
+            dependencies {
+                implementation 'junit:junit:4.12'
+            }
+            '''.stripIndent()
+
         projectDir.newFolder('src', 'main', 'java', 'my', 'example')
         projectDir.newFile('src/main/java/my/example/Foo.java') << '''\
             package my.example;
@@ -132,6 +139,7 @@ class JpiIntegrationSpec extends IntegrationSpec {
 
         !hpiEntries.contains('WEB-INF/classes/')
         hpiEntries.contains(jarPathInHpi)
+        hpiEntries.contains('WEB-INF/lib/junit-4.12.jar')
 
         def generatedJar = new File(projectDir.root, "${projectName}-${projectVersion}.jar")
         Files.copy(hpiFile.getInputStream(hpiFile.getEntry(jarPathInHpi)), generatedJar.toPath())

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiIntegrationSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiIntegrationSpec.groovy
@@ -3,8 +3,12 @@ package org.jenkinsci.gradle.plugins.jpi
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Unroll
 
+import java.nio.file.Files
+import java.util.zip.ZipFile
+
 class JpiIntegrationSpec extends IntegrationSpec {
     private final String projectName = TestDataGenerator.generateName()
+    private final String projectVersion = TestDataGenerator.generateVersion()
     private File settings
     private File build
 
@@ -101,6 +105,40 @@ class JpiIntegrationSpec extends IntegrationSpec {
         "shortName 'banana'"          | 'banana'
         "shortName = 'carrot-plugin'" | 'carrot-plugin'
         "shortName 'date'"            | 'date'
+    }
+
+    def 'should bundle classes as JAR file into HPI file'() {
+        given:
+        def jarPathInHpi = "WEB-INF/lib/${projectName}-${projectVersion}.jar" as String
+
+        projectDir.newFolder('src', 'main', 'java', 'my', 'example')
+        projectDir.newFile('src/main/java/my/example/Foo.java') << '''\
+            package my.example;
+
+            class Foo {}
+            '''.stripIndent()
+
+        when:
+        def run = gradleRunner()
+                .withArguments("-Pversion=${projectVersion}", 'jpi')
+                .build()
+
+        then:
+        run.task(':jpi').outcome == TaskOutcome.SUCCESS
+
+        def generatedHpi = new File(projectDir.root, "build/libs/${projectName}.hpi")
+        def hpiFile = new ZipFile(generatedHpi)
+        def hpiEntries = hpiFile.entries()*.name
+
+        !hpiEntries.contains('WEB-INF/classes/')
+        hpiEntries.contains(jarPathInHpi)
+
+        def generatedJar = new File(projectDir.root, "${projectName}-${projectVersion}.jar")
+        Files.copy(hpiFile.getInputStream(hpiFile.getEntry(jarPathInHpi)), generatedJar.toPath())
+        def jarFile = new ZipFile(generatedJar)
+        def jarEntries = jarFile.entries()*.name
+
+        jarEntries.contains('my/example/Foo.class')
     }
 
     @Unroll


### PR DESCRIPTION
Now the classes packaged as JAR file which is put into the JPI file under `WEB-INF/lib` instead of all the classes under `WEB-INF/classes`. Dependencies are still correctly put under `WEB-INF/lib` as JAR files.

But I am not sure if this solves the issue 100% or if some corner cases are missed.