### PR TITLE
Use resolved dependencies for writing manifest

### DIFF
--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/AbstractManifestIntegrationSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/AbstractManifestIntegrationSpec.groovy
@@ -289,6 +289,33 @@ abstract class AbstractManifestIntegrationSpec extends IntegrationSpec {
                 'credentials:1.9.4;resolution:=optional'
     }
 
+    def 'can use bom to manage plugin dependencies'() {
+        given:
+        build << """\
+            configurations {
+                jenkinsBom
+                compileClasspath.extendsFrom(jenkinsBom)
+                runtimeClasspath.extendsFrom(jenkinsBom)
+                jenkinsPlugins.extendsFrom(jenkinsBom)
+                optionalJenkinsPlugins.extendsFrom(jenkinsBom)
+                jenkinsServer.extendsFrom(jenkinsBom)
+                jenkinsWar.extendsFrom(jenkinsBom)
+                jenkinsTest.extendsFrom(jenkinsBom)
+                pluginResources.extendsFrom(jenkinsBom)
+            }
+            dependencies {
+                jenkinsBom platform("io.jenkins.tools.bom:bom-2.138.x:4")
+                jenkinsPlugins 'org.jenkins-ci.plugins.workflow:workflow-api'
+            }
+        """
+
+        when:
+        def actual = generateManifestThroughGradle()
+
+        then:
+        actual['Plugin-Dependencies'] == 'workflow-api:2.37'
+    }
+
     def 'should populate Plugin-Developers with sole developer'() {
         given:
         build << """\

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/AbstractManifestIntegrationSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/AbstractManifestIntegrationSpec.groovy
@@ -3,6 +3,8 @@ package org.jenkinsci.gradle.plugins.jpi
 import groovy.transform.CompileStatic
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.util.GradleVersion
+import spock.lang.Requires
 import spock.lang.Unroll
 
 import java.util.jar.JarInputStream
@@ -289,6 +291,7 @@ abstract class AbstractManifestIntegrationSpec extends IntegrationSpec {
                 'credentials:1.9.4;resolution:=optional'
     }
 
+    @Requires({ IntegrationSpec.gradleVersionForTest >= GradleVersion.version('5.3') })
     def 'can use bom to manage plugin dependencies'() {
         given:
         build << """\

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/IntegrationSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/IntegrationSpec.groovy
@@ -2,6 +2,7 @@ package org.jenkinsci.gradle.plugins.jpi
 
 import groovy.transform.CompileStatic
 import org.gradle.testkit.runner.GradleRunner
+import org.gradle.util.GradleVersion
 import org.junit.Rule
 import org.junit.experimental.categories.Category
 import org.junit.rules.TemporaryFolder
@@ -17,9 +18,14 @@ class IntegrationSpec extends Specification {
         def runner = GradleRunner.create()
                 .withPluginClasspath()
                 .withProjectDir(projectDir.root)
-        if (System.getProperty('gradle.under.test')) {
-            return runner.withGradleVersion(System.getProperty('gradle.under.test'))
+        def gradleVersion = gradleVersionForTest
+        if (gradleVersion != GradleVersion.current()) {
+            return runner.withGradleVersion(gradleVersion.version)
         }
         runner
+    }
+
+    static GradleVersion getGradleVersionForTest() {
+        System.getProperty('gradle.under.test')?.with { GradleVersion.version(delegate) } ?: GradleVersion.current()
     }
 }


### PR DESCRIPTION
So version constraints from e.g. BOMs can take effect.

It would be nice to have a better way to filter out platform dependencies, or anything different than JPI variants I suppose.