### PR TITLE
Fix generate-test-hpl task dependency for running tests

### DIFF
--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
@@ -422,10 +422,13 @@ class JpiPlugin implements Plugin<Project> {
 
         // generate test hpl manifest for the current plugin, to be used during unit test
         def outputDir = project.layout.buildDirectory.dir('generated-resources/test')
-        project.tasks.register('generate-test-hpl', GenerateTestHpl) {
+        testSourceSet.output.dir(outputDir)
+
+        def generateTestHplTask = project.tasks.register('generate-test-hpl', GenerateTestHpl) {
             it.hplDir.set(outputDir)
         }
-        testSourceSet.output.dir(outputDir)
+
+        project.tasks.named(JavaPlugin.TEST_CLASSES_TASK_NAME).configure { it.dependsOn(generateTestHplTask) }
     }
 
     private static void resolvePluginDependencies(Project project) {

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiIntegrationSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiIntegrationSpec.groovy
@@ -166,6 +166,7 @@ class JpiIntegrationSpec extends IntegrationSpec {
         'processTestResources' | ':resolveTestDependencies' | TaskOutcome.NO_SOURCE
         'jpi'                  | ':war'                     | TaskOutcome.SUCCESS
         'compileTestJava'      | ':insertTest'              | TaskOutcome.SKIPPED
+        'testClasses'          | ':generate-test-hpl'       | TaskOutcome.SUCCESS
         'compileJava'          | ':localizer'               | TaskOutcome.SUCCESS
     }
 


### PR DESCRIPTION
This issue was introduced in commit 7a565d3d51b400e67ce5643e3f71b9113c194296, when lazily registering the task.

Without this fix the `build/generated-resources/test/the.hpl` is not generated and therefore `org.jvnet.hudson.test.PluginAutomaticTestBuilder$OtherTests.testPluginActive` from `InjectedTest` is failing.