### PR TITLE
Address `set-output` deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up JDK 8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
         java-version: "8"
+        distribution: "temurin"
     - name: Cache Dependencies
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.gradle/caches
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
@@ -31,13 +32,13 @@ jobs:
     - name: Build
       run: ./gradlew clean build testGradle7.4
     - name: Archive Codenarc Report
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
         name: codenarc-results
         path: build/reports/codenarc
     - name: Archive Test Results
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
         name: test-results

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -19,13 +19,14 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         gradle_version: ["6.3", "6.4.1", "7.4"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up JDK 8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
         java-version: "8"
+        distribution: "temurin"
     - name: Cache Dependencies
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.gradle/caches
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
@@ -33,7 +34,7 @@ jobs:
     - name: Test ${{ matrix.gradle_version }}
       run: ./gradlew testGradle${{ matrix.gradle_version }}
     - name: Archive Test Results
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       if: ${{ always() }}
       with:
         name: test-results


### PR DESCRIPTION
https://github.com/jenkins-infra/helpdesk/issues/3176

The change proposed takes care of the Node 12 -> 16 warning too, see https://github.com/jenkinsci/gradle-jpi-plugin/actions/runs/3307997015 for reference.