### PR TITLE
Do not publish Gradle module metadata

### DIFF
--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
@@ -32,6 +32,7 @@ import org.gradle.api.plugins.GroovyPlugin
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
+import org.gradle.api.publish.tasks.GenerateModuleMetadata
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.Jar
@@ -366,6 +367,14 @@ class JpiPlugin implements Plugin<Project> {
     }
 
     private static configurePublishing(Project project) {
+        // Disable publication of Gradle module metadata
+        // Currently, this would produce a module metadata file which can't be consumed by downstream projects,
+        // since it doesn't contain any dependencies and only the hpi variant and not jar variant.
+        // Until this is fixed, Gradle module metadata shouldn't be published.
+        project.tasks.withType(GenerateModuleMetadata) {
+            enabled = false
+        }
+
         JpiExtension jpiExtension = project.extensions.getByType(JpiExtension)
 
         // delay configuration until all settings are available (groupId, shortName, ...)

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiIntegrationSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiIntegrationSpec.groovy
@@ -160,15 +160,15 @@ class JpiIntegrationSpec extends IntegrationSpec {
         result.task(dependency).outcome == outcome
 
         where:
-        task                                         | dependency                                    | outcome
-        'jar'                                        | ':configureManifest'                          | TaskOutcome.SUCCESS
-        'war'                                        | ':configureManifest'                          | TaskOutcome.SUCCESS
-        'processTestResources'                       | ':resolveTestDependencies'                    | TaskOutcome.NO_SOURCE
-        'jpi'                                        | ':war'                                        | TaskOutcome.SUCCESS
-        'compileTestJava'                            | ':insertTest'                                 | TaskOutcome.SKIPPED
-        'testClasses'                                | ':generate-test-hpl'                          | TaskOutcome.SUCCESS
-        'compileJava'                                | ':localizer'                                  | TaskOutcome.SUCCESS
-        'generateMetadataFileForMavenJpiPublication' | ':generateMetadataFileForMavenJpiPublication' | TaskOutcome.SKIPPED
+        task                             | dependency                                    | outcome
+        'jar'                            | ':configureManifest'                          | TaskOutcome.SUCCESS
+        'war'                            | ':configureManifest'                          | TaskOutcome.SUCCESS
+        'processTestResources'           | ':resolveTestDependencies'                    | TaskOutcome.NO_SOURCE
+        'jpi'                            | ':war'                                        | TaskOutcome.SUCCESS
+        'compileTestJava'                | ':insertTest'                                 | TaskOutcome.SKIPPED
+        'testClasses'                    | ':generate-test-hpl'                          | TaskOutcome.SUCCESS
+        'compileJava'                    | ':localizer'                                  | TaskOutcome.SUCCESS
+        'generateMetaFileForMavenJpiPub' | ':generateMetadataFileForMavenJpiPublication' | TaskOutcome.SKIPPED
     }
 
     @Unroll

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiIntegrationSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiIntegrationSpec.groovy
@@ -160,14 +160,15 @@ class JpiIntegrationSpec extends IntegrationSpec {
         result.task(dependency).outcome == outcome
 
         where:
-        task                   | dependency                 | outcome
-        'jar'                  | ':configureManifest'       | TaskOutcome.SUCCESS
-        'war'                  | ':configureManifest'       | TaskOutcome.SUCCESS
-        'processTestResources' | ':resolveTestDependencies' | TaskOutcome.NO_SOURCE
-        'jpi'                  | ':war'                     | TaskOutcome.SUCCESS
-        'compileTestJava'      | ':insertTest'              | TaskOutcome.SKIPPED
-        'testClasses'          | ':generate-test-hpl'       | TaskOutcome.SUCCESS
-        'compileJava'          | ':localizer'               | TaskOutcome.SUCCESS
+        task                                         | dependency                                    | outcome
+        'jar'                                        | ':configureManifest'                          | TaskOutcome.SUCCESS
+        'war'                                        | ':configureManifest'                          | TaskOutcome.SUCCESS
+        'processTestResources'                       | ':resolveTestDependencies'                    | TaskOutcome.NO_SOURCE
+        'jpi'                                        | ':war'                                        | TaskOutcome.SUCCESS
+        'compileTestJava'                            | ':insertTest'                                 | TaskOutcome.SKIPPED
+        'testClasses'                                | ':generate-test-hpl'                          | TaskOutcome.SUCCESS
+        'compileJava'                                | ':localizer'                                  | TaskOutcome.SUCCESS
+        'generateMetadataFileForMavenJpiPublication' | ':generateMetadataFileForMavenJpiPublication' | TaskOutcome.SKIPPED
     }
 
     @Unroll


### PR DESCRIPTION
Currently, this would produce a module metadata file which can't be
consumed by downstream projects, since it doesn't contain any
dependencies and only the hpi variant and not jar variant.

Until this is fixed, Gradle module metadata shouldn't be published.

I realized this when publishing version 1.36 of the Jenkins `gradle-plugin`: https://github.com/jenkinsci/gradle-plugin/pull/94#issuecomment-570720014.