### PR TITLE
Add a flag to disable adding timestamp to the SNAPSHOT version

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,17 +124,17 @@ Examples:
             usingSourceSet(sourceSets.main)
         }
     }
-    
+
     dependencies {
         implementation 'org.jenkinsci.plugins:git:1.1.15'
         api 'org.jenkins-ci.plugins:credentials:1.9.4'
-        
+
         // dependency of the (optional) ant feature
         antImplementation 'org.jenkins-ci.plugins:ant:1.2'
-        
+
         // dependency for testing only
         testImplementation 'org.jenkins-ci.main:maven-plugin:1.480'
-        
+
         // addition dependencies for manual tests on the server started with `gradle server`
         jenkinsServer 'org.jenkins-ci.plugins:ant:1.2'
     }
@@ -150,7 +150,7 @@ Examples:
   the Jenkins Maven repository to be included in the Update Center.
 * `gradle server` - Start a local instance of Jenkins with the plugin pre-installed for testing
   and debugging.
-  
+
 ### Running Jenkins Locally
 
 The `server` task creates a [hpl][hpl], installs plugins, and starts up Jenkins on port 8080. The server runs
@@ -262,6 +262,19 @@ tasks.named('checkAccessModifier').configure {
 ```
 
 `checkAccessModifier` will only be cached on success if `ignoreFailures` is `false`.
+
+### Disabling appending timestamp to the SNAPSHOT plugin version
+
+By default, `generateJenkinsManifest` task appends the current timestamp and the current username to the `-SNAPSHOT` plugin version.
+It leads to a non-repeatable outputs that affect the task cacheability.
+
+To opt-out from modifying the `-SNAPSHOT` plugin version, add this configuration to build.gradle:
+
+```gradle
+tasks.named('generateJenkinsManifest').configure {
+    dynamicSnapshotVersion.set(false)
+}
+```
 
 ## Disabling SHA256 and SHA512 checksums when releasing a plugin
 

--- a/src/main/kotlin/org/jenkinsci/gradle/plugins/manifest/GenerateJenkinsManifestTask.kt
+++ b/src/main/kotlin/org/jenkinsci/gradle/plugins/manifest/GenerateJenkinsManifestTask.kt
@@ -66,13 +66,22 @@ open class GenerateJenkinsManifestTask : DefaultTask() {
     @Internal
     val version: Property<String> = project.objects.property()
 
+    @Input
+    val dynamicSnapshotVersion: Property<Boolean> = project.objects.property<Boolean>().convention(true)
+
     // TODO this is most correct based on today's behavior, but it's worth considering
     // before 1.0.0 if this timestamp appending should continue to be a part of the jpi
     // plugin. There are many gradle plugins dedicated to versioning that could be
     // recommended instead, and this means the default behavior of `-SNAPSHOT` versions
     // is to always rerun this task and therefore any downstream task
     @Input
-    val pluginVersion: Provider<String> = version.map { VersionCalculator().calculate(it) }
+    val pluginVersion: Provider<String> =
+        dynamicSnapshotVersion.flatMap { isDynamicSnapshotVersion ->
+            when (isDynamicSnapshotVersion) {
+                true -> version.map { VersionCalculator().calculate(it) }
+                false -> version
+            }
+        }
 
     @Input
     val maskedClasses: SetProperty<String> = project.objects.setProperty()

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/manifest/GenerateJenkinsManifestTaskIntegrationSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/manifest/GenerateJenkinsManifestTaskIntegrationSpec.groovy
@@ -397,13 +397,13 @@ class GenerateJenkinsManifestTaskIntegrationSpec extends IntegrationSpec {
         result.task(taskPath).outcome == TaskOutcome.SUCCESS
 
         and:
-        pluginVersion() == "1.0-SNAPSHOT"
+        pluginVersion() == '1.0-SNAPSHOT'
     }
 
     def pluginVersion() {
         def manifest = new Manifest(inProjectDir('build/jenkins-manifests/jenkins.mf').newInputStream())
         assert manifest != null
 
-        manifest.getMainAttributes().getValue("Plugin-Version")
+        manifest.mainAttributes.getValue('Plugin-Version')
     }
 }

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/manifest/GenerateJenkinsManifestTaskIntegrationSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/manifest/GenerateJenkinsManifestTaskIntegrationSpec.groovy
@@ -332,11 +332,15 @@ class GenerateJenkinsManifestTaskIntegrationSpec extends IntegrationSpec {
         thirdRun.task(taskPath).outcome == TaskOutcome.UP_TO_DATE
     }
 
+    @Unroll
     def 'should use release plugin version as is'() {
         given:
         build.text = """\
             $BUILD_FILE
             version = '1.0'
+            tasks.named("$GenerateJenkinsManifestTask.NAME").configure {
+                dynamicSnapshotVersion = $dynamicSnapshotVersion
+            }
             """.stripIndent()
 
         when:
@@ -349,6 +353,9 @@ class GenerateJenkinsManifestTaskIntegrationSpec extends IntegrationSpec {
 
         and:
         pluginVersion() == '1.0'
+
+        where:
+        dynamicSnapshotVersion << [true, false]
     }
 
     def 'should enhance snapshot plugin version'() {

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/manifest/GenerateJenkinsManifestTaskIntegrationSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/manifest/GenerateJenkinsManifestTaskIntegrationSpec.groovy
@@ -367,8 +367,8 @@ class GenerateJenkinsManifestTaskIntegrationSpec extends IntegrationSpec {
 
         when:
         def result = gradleRunner()
-            .withArguments(taskName)
-            .build()
+                .withArguments(taskName)
+                .build()
 
         then:
         result.task(taskPath).outcome == TaskOutcome.SUCCESS

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/manifest/GenerateJenkinsManifestTaskIntegrationSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/manifest/GenerateJenkinsManifestTaskIntegrationSpec.groovy
@@ -295,7 +295,7 @@ class GenerateJenkinsManifestTaskIntegrationSpec extends IntegrationSpec {
         given:
         build.text = """\
             $BUILD_FILE
-            tasks.named("$GenerateJenkinsManifestTask.NAME").configure {
+            tasks.named('$GenerateJenkinsManifestTask.NAME').configure {
                 dynamicSnapshotVersion = true
             }
             """.stripIndent()
@@ -311,7 +311,7 @@ class GenerateJenkinsManifestTaskIntegrationSpec extends IntegrationSpec {
         when:
         build.text = """\
             $BUILD_FILE
-            tasks.named("$GenerateJenkinsManifestTask.NAME").configure {
+            tasks.named('$GenerateJenkinsManifestTask.NAME').configure {
                 dynamicSnapshotVersion = false
             }
             """.stripIndent()
@@ -338,7 +338,7 @@ class GenerateJenkinsManifestTaskIntegrationSpec extends IntegrationSpec {
         build.text = """\
             $BUILD_FILE
             version = '1.0'
-            tasks.named("$GenerateJenkinsManifestTask.NAME").configure {
+            tasks.named('$GenerateJenkinsManifestTask.NAME').configure {
                 dynamicSnapshotVersion = $dynamicSnapshotVersion
             }
             """.stripIndent()
@@ -383,7 +383,7 @@ class GenerateJenkinsManifestTaskIntegrationSpec extends IntegrationSpec {
             $BUILD_FILE
             version = '1.0-SNAPSHOT'
 
-            tasks.named("$GenerateJenkinsManifestTask.NAME").configure {
+            tasks.named('$GenerateJenkinsManifestTask.NAME').configure {
                 dynamicSnapshotVersion = false
             }
             """.stripIndent()


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This PR adds a flag that allows to opt-out from adding the timestamp to the `-SNAPSHOT` version in the Jenkins manifest file. Since the default value for the new flag is `true` there are no changes to the build. Users have to configure it explicitly. As mentioned in the [comment](https://github.com/jenkinsci/gradle-jpi-plugin/blob/master/src/main/kotlin/org/jenkinsci/gradle/plugins/manifest/GenerateJenkinsManifestTask.kt#L69) the current behavior doesn't allow Gradle to cache the results and causes all the dependent tasks always to be executed.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
