### PR TITLE
Mandatory upgrade for plugin portal publishing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     `maven-publish`
     signing
     codenarc
-    id("com.gradle.plugin-publish") version "0.10.1"
+    id("com.gradle.plugin-publish") version "0.11.0"
     `java-gradle-plugin`
 }
 


### PR DESCRIPTION
More info in https://blog.gradle.org/plugin-portal-update