### PR TITLE
No line length limit in tests

### DIFF
--- a/config/codenarc/rules-test.groovy
+++ b/config/codenarc/rules-test.groovy
@@ -9,6 +9,8 @@ ruleset {
         exclude 'MethodName'
         // OK for tests
         exclude 'Instanceof'
+        // No line length limit for tests
+        exclude 'LineLength'
         // Spock ...
         exclude 'UnnecessaryBooleanExpression'
     }

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiIntegrationSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiIntegrationSpec.groovy
@@ -160,15 +160,15 @@ class JpiIntegrationSpec extends IntegrationSpec {
         result.task(dependency).outcome == outcome
 
         where:
-        task                             | dependency                                    | outcome
-        'jar'                            | ':configureManifest'                          | TaskOutcome.SUCCESS
-        'war'                            | ':configureManifest'                          | TaskOutcome.SUCCESS
-        'processTestResources'           | ':resolveTestDependencies'                    | TaskOutcome.NO_SOURCE
-        'jpi'                            | ':war'                                        | TaskOutcome.SUCCESS
-        'compileTestJava'                | ':insertTest'                                 | TaskOutcome.SKIPPED
-        'testClasses'                    | ':generate-test-hpl'                          | TaskOutcome.SUCCESS
-        'compileJava'                    | ':localizer'                                  | TaskOutcome.SUCCESS
-        'generateMetaFileForMavenJpiPub' | ':generateMetadataFileForMavenJpiPublication' | TaskOutcome.SKIPPED
+        task                                         | dependency                                    | outcome
+        'jar'                                        | ':configureManifest'                          | TaskOutcome.SUCCESS
+        'war'                                        | ':configureManifest'                          | TaskOutcome.SUCCESS
+        'processTestResources'                       | ':resolveTestDependencies'                    | TaskOutcome.NO_SOURCE
+        'jpi'                                        | ':war'                                        | TaskOutcome.SUCCESS
+        'compileTestJava'                            | ':insertTest'                                 | TaskOutcome.SKIPPED
+        'testClasses'                                | ':generate-test-hpl'                          | TaskOutcome.SUCCESS
+        'compileJava'                                | ':localizer'                                  | TaskOutcome.SUCCESS
+        'generateMetadataFileForMavenJpiPublication' | ':generateMetadataFileForMavenJpiPublication' | TaskOutcome.SKIPPED
     }
 
     @Unroll


### PR DESCRIPTION
Remove the CodeNarc line length limit for tests.

See https://github.com/jenkinsci/gradle-jpi-plugin/pull/127#issuecomment-570798985