### PR TITLE
Fix classpath issues

### DIFF
--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtension.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtension.groovy
@@ -162,8 +162,8 @@ class JpiExtension {
         }
 
         if (this.coreVersion) {
+            jenkinsWarCoordinates = [group: 'org.jenkins-ci.main', name: 'jenkins-war', version: v]
             project.dependencies {
-                jenkinsWarCoordinates = [group: 'org.jenkins-ci.main', name: 'jenkins-war', version: v]
                 testRuntimeOnly(jenkinsWarCoordinates)
 
                 annotationProcessor "org.jenkins-ci.main:jenkins-core:$v"
@@ -174,6 +174,7 @@ class JpiExtension {
                         [group: 'javax.servlet', name: servletApiArtifact, version: servletApiVersion],
                 )
 
+                testImplementation("org.jenkins-ci.main:jenkins-core:$v")
                 testImplementation("org.jenkins-ci.main:jenkins-test-harness:${testHarnessVersion}")
                 testImplementation("org.jenkins-ci.main:ui-samples-plugin:${uiSamplesVersion}")
                 if (new VersionNumber(this.coreVersion) < new VersionNumber('1.505')) {

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiHplManifest.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiHplManifest.groovy
@@ -30,7 +30,8 @@ class JpiHplManifest extends JpiManifest {
         mainAttributes.putValue('Resource-Path', project.file(JpiPlugin.WEB_APP_DIR).absolutePath)
 
         // add resource directories directly so that we can pick up the source, then add all the jars and class path
-        Set<File> libraries = jpiExtension.mainSourceTree().output.files
+        Set<File> libraries = (jpiExtension.mainSourceTree().resources.srcDirs + jpiExtension.mainSourceTree().output
+                + project.plugins.getPlugin(JpiPlugin).dependencyAnalysis.allLibraryDependencies)
         mainAttributes.putValue('Libraries', libraries.findAll { it.exists() }.join(','))
     }
 }

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
@@ -42,6 +42,7 @@ import org.gradle.api.tasks.bundling.War
 import org.gradle.api.tasks.compile.GroovyCompile
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.testing.Test
+import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.gradle.util.GradleVersion
 
 import static org.gradle.api.logging.LogLevel.INFO
@@ -171,7 +172,7 @@ class JpiPlugin implements Plugin<Project> {
         JpiExtension jpiExtension = project.extensions.getByType(JpiExtension)
 
         def jar = project.tasks.named(JavaPlugin.JAR_TASK_NAME)
-        project.tasks.register(JPI_TASK_NAME, War) {
+        def jpi = project.tasks.register(JPI_TASK_NAME, War) {
             it.description = 'Generates the JPI package'
             it.group = BasePlugin.BUILD_GROUP
             def fileName = "${jpiExtension.shortName}.${jpiExtension.fileExtension}"
@@ -180,6 +181,9 @@ class JpiPlugin implements Plugin<Project> {
             it.archiveExtension.set(extension)
             it.classpath(jar, project.plugins.getPlugin(JpiPlugin).dependencyAnalysis.allLibraryDependencies)
             it.from(WEB_APP_DIR)
+        }
+        project.tasks.named(LifecycleBasePlugin.ASSEMBLE_TASK_NAME) {
+            it.dependsOn(jpi)
         }
     }
 

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiHplManifestSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiHplManifestSpec.groovy
@@ -13,6 +13,10 @@ class JpiHplManifestSpec extends Specification {
         setup:
         project.with {
             apply plugin: 'jpi'
+            dependencies.with {
+                implementation('org.apache.commons:commons-lang3:3.9')
+            }
+            evaluate() // trigger 'afterEvaluate { }' configurations
         }
         def libraries = [
                 new File(project.rootDir, 'src/main/resources'),
@@ -20,6 +24,9 @@ class JpiHplManifestSpec extends Specification {
                 new File(project.buildDir, 'resources/main'),
         ]
         libraries*.mkdirs()
+        libraries += new File(project.gradle.gradleUserHomeDir,
+                'caches/modules-2/files-2.1/org.apache.commons/commons-lang3/3.9/' +
+                        '122c7cee69b53ed4a7681c03d4ee4c0e2765da5/commons-lang3-3.9.jar')
 
         when:
         Manifest manifest = new JpiHplManifest(project)

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiHplManifestSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiHplManifestSpec.groovy
@@ -15,6 +15,7 @@ class JpiHplManifestSpec extends Specification {
             apply plugin: 'jpi'
         }
         def libraries = [
+                new File(project.rootDir, 'src/main/resources'),
                 new File(project.buildDir, 'classes/java/main'),
                 new File(project.buildDir, 'resources/main'),
         ]


### PR DESCRIPTION
This is a follow up to #132 that unintentionally broke some classpath setups. This should fix:
- https://github.com/jenkinsci/gradle-jpi-plugin/commit/c21a7a10fbfa017d132e002d4024233aa8cecbd6#r37121475
- https://github.com/jenkinsci/gradle-jpi-plugin/pull/132#issuecomment-582327165