### PR TITLE
Improve task avoidance

### DIFF
--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiManifest.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiManifest.groovy
@@ -15,6 +15,7 @@
  */
 package org.jenkinsci.gradle.plugins.jpi
 
+import groovy.transform.Memoized
 import hudson.Extension
 import jenkins.YesNoMaybe
 import net.java.sezpoz.Index
@@ -23,7 +24,6 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.plugins.JavaPluginConvention
 import org.jenkinsci.gradle.plugins.jpi.internal.VersionCalculator
 
-import java.util.jar.Attributes
 import java.util.jar.Manifest
 
 import static java.util.jar.Attributes.Name.MANIFEST_VERSION
@@ -112,7 +112,8 @@ class JpiManifest extends Manifest {
         YesNoMaybe.YES
     }
 
-    static Map<String, ?> attributesToMap(Attributes attributes) {
-        attributes.collectEntries { k, v -> [k.toString(), v] } as Map<String, ?>
+    @Memoized
+    static Map<String, ?> attributesToMap(Project project) {
+        new JpiManifest(project).mainAttributes.collectEntries { k, v -> [k.toString(), v] } as Map<String, ?>
     }
 }

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
@@ -227,28 +227,17 @@ class JpiPlugin implements Plugin<Project> {
     }
 
     private static configureManifest(Project project) {
-        JavaPluginConvention javaPluginConvention = project.convention.getPlugin(JavaPluginConvention)
         TaskProvider<War> jpiProvider = project.tasks.named(JPI_TASK_NAME) as TaskProvider<War>
         TaskProvider<Jar> jarProvider = project.tasks.named(JavaPlugin.JAR_TASK_NAME) as TaskProvider<Jar>
 
-        def configureManifest = project.tasks.register('configureManifest') {
-            it.doLast {
-                Map<String, ?> attributes = attributesToMap(new JpiManifest(project).mainAttributes)
-                jpiProvider.configure {
-                    it.manifest.attributes(attributes)
-                    it.inputs.property('manifest', attributes)
-                }
-                jarProvider.configure {
-                    it.manifest.attributes(attributes)
-                    it.inputs.property('manifest', attributes)
+        [jpiProvider, jarProvider].each { provider ->
+            provider.configure { Jar task ->
+                task.doFirst {
+                    Map<String, ?> attributes = attributesToMap(project)
+                    task.manifest.attributes(attributes)
                 }
             }
-
-            it.dependsOn(javaPluginConvention.sourceSets.getByName(MAIN_SOURCE_SET_NAME).output)
         }
-
-        jpiProvider.configure { it.dependsOn(configureManifest) }
-        jarProvider.configure { it.dependsOn(configureManifest) }
     }
 
     private configureJpi(Project project) {

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiIntegrationSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiIntegrationSpec.groovy
@@ -196,12 +196,12 @@ class JpiIntegrationSpec extends IntegrationSpec {
 
         where:
         task                                         | dependency                                    | outcome
-        'jar'                                        | ':configureManifest'                          | TaskOutcome.SUCCESS
-        'jpi'                                        | ':configureManifest'                          | TaskOutcome.SUCCESS
+        'jar'                                        | ':classes'                                    | TaskOutcome.UP_TO_DATE
+        'jpi'                                        | ':generateLicenseInfo'                        | TaskOutcome.SUCCESS
         'processTestResources'                       | ':resolveTestDependencies'                    | TaskOutcome.SUCCESS
         'compileTestJava'                            | ':insertTest'                                 | TaskOutcome.SKIPPED
-        'testClasses'                                | ':generateTestHpl'                          | TaskOutcome.SUCCESS
-        'generate-test-hpl'                          | ':generateTestHpl'                          | TaskOutcome.SUCCESS
+        'testClasses'                                | ':generateTestHpl'                            | TaskOutcome.SUCCESS
+        'generate-test-hpl'                          | ':generateTestHpl'                            | TaskOutcome.SUCCESS
         'compileJava'                                | ':localizer'                                  | TaskOutcome.SUCCESS
         'sourcesJar'                                 | ':localizer'                                  | TaskOutcome.SUCCESS
         'generateMetadataFileForMavenJpiPublication' | ':generateMetadataFileForMavenJpiPublication' | TaskOutcome.SUCCESS


### PR DESCRIPTION
Configure the manifest attributes for the "jar" & "jpi" tasks as part of a "doFirst" closure instead of configuring them via another task and updating the task inputs.