### PR TITLE
Add some utilities to support incrementals via Jenkins infra pipeline-library

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ jenkinsPlugin {
         allowDirty = true
         // Customize version format (default: %d.%s where %d is the commit depth, %s the abbreviated sha)
         versionFormat = 'rc-%d.%s'
+        // Sanitize the hash according to Jenkins requirements (default: false)  
+        sanitize = true 
         // Customize abbreviated sha length (default: 12)
         abbrevLength = 10
         // Customize git root (default: project directory)
@@ -310,26 +312,18 @@ tasks.named('generateJenkinsManifest').configure {
 
 ### Using Git based version
 [JEP-229](https://github.com/jenkinsci/jep/blob/master/jep/229/README.adoc#version-format) outlines requirements for creating sensible version numbers automatically.
-The plugin registers a `generateGitVersion` task that generates a Git based version in a text file. A bit of plumbing is required to use this version, for example:
+The plugin registers a `generateGitVersion` task that generates a Git based version in a text file. 
+This version scheme is typically used on ci.jenkins.io by first generating the version and then setting it when 
+building with `-Pversion=${versionFile.text}`. This works fine as long as no version is set in `build.gradle`.
 
-```
-tasks.named('generateGitVersion') {
-    doLast {
-        project.version = outputFile.get().getAsFile().text
-    }
-}
-
-tasks.named('jar') {
-    dependsOn(tasks.named('generateGitVersion'))
-}
-```
 See [Configuration](#configuration) to customize the generation.
 
 ### Using Jenkins "incrementals" repository
-[JEP-305](https://github.com/jenkinsci/jep/tree/master/jep/305) specifies how to deploy incremental versions, the plugin defines the
-https://repo.jenkins-ci.org/incrementals/ repository. The `publish` task will not publish to this one by default, instead one should call
-the `publish*PublicationToJenkinsIncrementalsRepository` task(s) separately (so `publishMavenJpiPublicationToJenkinsIncrementalsRepository` for the default publication)
+[JEP-305](https://github.com/jenkinsci/jep/tree/master/jep/305) specifies how to deploy incremental versions.
+This applies mainly for the ci.jenkins.io infrastructure, for Gradle the logic is defined in https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPluginWithGradle.groovy.
 
+For local builds, the plugin defines the https://repo.jenkins-ci.org/incrementals/ repository. The `publish` task will not publish to this one by default, instead one should call
+the `publish*PublicationToJenkinsIncrementalsRepository` task(s) separately (so `publishMavenJpiPublicationToJenkinsIncrementalsRepository` for the default publication)
 It's also possible to specify a different repository, see [Configuration](#configuration).
 
 ### Enabling quality checks

--- a/src/main/java/org/jenkinsci/gradle/plugins/jpi/GitVersionExtension.java
+++ b/src/main/java/org/jenkinsci/gradle/plugins/jpi/GitVersionExtension.java
@@ -2,7 +2,9 @@ package org.jenkinsci.gradle.plugins.jpi;
 
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.Optional;
 
 import javax.inject.Inject;
@@ -13,15 +15,24 @@ public abstract class GitVersionExtension {
     private static final String DEFAULT_VERSION_FORMAT = "%d.%s";
 
     @Inject
-    public GitVersionExtension(ProjectLayout layout) {
-        getVersionFormat().convention(DEFAULT_VERSION_FORMAT);
+    public GitVersionExtension(ProjectLayout layout, ProviderFactory providers) {
+        getVersionFormat().convention(
+                providers.gradleProperty("gitVersionFormat").orElse(DEFAULT_VERSION_FORMAT));
         getAbbrevLength().convention(DEFAULT_ABBREV_LENGTH);
         getAllowDirty().convention(false);
         getGitRoot().convention(layout.getProjectDirectory());
+        getSanitize().convention(providers.gradleProperty("gitVersionSanitize").map(p -> true).orElse(false));
+        getOutputFile().convention(
+                providers.gradleProperty("gitVersionFile")
+                        .map(p-> layout.getProjectDirectory().file(p))
+                        .orElse(layout.getBuildDirectory().file("generated/version/version.txt")));
     }
 
     @Optional
     public abstract Property<String> getVersionFormat();
+
+    @Optional
+    public abstract Property<Boolean> getSanitize();
 
     @Optional
     public abstract Property<Integer> getAbbrevLength();
@@ -31,4 +42,9 @@ public abstract class GitVersionExtension {
 
     @Optional
     public abstract DirectoryProperty getGitRoot();
+
+    @Optional
+    public abstract RegularFileProperty getOutputFile();
+
+
 }

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/version/GitVersionGeneratorSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/version/GitVersionGeneratorSpec.groovy
@@ -15,7 +15,7 @@ class GitVersionGeneratorSpec extends Specification {
         def gitRoot = generateGitRepo()
 
         when:
-        def version = new GitVersionGenerator(gitRoot, 12, '%d.%s', false).generate()
+        def version = new GitVersionGenerator(gitRoot, 12, '%d.%s', false, false).generate()
 
         then:
         version ==~ /3\.\w{12}/
@@ -26,7 +26,7 @@ class GitVersionGeneratorSpec extends Specification {
         def gitRoot = generateGitRepo()
 
         when:
-        def version = new GitVersionGenerator(gitRoot, 12, 'rc.%d-%s', false).generate()
+        def version = new GitVersionGenerator(gitRoot, 12, 'rc.%d-%s', false, false).generate()
 
         then:
         version ==~ /rc\.3-\w{12}/
@@ -38,7 +38,7 @@ class GitVersionGeneratorSpec extends Specification {
         def gitRoot = generateGitRepo()
 
         when:
-        def version = new GitVersionGenerator(gitRoot, 2, '%d.%s', false).generate()
+        def version = new GitVersionGenerator(gitRoot, 2, '%d.%s', false, false).generate()
 
         then:
         version ==~ /3\.\w{2}/
@@ -50,7 +50,7 @@ class GitVersionGeneratorSpec extends Specification {
         Files.createFile(gitRoot.resolve('untracked')).text = 'bar'
 
         when:
-        new GitVersionGenerator(gitRoot, 12, '%d.%s', false).generate()
+        new GitVersionGenerator(gitRoot, 12, '%d.%s', false, false).generate()
 
         then:
         def exception = thrown(RuntimeException)
@@ -63,7 +63,7 @@ class GitVersionGeneratorSpec extends Specification {
         gitRoot.resolve('somefile').text = 'foo!'
 
         when:
-        new GitVersionGenerator(gitRoot, 12, '%d.%s', false).generate()
+        new GitVersionGenerator(gitRoot, 12, '%d.%s', false, false).generate()
 
         then:
         def exception = thrown(RuntimeException)
@@ -77,7 +77,7 @@ class GitVersionGeneratorSpec extends Specification {
         gitRoot.resolve('somefile').text = 'foo!'
 
         when:
-        new GitVersionGenerator(gitRoot, 12, '%d.%s', false).generate()
+        new GitVersionGenerator(gitRoot, 12, '%d.%s', false, false).generate()
 
         then:
         def exception = thrown(RuntimeException)
@@ -93,10 +93,29 @@ class GitVersionGeneratorSpec extends Specification {
         Files.createFile(gitRoot.resolve('untracked')).text = 'bar'
 
         when:
-        def version = new GitVersionGenerator(gitRoot, 12, '%d.%s', true).generate()
+        def version = new GitVersionGenerator(gitRoot, 12, '%d.%s', true, false).generate()
 
         then:
         version ==~ /3\.\w{12}/
+    }
+
+    def 'can sanitize version from git'() {
+        given:
+        def gitRoot = generateGitRepo()
+
+        when:
+        def version = new GitVersionGenerator(gitRoot, 12, 'ab-%d.%s', true, true).generate()
+
+        then:
+        !(version ==~ /ab-([ab][^_])/)
+    }
+
+    def 'sanitize'() {
+        when:
+        def sanitized = GitVersionGenerator.sanitize('9a80981b849e')
+
+        then:
+        sanitized == '9a_80981b_849e'
     }
 
     Path generateGitRepo() {


### PR DESCRIPTION
This is a follow up of https://github.com/jenkinsci/gradle-jpi-plugin/issues/215 that is not sufficient to publish incrementals when running on ci.jenkins.io, since it would require passing credentials.
Instead some plumbing is required in https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPluginWithGradle.groovy like it's done on the Maven side:
* Running a build to generate the version file containing the sanitize version (`a`, `b` not allowed)
* Running the build overriding the version with `-Pversion` and archiving the resulting artifacts
* Call `infra.maybePublishIncrementals()` that should eventually caused an external service to pull the artifacts and publish them on Artifactory

This PR adds the necessary hooks to achieve this:
* one additional option is available to sanitize the version according to Jenkins requirement
* version format and version file path can be customized via Gradle properties

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue