### PR TITLE
JpiPlugin: Do not attempt to get the plugin that is just being applied

### DIFF
--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
@@ -164,7 +164,7 @@ class JpiPlugin implements Plugin<Project> {
         jarProvider.configure { it.dependsOn(configureManifest) }
     }
 
-    private static configureJpi(Project project) {
+    private configureJpi(Project project) {
         JpiExtension jpiExtension = project.extensions.getByType(JpiExtension)
 
         def jar = project.tasks.named(JavaPlugin.JAR_TASK_NAME)
@@ -175,7 +175,7 @@ class JpiPlugin implements Plugin<Project> {
             def extension = jpiExtension.fileExtension
             it.archiveFileName.set(fileName)
             it.archiveExtension.set(extension)
-            it.classpath(jar, project.plugins.getPlugin(JpiPlugin).dependencyAnalysis.allLibraryDependencies)
+            it.classpath(jar, dependencyAnalysis.allLibraryDependencies)
             it.from(WEB_APP_DIR)
         }
         project.tasks.named(LifecycleBasePlugin.ASSEMBLE_TASK_NAME) {
@@ -213,12 +213,12 @@ class JpiPlugin implements Plugin<Project> {
         }
     }
 
-    private static configureLicenseInfo(Project project) {
+    private configureLicenseInfo(Project project) {
         def licenseTask = project.tasks.register(LICENSE_TASK_NAME, LicenseTask) {
             it.description = 'Generates license information.'
             it.group = BasePlugin.BUILD_GROUP
             it.outputDirectory = new File(project.buildDir, 'licenses')
-            it.libraryConfiguration = project.plugins.getPlugin(JpiPlugin).dependencyAnalysis.allLibraryDependencies
+            it.libraryConfiguration = dependencyAnalysis.allLibraryDependencies
         }
 
         project.tasks.named(JPI_TASK_NAME).configure {
@@ -263,7 +263,7 @@ class JpiPlugin implements Plugin<Project> {
         }
     }
 
-    private static configureConfigurations(Project project) {
+    private configureConfigurations(Project project) {
         project.dependencies.components.all(JpiVariantRule)
         project.dependencies.components.withModule(JenkinsWarRule.JENKINS_WAR_COORDINATES, JenkinsWarRule)
 
@@ -328,7 +328,7 @@ class JpiPlugin implements Plugin<Project> {
                         }
                     }
 
-                    project.plugins.getPlugin(JpiPlugin).dependencyAnalysis.registerJpiConfigurations(
+                    dependencyAnalysis.registerJpiConfigurations(
                             runtimeElements,
                             runtimeElementsJenkins,
                             runtimeClasspathJenkins)

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiTaskRegistrationIntegrationSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiTaskRegistrationIntegrationSpec.groovy
@@ -1,0 +1,79 @@
+package org.jenkinsci.gradle.plugins.jpi
+
+import org.gradle.testkit.runner.BuildResult
+
+class JpiTaskRegistrationIntegrationSpec extends IntegrationSpec {
+    private final String projectName = TestDataGenerator.generateName()
+    private File settings
+    private File build
+    def setup() {
+        settings = projectDir.newFile('settings.gradle')
+        settings << """rootProject.name = \"$projectName\""""
+        build = projectDir.newFile('build.gradle')
+        build << '''\
+            plugins {
+                id 'org.jenkins-ci.jpi'
+            }
+            '''.stripIndent()
+    }
+
+    def 'JpiPlugin is applied when some other plugin modifies War tasks'() {
+        given:
+        build.text = '''
+            import jenkinsci.ConflictPlugin
+
+            allprojects {
+                apply plugin: ConflictPlugin
+                apply plugin: 'java'
+            }
+            '''.stripIndent()
+
+        new File(projectDir.root, 'submodule').mkdirs()
+
+        File submoduleBuildFile = new File(projectDir.root, 'submodule/build.gradle')
+        submoduleBuildFile.text = '''
+            plugins {
+                id 'org.jenkins-ci.jpi'
+            }
+        '''
+
+        settings.text = '''
+            include 'submodule'
+        '''
+
+        new File(projectDir.root, 'buildSrc/src/main/groovy/jenkinsci').mkdirs()
+        File conflictPlugin = new File(projectDir.root, 'buildSrc/src/main/groovy/jenkinsci/ConflictPlugin.groovy')
+        conflictPlugin.text = '''
+            package jenkinsci
+
+            import org.gradle.api.Plugin
+            import org.gradle.api.Project
+            import org.gradle.api.tasks.bundling.War
+
+            class ConflictPlugin implements Plugin<Project> {
+                @Override
+                void apply(Project project) {
+                    project.tasks.withType(War) { War war ->
+                        war.archiveBaseName.set('do-something')
+                    }
+                }
+            }
+        '''
+
+        File buildSrcFile = new File(projectDir.root, 'buildSrc/build.groovy')
+        buildSrcFile.text = '''
+            plugins {
+                id 'groovy'
+            }
+        '''
+
+        when:
+        BuildResult result = gradleRunner()
+                .withArguments('buildEnvironment')
+                .build()
+
+        then:
+        !result.output.contains('Plugin with type class org.jenkinsci.gradle.plugins.jpi.JpiPlugin has not been used')
+    }
+
+}


### PR DESCRIPTION
Hi @sghill,

This is for https://github.com/jenkinsci/gradle-jpi-plugin/issues/141

Prevent: 

```
Caused by: org.gradle.api.plugins.UnknownPluginException: Plugin with type class org.jenkinsci.gradle.plugins.jpi.JpiPlugin has not been used.
        at org.gradle.api.internal.plugins.DefaultPluginContainer.getPlugin(DefaultPluginContainer.java:140)
        at org.gradle.api.plugins.PluginContainer$getPlugin$2.call(Unknown Source)
        at org.jenkinsci.gradle.plugins.jpi.JpiPlugin$_configureJpi_closure10.doCall(JpiPlugin.groovy:178)
``` 

This happened when other plugins create the `jpi` task during configuration phase. 