### PR TITLE
Add sezpoz to testAnnotation configuration by default

### DIFF
--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/internal/DependencyLookup.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/internal/DependencyLookup.groovy
@@ -33,6 +33,8 @@ class DependencyLookup {
                 return [core] as Set
             case 'compileOnly':
                 return [core, findbugs, servlet] as Set
+            case 'testAnnotationProcessor':
+                return ['net.java.sezpoz:sezpoz:1.13'] as Set
             case 'testImplementation':
                 Set<String> deps = [core, testHarness, uiSamples] as Set
                 if (version < GradleVersion.version('1.505')) {

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/internal/DependencyLookupSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/internal/DependencyLookupSpec.groovy
@@ -17,6 +17,19 @@ class DependencyLookupSpec extends Specification {
         ] as Set
     }
 
+    def 'should get testAnnotationProcessor dependencies by version'() {
+        given:
+        DependencyLookup lookup = new DependencyLookup()
+
+        when:
+        def actual = lookup.find('testAnnotationProcessor', '2.0')
+
+        then:
+        actual == [
+                'net.java.sezpoz:sezpoz:1.13',
+        ] as Set
+    }
+
     @Unroll
     def 'should get compileOnly dependencies for #version'(String version, Set<String> expected) {
         given:


### PR DESCRIPTION
Some tests require sezpoz's annotation processing. Today this must be added explicitly. This change adds sezpoz as an annotation processor for tests automatically.

cc @rahulsom