### PR TITLE
Enable quality check plugins with functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,9 +336,9 @@ It's also possible to specify a different repository, see [Configuration](#confi
 To eventually publish reports to ci.jenkins.io, one can enable SpotBugs, Checkstyle or JaCoCo plugins:
 ```
 jenkinsPlugin {
-    spotBugsEnabled = true
-    checkstyleEnabled = true
-    jacocoEnabled = true
+    enableSpotBugs()
+    enableCheckstyle()
+    enableJacoco()
 }
 ```
 When enabled, plugins are configured with sensitive defaults: only xml reports, checkstyle rules default to sun-checks.xml... still the plugins can be configured as usual, see their corresponding docs.

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/CheckstylePluginSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/CheckstylePluginSpec.groovy
@@ -33,8 +33,8 @@ class CheckstylePluginSpec extends IntegrationSpec {
             .build()
 
         then:
-        result.task(':checkstyleMain').outcome == TaskOutcome.SKIPPED
-        result.task(':checkstyleTest').outcome == TaskOutcome.SKIPPED
+        result.task(':checkstyleMain') == null
+        result.task(':checkstyleTest') == null
     }
 
     def "should run checkstyle tasks with default sun-checks and generate only xml"() {
@@ -42,7 +42,7 @@ class CheckstylePluginSpec extends IntegrationSpec {
         build << """
             jenkinsPlugin {
                 jenkinsVersion = '${TestSupport.RECENT_JENKINS_VERSION}'
-                checkstyleEnabled = true
+                enableCheckstyle()
             }""".stripIndent()
 
         when:
@@ -61,7 +61,7 @@ class CheckstylePluginSpec extends IntegrationSpec {
         build << """
             jenkinsPlugin {
                 jenkinsVersion = '${TestSupport.RECENT_JENKINS_VERSION}'
-                checkstyleEnabled = true
+                enableCheckstyle()
             }
 
             checkstyle {

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JacocoPluginSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JacocoPluginSpec.groovy
@@ -37,7 +37,7 @@ class JacocoPluginSpec extends IntegrationSpec {
             .build()
 
         then:
-        result.task(':jacocoTestReport').outcome == TaskOutcome.SKIPPED
+        result.task(':jacocoTestReport') == null
     }
 
     def "should run jacoco task and generate only xml report"() {
@@ -45,7 +45,7 @@ class JacocoPluginSpec extends IntegrationSpec {
         build << """
             jenkinsPlugin {
                 jenkinsVersion = '${TestSupport.RECENT_JENKINS_VERSION}'
-                jacocoEnabled = true
+                enableJacoco()
             }""".stripIndent()
 
         when:
@@ -65,7 +65,7 @@ class JacocoPluginSpec extends IntegrationSpec {
         build << """
             jenkinsPlugin {
                 jenkinsVersion = '${TestSupport.RECENT_JENKINS_VERSION}'
-                jacocoEnabled = true
+                enableJacoco()
             }
 
             jacocoTestReport {

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/SpotBugsPluginSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/SpotBugsPluginSpec.groovy
@@ -36,8 +36,8 @@ class SpotBugsPluginSpec extends IntegrationSpec {
             .build()
 
         then:
-        result.task(':spotbugsMain').outcome == TaskOutcome.SKIPPED
-        result.task(':spotbugsTest').outcome == TaskOutcome.SKIPPED
+        result.task(':spotbugsMain') == null
+        result.task(':spotbugsTest') == null
     }
 
     @Requires({ gradle7AndAbove() })
@@ -46,7 +46,7 @@ class SpotBugsPluginSpec extends IntegrationSpec {
         build << """
             jenkinsPlugin {
                 jenkinsVersion = '${TestSupport.RECENT_JENKINS_VERSION}'
-                spotBugsEnabled = true
+                enableSpotBugs()
             }""".stripIndent()
 
         when:
@@ -67,7 +67,7 @@ class SpotBugsPluginSpec extends IntegrationSpec {
         build << """
             jenkinsPlugin {
                 jenkinsVersion = '${TestSupport.RECENT_JENKINS_VERSION}'
-                spotBugsEnabled = true
+                enableSpotBugs()
             }
             spotbugsMain {
                 reports {


### PR DESCRIPTION
This avoids applying the plugin(s) if not explicitly required by exposing functions instead of boolean flags.
See original discussion https://github.com/jenkinsci/gradle-jpi-plugin/pull/220#issuecomment-1466458399

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
