### PR TITLE
Fix a number of initialization order issues with 0.43.0

### DIFF
--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
@@ -95,15 +95,17 @@ class JpiPlugin implements Plugin<Project>, PluginDependencyProvider {
 
         dependencyAnalysis = new DependencyAnalysis(gradleProject)
 
+        def ext = gradleProject.extensions.create('jenkinsPlugin', JpiExtension, gradleProject)
+
         gradleProject.plugins.apply(JavaLibraryPlugin)
         gradleProject.plugins.apply(GroovyPlugin)
         gradleProject.plugins.apply(kotlinPlugin('org.jenkinsci.gradle.plugins.accmod.AccessModifierPlugin'))
         gradleProject.plugins.apply(kotlinPlugin('org.jenkinsci.gradle.plugins.manifest.JenkinsManifestPlugin'))
         gradleProject.plugins.apply(kotlinPlugin('org.jenkinsci.gradle.plugins.testing.JpiTestingPlugin'))
 
-        def ext = gradleProject.extensions.create('jenkinsPlugin', JpiExtension, gradleProject)
         gradleProject.plugins.apply(LegacyWorkaroundsPlugin)
 
+        configureConfigurations(gradleProject)
         def overlap = gradleProject.tasks.register(CheckOverlappingSourcesTask.TASK_NAME,
                 CheckOverlappingSourcesTask) { CheckOverlappingSourcesTask t ->
             t.group = LifecycleBasePlugin.VERIFICATION_GROUP
@@ -125,7 +127,7 @@ class JpiPlugin implements Plugin<Project>, PluginDependencyProvider {
             def main = project.extensions.getByType(SourceSetContainer)['main']
             def mainResources = main.resources.srcDirs
             def mainOutput = main.output
-            def libraries = project.plugins.getPlugin(JpiPlugin).dependencyAnalysis.allLibraryDependencies
+            def libraries = dependencyAnalysis.allLibraryDependencies
             t.fileName.set(ext.shortName + '.hpl')
             t.hplDir.set(project.layout.buildDirectory.dir('hpl'))
             t.resourcePath.set(project.file(WEB_APP_DIR))
@@ -200,7 +202,6 @@ class JpiPlugin implements Plugin<Project>, PluginDependencyProvider {
         }
         configureRepositories(gradleProject)
         configureJpi(gradleProject)
-        configureConfigurations(gradleProject)
         configureManifest(gradleProject)
         configureLicenseInfo(gradleProject)
         configureTestDependencies(gradleProject)
@@ -514,7 +515,7 @@ class JpiPlugin implements Plugin<Project>, PluginDependencyProvider {
         }
     }
 
-    private static configureTestHpl(Project project) {
+    private configureTestHpl(Project project) {
         // generate test hpl manifest for the current plugin, to be used during unit test
         def outputDir = project.layout.buildDirectory.dir('generated-resources/test')
 
@@ -523,7 +524,7 @@ class JpiPlugin implements Plugin<Project>, PluginDependencyProvider {
             def main = project.extensions.getByType(SourceSetContainer)['main']
             def mainResources = main.resources.srcDirs
             def mainOutput = main.output
-            def libraries = project.plugins.getPlugin(JpiPlugin).dependencyAnalysis.allLibraryDependencies
+            def libraries = dependencyAnalysis.allLibraryDependencies
             it.fileName.set('the.hpl')
             it.hplDir.set(outputDir)
             it.resourcePath.set(project.file(WEB_APP_DIR))


### PR DESCRIPTION
I had a number issues applying this upgrade from 0.38.0 because I needed
to build against Gradle 7.3.1

Specifically the main error I received was:

```
* What went wrong:
A problem occurred evaluating project ':jenkins-skylab-plugin'.
> Failed to apply plugin class 'org.jenkinsci.gradle.plugins.manifest.JenkinsManifestPlugin'.
   > Could not create task ':jenkins-skylab-plugin:generateJenkinsManifest'.
      > Extension of type 'JpiExtensionBridge' does not exist. Currently registered extension types: [ExtraPropertiesExtension, EclipseModel, IdeaModel, ProcessorsExtension, BlacklistExtension, BasePluginExtension, DefaultArtifactPublicationSet, SourceSetContainer, ReportingExtension, JavaPluginExtension, JavaToolchainService, TestingExtension, BaselineJavaVersionExtension, GroovyRuntime]
```

Which made sense because the extension was being accessed before it
was actually constructed. I'm unsure if Gradle changed initialization
order in some versions of Gradle, but in any case, moving a few of
these initialization blocks around managed to fix my issue.

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [n/a] Link to relevant issues in GitHub or Jira
- [n/a] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue - unsure how to test this

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
