### PR TITLE
Add Jenkins "incrementals" binary repository

### DIFF
--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtension.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtension.groovy
@@ -39,6 +39,7 @@ import shaded.hudson.util.VersionNumber
  */
 @SuppressWarnings('MethodCount')
 class JpiExtension implements JpiExtensionBridge {
+    public static final String JENKINS_INCREMENTALS_REPO = 'https://repo.jenkins-ci.org/incrementals'
     final Project project
     @Deprecated
     Map<String, String> jenkinsWarCoordinates
@@ -69,6 +70,7 @@ class JpiExtension implements JpiExtensionBridge {
     private final Property<Boolean> usePluginFirstClassLoader
     private final SetProperty<String> maskedClassesFromCore
     private final ListProperty<PluginDeveloper> pluginDevelopers
+    private final Property<String> incrementalsRepoUrl
 
     @SuppressWarnings('UnnecessarySetter')
     JpiExtension(Project project) {
@@ -92,6 +94,7 @@ class JpiExtension implements JpiExtensionBridge {
         this.generateTests = project.objects.property(Boolean).convention(false)
         this.requireEscapeByDefaultInJelly = project.objects.property(Boolean).convention(true)
         this.generatedTestClassName = project.objects.property(String).convention('InjectedTest')
+        this.incrementalsRepoUrl = project.objects.property(String).convention(JENKINS_INCREMENTALS_REPO)
     }
 
     /**
@@ -466,6 +469,10 @@ class JpiExtension implements JpiExtensionBridge {
     @Override
     ListProperty<PluginDeveloper> getPluginDevelopers() {
         pluginDevelopers
+    }
+
+    Property<String> getIncrementalsRepoUrl() {
+        incrementalsRepoUrl
     }
 
     /**

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
@@ -515,6 +515,10 @@ class JpiPlugin implements Plugin<Project>, PluginDependencyProvider {
                             url jpiExtension.repoUrl
                         }
                     }
+                    maven {
+                        name 'jenkinsIncrementals'
+                        url(jpiExtension.incrementalsRepoUrl.get() ?: jpiExtension.JENKINS_INCREMENTALS_REPO)
+                    }
                 }
 
                 JavaPluginExtension javaPluginExtension = project.extensions.getByType(JavaPluginExtension)

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/ConfigurePublishingIntegrationSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/ConfigurePublishingIntegrationSpec.groovy
@@ -147,7 +147,7 @@ class ConfigurePublishingIntegrationSpec extends IntegrationSpec {
     def 'should configure publishing repository for #status'(String status,
                                                              String version,
                                                              String declaration,
-                                                             String expected) {
+                                                             List<String> expected) {
         given:
         build << """
             jenkinsPlugin {
@@ -164,14 +164,14 @@ class ConfigurePublishingIntegrationSpec extends IntegrationSpec {
         def actual = deserializeReposFrom(result)
 
         then:
-        actual == [expected]
+        actual == expected
 
         where:
         status     | version        | declaration                  | expected
-        'snapshot' | '1.0-SNAPSHOT' | 'configurePublishing = true' | 'https://repo.jenkins-ci.org/snapshots'
-        'release'  | '1.0'          | 'configurePublishing = true' | 'https://repo.jenkins-ci.org/releases'
-        'snapshot' | '1.0-SNAPSHOT' | null                         | 'https://repo.jenkins-ci.org/snapshots'
-        'release'  | '1.0'          | null                         | 'https://repo.jenkins-ci.org/releases'
+        'snapshot' | '1.0-SNAPSHOT' | 'configurePublishing = true' | ['https://repo.jenkins-ci.org/incrementals', 'https://repo.jenkins-ci.org/snapshots']
+        'release'  | '1.0'          | 'configurePublishing = true' | ['https://repo.jenkins-ci.org/incrementals', 'https://repo.jenkins-ci.org/releases']
+        'snapshot' | '1.0-SNAPSHOT' | null                         | ['https://repo.jenkins-ci.org/incrementals', 'https://repo.jenkins-ci.org/snapshots']
+        'release'  | '1.0'          | null                         | ['https://repo.jenkins-ci.org/incrementals', 'https://repo.jenkins-ci.org/releases']
     }
 
     @Unroll
@@ -259,7 +259,7 @@ class ConfigurePublishingIntegrationSpec extends IntegrationSpec {
     }
 
     private static List<String> deserializeReposFrom(BuildResult result) {
-        new JsonSlurper().parseText(result.output)['repositories']*.uri
+        new JsonSlurper().parseText(result.output)['repositories']*.uri.toSorted()
     }
 
     private static Map<String, Map<String, Object>> deserializePublicationsFrom(BuildResult result) {

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiIntegrationSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiIntegrationSpec.groovy
@@ -624,4 +624,39 @@ class JpiIntegrationSpec extends IntegrationSpec {
         then:
         result.output.contains(expected)
     }
+
+    @Unroll
+    def 'setup publishing incrementals repo by extension (#url)'(String url, String expected) {
+        given:
+        build << """\
+            jenkinsPlugin {
+                jenkinsVersion = '${TestSupport.RECENT_JENKINS_VERSION}'
+                incrementalsRepoUrl = $url
+            }
+            version = '0.40.0-SNAPSHOT'
+
+            tasks.register('repos') {
+                doLast {
+                    publishing.repositories.each {
+                        println it.url
+                    }
+                }
+            }
+            """.stripIndent()
+
+        when:
+        def result = gradleRunner()
+            .withArguments('repos', '-q')
+            .build()
+
+        then:
+        result.output.contains(expected)
+
+        where:
+        url                            | expected
+        null                           | 'https://repo.jenkins-ci.org/incrementals'
+        "''"                           | 'https://repo.jenkins-ci.org/incrementals'
+        "'https://maven.example.org/'" | 'https://maven.example.org/'
+    }
+
 }


### PR DESCRIPTION
This fixes https://github.com/jenkinsci/gradle-jpi-plugin/issues/215.
It just adds a new Maven repository named `jenkinsIncrementals` with default url of `https://repo.jenkins-ci.org/incrementals`. The url can be tweaked with the extension:
```
jenkinsPlugin {
    incrementalsRepoUrl = '...'
}
```

Note that this does not enforce a generated version to publish to the incrementals repository. To do so see https://github.com/jenkinsci/gradle-jpi-plugin/pull/218

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
