### PR TITLE
Workaround: Apply usage attribute if Kotlin plugin applied

### DIFF
--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/DependencyAnalysis.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/DependencyAnalysis.groovy
@@ -12,6 +12,7 @@ import org.gradle.api.artifacts.result.ResolvedVariantResult
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.LibraryElements
+import org.gradle.api.attributes.Usage
 
 @CompileStatic
 class DependencyAnalysis {
@@ -42,6 +43,10 @@ class DependencyAnalysis {
 
     DependencyAnalysis(Project project) {
         this.allLibraryDependencies = project.configurations.detachedConfiguration()
+        project.plugins.withId('org.jetbrains.kotlin.jvm') {
+            this.allLibraryDependencies.attributes.attribute(Usage.USAGE_ATTRIBUTE,
+                    project.objects.named(Usage, Usage.JAVA_RUNTIME))
+        }
         this.allLibraryDependencies.withDependencies {
             // do the analysis when this configuration is resolved
             analyse()

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/DependencyAnalysis.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/DependencyAnalysis.groovy
@@ -43,10 +43,8 @@ class DependencyAnalysis {
 
     DependencyAnalysis(Project project) {
         this.allLibraryDependencies = project.configurations.detachedConfiguration()
-        project.plugins.withId('org.jetbrains.kotlin.jvm') {
-            this.allLibraryDependencies.attributes.attribute(Usage.USAGE_ATTRIBUTE,
-                    project.objects.named(Usage, Usage.JAVA_RUNTIME))
-        }
+        this.allLibraryDependencies.attributes.attribute(Usage.USAGE_ATTRIBUTE,
+                project.objects.named(Usage, Usage.JAVA_RUNTIME))
         this.allLibraryDependencies.withDependencies {
             // do the analysis when this configuration is resolved
             analyse()

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/LicenseTask.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/LicenseTask.groovy
@@ -8,6 +8,7 @@ import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.attributes.Usage
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
@@ -66,8 +67,12 @@ class LicenseTask extends DefaultTask {
     }
 
     private Set<ResolvedArtifact> collectPomArtifacts() {
-        project.configurations
+        def detached = project.configurations
                 .detachedConfiguration(collectDependencies())
+        project.plugins.withId('org.jetbrains.kotlin.jvm') {
+            detached.attributes.attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME))
+        }
+        detached
                 .resolvedConfiguration
                 .resolvedArtifacts
     }

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/LicenseTask.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/LicenseTask.groovy
@@ -69,9 +69,7 @@ class LicenseTask extends DefaultTask {
     private Set<ResolvedArtifact> collectPomArtifacts() {
         def detached = project.configurations
                 .detachedConfiguration(collectDependencies())
-        project.plugins.withId('org.jetbrains.kotlin.jvm') {
-            detached.attributes.attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME))
-        }
+        detached.attributes.attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME))
         detached
                 .resolvedConfiguration
                 .resolvedArtifacts

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/LicenseTaskSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/LicenseTaskSpec.groovy
@@ -3,13 +3,15 @@ package org.jenkinsci.gradle.plugins.jpi
 import org.gradle.testkit.runner.TaskOutcome
 import org.xmlunit.builder.DiffBuilder
 import org.xmlunit.builder.Input
+import spock.lang.Unroll
 
 class LicenseTaskSpec extends IntegrationSpec {
 
-    def 'compute license information'() {
+    @Unroll
+    def 'compute license information - #buildFile'(String buildFile, String expectedLicensesFile) {
         given:
         File projectFolder = projectDir.newFolder('bar')
-        new File(projectFolder, 'build.gradle') << getClass().getResource('licenseInfo.gradle').text
+        new File(projectFolder, 'build.gradle') << getClass().getResource(buildFile).text
 
         when:
         def result = gradleRunner()
@@ -21,7 +23,12 @@ class LicenseTaskSpec extends IntegrationSpec {
         result.task(':generateLicenseInfo').outcome == TaskOutcome.SUCCESS
         File licensesFile = new File(projectFolder, 'build/licenses/licenses.xml')
         licensesFile.exists()
-        compareXml(licensesFile.text, getClass().getResource('licenses.xml').text)
+        compareXml(licensesFile.text, getClass().getResource(expectedLicensesFile).text)
+
+        where:
+        buildFile                      | expectedLicensesFile
+        'licenseInfo.gradle'           | 'licenses.xml'
+        'licenseInfoWithKotlin.gradle' | 'licensesWithKotlin.xml'
     }
 
     private static boolean compareXml(String actual, String expected) {

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/ServerTaskSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/ServerTaskSpec.groovy
@@ -16,6 +16,7 @@ class ServerTaskSpec extends IntegrationSpec {
         def build = projectDir.newFile('build.gradle')
         build << """\
             plugins {
+                $additionalPlugin
                 id 'org.jenkins-ci.jpi'
             }
             jenkinsPlugin {
@@ -23,6 +24,7 @@ class ServerTaskSpec extends IntegrationSpec {
             }
             dependencies {
                 jenkinsServer 'org.jenkins-ci.plugins:git:3.12.1'
+                implementation 'com.squareup.okio:okio:2.4.3'
             }
             """.stripIndent()
 
@@ -53,7 +55,10 @@ class ServerTaskSpec extends IntegrationSpec {
         new File(projectDir.root, 'work/plugins/git.hpi').exists()
 
         where:
-        jenkinsVersion << ['1.580.1', '2.64']
+        jenkinsVersion | additionalPlugin
+        '1.580.1'      | ''
+        '2.64'         | ''
+        '2.64'         | "id 'org.jetbrains.kotlin.jvm' version '1.3.70'"
     }
 
     private static String path(File file) {

--- a/src/test/resources/org/jenkinsci/gradle/plugins/jpi/licenseInfoWithKotlin.gradle
+++ b/src/test/resources/org/jenkinsci/gradle/plugins/jpi/licenseInfoWithKotlin.gradle
@@ -1,0 +1,32 @@
+plugins {
+    id 'org.jetbrains.kotlin.jvm' version '1.3.70'
+    id 'org.jenkins-ci.jpi'
+}
+
+group = 'org.foo'
+description = 'lorem ipsum'
+version = '1.2.3'
+
+jenkinsPlugin {
+    coreVersion = '2.72'
+    displayName = 'A Test'
+    url = 'https:/acme.org'
+    licenses {
+        license {
+            name 'Apache License, Version 2.0'
+            url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+        }
+    }
+}
+
+dependencies {
+    // packaged library dependencies -> include license
+    api 'xmlunit:xmlunit:1.4'
+    // dependency provided -> do not include license
+    compileOnly 'commons-codec:commons-codec:1.8'
+    // plugin dependency -> do not include license
+    implementation 'org.jenkins-ci.plugins:credentials:1.9.4'
+
+    // Kotlin plugin needs workaround on detached configuration
+    implementation 'com.squareup.okio:okio:2.4.3'
+}

--- a/src/test/resources/org/jenkinsci/gradle/plugins/jpi/licensesWithKotlin.xml
+++ b/src/test/resources/org/jenkinsci/gradle/plugins/jpi/licensesWithKotlin.xml
@@ -1,0 +1,22 @@
+<l:dependencies xmlns:l='licenses' version='1.2.3' artifactId='bar' groupId='org.foo'>
+    <l:dependency version='1.2.3' artifactId='bar' groupId='org.foo' name='A Test' url='https:/acme.org'>
+        <l:description>lorem ipsum</l:description>
+        <l:license url='https://www.apache.org/licenses/LICENSE-2.0.txt' name='Apache License, Version 2.0'/>
+    </l:dependency>
+    <l:dependency version='2.4.3' artifactId='okio' groupId='com.squareup.okio' name='' url=''>
+        <l:description></l:description>
+    </l:dependency>
+    <l:dependency version='1.4' artifactId='xmlunit' groupId='xmlunit' name='XMLUnit for Java' url='http://xmlunit.sourceforge.net/'>
+        <l:description>XMLUnit compares a control XML document to a test document or the result of a transformation, validates documents, and compares the results of XPath expressions.</l:description>
+        <l:license url='http://xmlunit.svn.sourceforge.net/viewvc/*checkout*/xmlunit/trunk/xmlunit/LICENSE.txt' name='BSD License'/>
+    </l:dependency>
+    <l:dependency version='1.3.61' artifactId='kotlin-stdlib' groupId='org.jetbrains.kotlin' name='' url=''>
+        <l:description></l:description>
+    </l:dependency>
+    <l:dependency version='1.3.61' artifactId='kotlin-stdlib-common' groupId='org.jetbrains.kotlin' name='' url=''>
+        <l:description></l:description>
+    </l:dependency>
+    <l:dependency version='13.0' artifactId='annotations' groupId='org.jetbrains' name='' url=''>
+        <l:description></l:description>
+    </l:dependency>
+</l:dependencies>


### PR DESCRIPTION
This plugin creates detached configurations in three places. Two of them will fail if the Kotlin plugin is applied because we cannot find a matching variant ([Louis describes the underlying issue here](https://youtrack.jetbrains.com/issue/KT-31641#focus=streamItem-27-3698024.0-0)). One way to fix this is with [a workaround mentioned in YouTrack for Kapt](https://youtrack.jetbrains.com/issue/KT-31641#focus=streamItem-27-3666505.0-0).

This workaround is not ideal since we have to modify two places to behave differently if another plugin is applied. @wolfs or @jjohannes would you mind looking at this?

Fixes #153.