### PR TITLE
Handle deprecated Gradle properties of "jar" and "war" task

### DIFF
--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
@@ -39,6 +39,7 @@ import org.gradle.api.tasks.bundling.War
 import org.gradle.api.tasks.compile.GroovyCompile
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.testing.Test
+import org.gradle.util.GradleVersion
 
 import static org.gradle.api.logging.LogLevel.INFO
 import static org.gradle.api.plugins.JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME
@@ -194,8 +195,15 @@ class JpiPlugin implements Plugin<Project> {
         project.afterEvaluate {
             war.configure {
                 it.description = 'Generates the JPI package'
-                it.archiveName = "${jpiExtension.shortName}.${jpiExtension.fileExtension}"
-                it.extension = jpiExtension.fileExtension
+                def fileName = "${jpiExtension.shortName}.${jpiExtension.fileExtension}"
+                def extension = jpiExtension.fileExtension
+                if (GradleVersion.current() >= GradleVersion.version('5.1')) {
+                    it.archiveFileName.set(fileName)
+                    it.archiveExtension.set(extension)
+                } else {
+                    it.archiveName = fileName
+                    it.extension = extension
+                }
                 it.classpath -= project.sourceSets.main.output
                 it.classpath(jar)
             }

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
@@ -118,12 +118,22 @@ class JpiPlugin implements Plugin<Project> {
 
         gradleProject.tasks.register(SOURCES_JAR_TASK_NAME, Jar) {
             it.dependsOn('classes')
-            it.classifier = 'sources'
+            def classifier = 'sources'
+            if (GradleVersion.current() >= GradleVersion.version('5.1')) {
+                it.archiveClassifier.set(classifier)
+            } else {
+                it.classifier = classifier
+            }
             it.from gradleProject.sourceSets.main.allSource
         }
         gradleProject.tasks.register(JAVADOC_JAR_TASK_NAME, Jar) {
             it.dependsOn('javadoc')
-            it.classifier = 'javadoc'
+            def classifier = 'javadoc'
+            if (GradleVersion.current() >= GradleVersion.version('5.1')) {
+                it.archiveClassifier.set(classifier)
+            } else {
+                it.classifier = classifier
+            }
             it.from gradleProject.javadoc.destinationDir
         }
 

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPluginSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPluginSpec.groovy
@@ -10,7 +10,6 @@ import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.plugins.WarPlugin
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.api.tasks.bundling.War
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
 
@@ -91,25 +90,24 @@ class JpiPluginSpec extends Specification {
         (project as ProjectInternal).evaluate()
 
         then:
-        War task = project.tasks[WarPlugin.WAR_TASK_NAME] as War
-        task != null
-        task.description != null
-        task.group == BasePlugin.BUILD_GROUP
-        task.archiveName == archiveName
-        task.extension == extension
-        Task jpi = project.tasks[JpiPlugin.JPI_TASK_NAME]
-        jpi != null
-        jpi.description != null
-        jpi.group == BasePlugin.BUILD_GROUP
+        Task warTask = project.tasks[WarPlugin.WAR_TASK_NAME]
+        warTask != null
+        warTask.description != null
+        warTask.group == BasePlugin.BUILD_GROUP
+
+        Task jpiTask = project.tasks[JpiPlugin.JPI_TASK_NAME]
+        jpiTask != null
+        jpiTask.description != null
+        jpiTask.group == BasePlugin.BUILD_GROUP
 
         where:
-        name  | extension || archiveName
-        ''    | 'jpi'     || 'test.jpi'
-        null  | 'jpi'     || 'test.jpi'
-        'foo' | 'jpi'     || 'foo.jpi'
-        ''    | 'hpi'     || 'test.hpi'
-        null  | 'hpi'     || 'test.hpi'
-        'foo' | 'hpi'     || 'foo.hpi'
+        name  | extension
+        ''    | 'jpi'
+        null  | 'jpi'
+        'foo' | 'jpi'
+        ''    | 'hpi'
+        null  | 'hpi'
+        'foo' | 'hpi'
     }
 
     def 'publishing configuration has been skipped'() {


### PR DESCRIPTION
The following output was shown when running `gradle help --warning-mode all` for a Jenkins plugin that is based on this one:

> The ... property has been deprecated. This is scheduled to be removed in Gradle 7.0. Please use the ... property instead.

This is to resolve these warnings.