### PR TITLE
Do not publish to incrementals by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,9 +327,10 @@ See [Configuration](#configuration) to customize the generation.
 
 ### Using Jenkins "incrementals" repository
 [JEP-305](https://github.com/jenkinsci/jep/tree/master/jep/305) specifies how to deploy incremental versions, the plugin defines the
-https://repo.jenkins-ci.org/incrementals/ repository and the `publish` task will also publish to this one.
-It's possible to specify a different repository,
-See [Configuration](#configuration) to customize the generation.
+https://repo.jenkins-ci.org/incrementals/ repository. The `publish` task will not publish to this one by default, instead one should call
+the `publish*PublicationToJenkinsIncrementalsRepository` task(s) separately (so `publishMavenJpiPublicationToJenkinsIncrementalsRepository` for the default publication)
+
+It's also possible to specify a different repository, see [Configuration](#configuration).
 
 ### Enabling quality checks
 To eventually publish reports to ci.jenkins.io, one can enable SpotBugs, Checkstyle or JaCoCo plugins:

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
@@ -69,6 +69,7 @@ import org.jenkinsci.gradle.plugins.jpi.verification.CheckOverlappingSourcesTask
 import org.jenkinsci.gradle.plugins.jpi.version.GenerateGitVersionTask
 
 import java.util.concurrent.Callable
+import java.util.stream.Collectors
 
 import static org.gradle.api.logging.LogLevel.INFO
 import static org.gradle.api.tasks.SourceSet.MAIN_SOURCE_SET_NAME
@@ -555,6 +556,13 @@ class JpiPlugin implements Plugin<Project>, PluginDependencyProvider {
                         name 'jenkinsIncrementals'
                         url(jpiExtension.incrementalsRepoUrl.get() ?: jpiExtension.JENKINS_INCREMENTALS_REPO)
                     }
+                }
+
+                project.tasks.named('publish').configure {
+                    def depTasks = it.dependsOn.stream()
+                        .filter { t -> !(t as String).contains('ToJenkinsIncrementalsRepository') }
+                        .collect(Collectors.toSet())
+                    it.dependsOn = depTasks
                 }
 
                 JavaPluginExtension javaPluginExtension = project.extensions.getByType(JavaPluginExtension)


### PR DESCRIPTION
Previous [PR](https://github.com/jenkinsci/gradle-jpi-plugin/pull/219) fixing https://github.com/jenkinsci/gradle-jpi-plugin/issues/215 added incrementals repository support by publishing to both regular and incrementals repository by default 
This PR basically removes the dependency of `publish` to `publishMavenJpiPublicationToJenkinsIncrementalsRepository` so instead one should call directly `publishMavenJpiPublicationToJenkinsIncrementalsRepository` to publish to incrementals.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

