### PR TITLE
sources and javadocs jar should only be configured when configurePublishing is enabled

### DIFF
--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
@@ -103,10 +103,6 @@ class JpiPlugin implements Plugin<Project> {
         configureLocalizer(gradleProject)
         configureInjectedTest(gradleProject)
 
-        JavaPluginExtension javaPluginExtension = gradleProject.extensions.getByType(JavaPluginExtension)
-        javaPluginExtension.withSourcesJar()
-        javaPluginExtension.withJavadocJar()
-
         if (!gradleProject.logger.isEnabled(INFO)) {
             gradleProject.tasks.withType(JavaCompile).configureEach {
                 options.compilerArgs << '-Asezpoz.quiet=true'
@@ -408,6 +404,10 @@ class JpiPlugin implements Plugin<Project> {
                         }
                     }
                 }
+
+                JavaPluginExtension javaPluginExtension = project.extensions.getByType(JavaPluginExtension)
+                javaPluginExtension.withSourcesJar()
+                javaPluginExtension.withJavadocJar()
             }
         }
 

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPluginSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPluginSpec.groovy
@@ -68,6 +68,8 @@ class JpiPluginSpec extends Specification {
         publishingExtension.repositories.get(0).name == 'jenkins'
         publishingExtension.repositories.get(0) instanceof MavenArtifactRepository
         (publishingExtension.repositories.get(0) as MavenArtifactRepository).url == URI.create(repositoryUrl)
+        project.tasks.findByName('javadocJar')
+        project.tasks.findByName('sourcesJar')
 
         where:
         projectVersion   | repositoryUrl                           | extension
@@ -105,19 +107,27 @@ class JpiPluginSpec extends Specification {
     }
 
     def 'publishing configuration has been skipped'() {
-        when:
+        setup:
         project.with {
             apply plugin: 'jpi'
             jenkinsPlugin {
                 configurePublishing = false
             }
         }
+
+        when:
         (project as ProjectInternal).evaluate()
+
+        and:
         project.extensions.getByType(PublishingExtension)
 
         then:
         UnknownDomainObjectException ex = thrown()
         ex.message.contains("Extension of type 'PublishingExtension' does not exist.")
+
+        and:
+        !project.tasks.findByName('javadocJar')
+        !project.tasks.findByName('sourcesJar')
     }
 
     def 'localizer task has been setup'(Object outputDir, String expectedOutputDir) {

--- a/src/test/resources/org/jenkinsci/gradle/plugins/jpi/compile-dependencies-module.json
+++ b/src/test/resources/org/jenkinsci/gradle/plugins/jpi/compile-dependencies-module.json
@@ -76,6 +76,27 @@
       ]
     },
     {
+      "name": "runtimeElementsJenkins",
+      "attributes": {
+        "org.gradle.category": "library",
+        "org.gradle.dependency.bundling": "external",
+        "org.gradle.jvm.version": 8,
+        "org.gradle.libraryelements": "jpi",
+        "org.gradle.usage": "java-runtime"
+      },
+      "files": [
+        {
+          "name": "test-1.0.hpi",
+          "url": "test-1.0.hpi",
+          "size": "",
+          "sha512": "",
+          "sha256": "",
+          "sha1": "",
+          "md5": ""
+        }
+      ]
+    },
+    {
       "name": "sourcesElements",
       "attributes": {
         "org.gradle.category": "documentation",
@@ -107,27 +128,6 @@
         {
           "name": "test-1.0-javadoc.jar",
           "url": "test-1.0-javadoc.jar",
-          "size": "",
-          "sha512": "",
-          "sha256": "",
-          "sha1": "",
-          "md5": ""
-        }
-      ]
-    },
-    {
-      "name": "runtimeElementsJenkins",
-      "attributes": {
-        "org.gradle.category": "library",
-        "org.gradle.dependency.bundling": "external",
-        "org.gradle.jvm.version": 8,
-        "org.gradle.libraryelements": "jpi",
-        "org.gradle.usage": "java-runtime"
-      },
-      "files": [
-        {
-          "name": "test-1.0.hpi",
-          "url": "test-1.0.hpi",
           "size": "",
           "sha512": "",
           "sha256": "",

--- a/src/test/resources/org/jenkinsci/gradle/plugins/jpi/compile-dependencies-with-excludes-module.json
+++ b/src/test/resources/org/jenkinsci/gradle/plugins/jpi/compile-dependencies-with-excludes-module.json
@@ -88,6 +88,27 @@
       ]
     },
     {
+      "name": "runtimeElementsJenkins",
+      "attributes": {
+        "org.gradle.category": "library",
+        "org.gradle.dependency.bundling": "external",
+        "org.gradle.jvm.version": 8,
+        "org.gradle.libraryelements": "jpi",
+        "org.gradle.usage": "java-runtime"
+      },
+      "files": [
+        {
+          "name": "test-1.0.hpi",
+          "url": "test-1.0.hpi",
+          "size": "",
+          "sha512": "",
+          "sha256": "",
+          "sha1": "",
+          "md5": ""
+        }
+      ]
+    },
+    {
       "name": "sourcesElements",
       "attributes": {
         "org.gradle.category": "documentation",
@@ -119,27 +140,6 @@
         {
           "name": "test-1.0-javadoc.jar",
           "url": "test-1.0-javadoc.jar",
-          "size": "",
-          "sha512": "",
-          "sha256": "",
-          "sha1": "",
-          "md5": ""
-        }
-      ]
-    },
-    {
-      "name": "runtimeElementsJenkins",
-      "attributes": {
-        "org.gradle.category": "library",
-        "org.gradle.dependency.bundling": "external",
-        "org.gradle.jvm.version": 8,
-        "org.gradle.libraryelements": "jpi",
-        "org.gradle.usage": "java-runtime"
-      },
-      "files": [
-        {
-          "name": "test-1.0.hpi",
-          "url": "test-1.0.hpi",
           "size": "",
           "sha512": "",
           "sha256": "",

--- a/src/test/resources/org/jenkinsci/gradle/plugins/jpi/minimal-module.json
+++ b/src/test/resources/org/jenkinsci/gradle/plugins/jpi/minimal-module.json
@@ -58,6 +58,27 @@
       ]
     },
     {
+      "name": "runtimeElementsJenkins",
+      "attributes": {
+        "org.gradle.category": "library",
+        "org.gradle.dependency.bundling": "external",
+        "org.gradle.jvm.version": 8,
+        "org.gradle.libraryelements": "jpi",
+        "org.gradle.usage": "java-runtime"
+      },
+      "files": [
+        {
+          "name": "test-1.0.hpi",
+          "url": "test-1.0.hpi",
+          "size": "",
+          "sha512": "",
+          "sha256": "",
+          "sha1": "",
+          "md5": ""
+        }
+      ]
+    },
+    {
       "name": "sourcesElements",
       "attributes": {
         "org.gradle.category": "documentation",
@@ -89,27 +110,6 @@
         {
           "name": "test-1.0-javadoc.jar",
           "url": "test-1.0-javadoc.jar",
-          "size": "",
-          "sha512": "",
-          "sha256": "",
-          "sha1": "",
-          "md5": ""
-        }
-      ]
-    },
-    {
-      "name": "runtimeElementsJenkins",
-      "attributes": {
-        "org.gradle.category": "library",
-        "org.gradle.dependency.bundling": "external",
-        "org.gradle.jvm.version": 8,
-        "org.gradle.libraryelements": "jpi",
-        "org.gradle.usage": "java-runtime"
-      },
-      "files": [
-        {
-          "name": "test-1.0.hpi",
-          "url": "test-1.0.hpi",
           "size": "",
           "sha512": "",
           "sha256": "",

--- a/src/test/resources/org/jenkinsci/gradle/plugins/jpi/optional-plugin-dependencies-module.json
+++ b/src/test/resources/org/jenkinsci/gradle/plugins/jpi/optional-plugin-dependencies-module.json
@@ -58,46 +58,6 @@
       ]
     },
     {
-      "name": "sourcesElements",
-      "attributes": {
-        "org.gradle.category": "documentation",
-        "org.gradle.dependency.bundling": "external",
-        "org.gradle.docstype": "sources",
-        "org.gradle.usage": "java-runtime"
-      },
-      "files": [
-        {
-          "name": "test-1.0-sources.jar",
-          "url": "test-1.0-sources.jar",
-          "size": "",
-          "sha512": "",
-          "sha256": "",
-          "sha1": "",
-          "md5": ""
-        }
-      ]
-    },
-    {
-      "name": "javadocElements",
-      "attributes": {
-        "org.gradle.category": "documentation",
-        "org.gradle.dependency.bundling": "external",
-        "org.gradle.docstype": "javadoc",
-        "org.gradle.usage": "java-runtime"
-      },
-      "files": [
-        {
-          "name": "test-1.0-javadoc.jar",
-          "url": "test-1.0-javadoc.jar",
-          "size": "",
-          "sha512": "",
-          "sha256": "",
-          "sha1": "",
-          "md5": ""
-        }
-      ]
-    },
-    {
       "name": "credentialsApiElements",
       "attributes": {
         "org.gradle.category": "library",
@@ -221,6 +181,46 @@
         {
           "name": "test-1.0.hpi",
           "url": "test-1.0.hpi",
+          "size": "",
+          "sha512": "",
+          "sha256": "",
+          "sha1": "",
+          "md5": ""
+        }
+      ]
+    },
+    {
+      "name": "sourcesElements",
+      "attributes": {
+        "org.gradle.category": "documentation",
+        "org.gradle.dependency.bundling": "external",
+        "org.gradle.docstype": "sources",
+        "org.gradle.usage": "java-runtime"
+      },
+      "files": [
+        {
+          "name": "test-1.0-sources.jar",
+          "url": "test-1.0-sources.jar",
+          "size": "",
+          "sha512": "",
+          "sha256": "",
+          "sha1": "",
+          "md5": ""
+        }
+      ]
+    },
+    {
+      "name": "javadocElements",
+      "attributes": {
+        "org.gradle.category": "documentation",
+        "org.gradle.dependency.bundling": "external",
+        "org.gradle.docstype": "javadoc",
+        "org.gradle.usage": "java-runtime"
+      },
+      "files": [
+        {
+          "name": "test-1.0-javadoc.jar",
+          "url": "test-1.0-javadoc.jar",
           "size": "",
           "sha512": "",
           "sha256": "",

--- a/src/test/resources/org/jenkinsci/gradle/plugins/jpi/plugin-dependencies-module.json
+++ b/src/test/resources/org/jenkinsci/gradle/plugins/jpi/plugin-dependencies-module.json
@@ -76,6 +76,36 @@
       ]
     },
     {
+      "name": "runtimeElementsJenkins",
+      "attributes": {
+        "org.gradle.category": "library",
+        "org.gradle.dependency.bundling": "external",
+        "org.gradle.jvm.version": 8,
+        "org.gradle.libraryelements": "jpi",
+        "org.gradle.usage": "java-runtime"
+      },
+      "dependencies": [
+        {
+          "group": "org.jenkins-ci.plugins",
+          "module": "credentials",
+          "version": {
+            "requires": "1.9.4"
+          }
+        }
+      ],
+      "files": [
+        {
+          "name": "test-1.0.hpi",
+          "url": "test-1.0.hpi",
+          "size": "",
+          "sha512": "",
+          "sha256": "",
+          "sha1": "",
+          "md5": ""
+        }
+      ]
+    },
+    {
       "name": "sourcesElements",
       "attributes": {
         "org.gradle.category": "documentation",
@@ -107,36 +137,6 @@
         {
           "name": "test-1.0-javadoc.jar",
           "url": "test-1.0-javadoc.jar",
-          "size": "",
-          "sha512": "",
-          "sha256": "",
-          "sha1": "",
-          "md5": ""
-        }
-      ]
-    },
-    {
-      "name": "runtimeElementsJenkins",
-      "attributes": {
-        "org.gradle.category": "library",
-        "org.gradle.dependency.bundling": "external",
-        "org.gradle.jvm.version": 8,
-        "org.gradle.libraryelements": "jpi",
-        "org.gradle.usage": "java-runtime"
-      },
-      "dependencies": [
-        {
-          "group": "org.jenkins-ci.plugins",
-          "module": "credentials",
-          "version": {
-            "requires": "1.9.4"
-          }
-        }
-      ],
-      "files": [
-        {
-          "name": "test-1.0.hpi",
-          "url": "test-1.0.hpi",
           "size": "",
           "sha512": "",
           "sha256": "",


### PR DESCRIPTION
Hi @sghill 

I was going through https://github.com/jenkinsci/gradle-jpi-plugin/issues/138 again and then realized that maybe what would be nice is to avoid creating sources/javadoc jar tasks if `configurePublishing` is `false`.

The current experience is that if you have `configurePublishing` as `false`, the `mavenJpi` publication won;'t be created, avoiding `JpiPomCustomizer`. However, `javaPluginExtension.withSourcesJar()` and  `javaPluginExtension.withJavadocJar()` configure publications so it goes against the nature of the `configurePublishing`. 

Do you think this change would make .sense? The changes contain modification to the expected module.json files because the order of the `variants` changed with this modification