### PR TITLE
Add again some utilities to support incrementals via Jenkins infra pipeline-library 

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ jenkinsPlugin {
 
     // plugin URL on GitHub, optional
     gitHubUrl = 'https://github.com/jenkinsci/some-plugin'
+  
+    // scm tag eventually set in the published pom, optional
+    scmTag = 'v1.0.0'
 
     // use the plugin class loader before the core class loader, defaults to false
     pluginFirstClassLoader = true
@@ -312,9 +315,9 @@ tasks.named('generateJenkinsManifest').configure {
 
 ### Using Git based version
 [JEP-229](https://github.com/jenkinsci/jep/blob/master/jep/229/README.adoc#version-format) outlines requirements for creating sensible version numbers automatically.
-The plugin registers a `generateGitVersion` task that generates a Git based version in a text file. 
+The plugin registers a `generateGitVersion` task that generates a Git based version in a text file (1st line an abbreviated hash, 2nd line the full hash). 
 This version scheme is typically used on ci.jenkins.io by first generating the version and then setting it when 
-building with `-Pversion=${versionFile.text}`. This works fine as long as no version is set in `build.gradle`.
+building with `-Pversion=${versionFile.readLines()[0]}`. This works fine as long as no version is set in `build.gradle`.
 
 See [Configuration](#configuration) to customize the generation.
 

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtension.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtension.groovy
@@ -108,7 +108,7 @@ class JpiExtension implements JpiExtensionBridge {
         this.gitVersion = project.objects.newInstance(GitVersionExtension)
         this.incrementalsRepoUrl = project.objects.property(String).convention(JENKINS_INCREMENTALS_REPO)
         this.scmTag = project.objects.property(String)
-                .convention(project.providers.gradleProperty('scmTag').forUseAtConfigurationTime())
+                .convention(project.providers.gradleProperty('scmTag'))
     }
 
     /**

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtension.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtension.groovy
@@ -81,6 +81,7 @@ class JpiExtension implements JpiExtensionBridge {
     private final ListProperty<PluginDeveloper> pluginDevelopers
     private final Property<String> incrementalsRepoUrl
     private final GitVersionExtension gitVersion
+    private final Property<String> scmTag
 
     @SuppressWarnings('UnnecessarySetter')
     JpiExtension(Project project) {
@@ -106,6 +107,8 @@ class JpiExtension implements JpiExtensionBridge {
         this.generatedTestClassName = project.objects.property(String).convention('InjectedTest')
         this.gitVersion = project.objects.newInstance(GitVersionExtension)
         this.incrementalsRepoUrl = project.objects.property(String).convention(JENKINS_INCREMENTALS_REPO)
+        this.scmTag = project.objects.property(String)
+                .convention(project.providers.gradleProperty('scmTag').forUseAtConfigurationTime())
     }
 
     /**
@@ -492,6 +495,10 @@ class JpiExtension implements JpiExtensionBridge {
 
     Property<String> getIncrementalsRepoUrl() {
         incrementalsRepoUrl
+    }
+
+    Property<String> getScmTag() {
+        scmTag
     }
 
     void enableCheckstyle() {

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPomCustomizer.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPomCustomizer.groovy
@@ -44,6 +44,11 @@ class JpiPomCustomizer {
         pom.url.set(jpiExtension.url)
         pom.description.set(project.description)
         def github = jpiExtension.gitHubUrl
+        if (jpiExtension.scmTag.isPresent()) {
+            pom.scm { MavenPomScm s ->
+                s.tag.set(jpiExtension.scmTag)
+            }
+        }
         if (github) {
             pom.scm { MavenPomScm s ->
                 s.url.set(github)

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPomCustomizer.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPomCustomizer.groovy
@@ -44,17 +44,13 @@ class JpiPomCustomizer {
         pom.url.set(jpiExtension.url)
         pom.description.set(project.description)
         def github = jpiExtension.gitHubUrl
-        if (jpiExtension.scmTag.isPresent()) {
-            pom.scm { MavenPomScm s ->
-                s.tag.set(jpiExtension.scmTag)
-            }
-        }
         if (github) {
             pom.scm { MavenPomScm s ->
                 s.url.set(github)
                 if (github =~ /^https:\/\/github\.com/) {
                     s.connection.set(github.replaceFirst(~/https:/, 'scm:git:git:') + '.git')
                 }
+                s.tag.set(jpiExtension.scmTag)
             }
         }
         if (!jpiExtension.licenses.isEmpty()) {

--- a/src/main/java/org/jenkinsci/gradle/plugins/jpi/GitVersionExtension.java
+++ b/src/main/java/org/jenkinsci/gradle/plugins/jpi/GitVersionExtension.java
@@ -26,10 +26,14 @@ public abstract class GitVersionExtension {
                 providers.gradleProperty("gitVersionFile")
                         .map(p-> layout.getProjectDirectory().file(p))
                         .orElse(layout.getBuildDirectory().file("generated/version/version.txt")));
+        getVersionPrefix().convention("");
     }
 
     @Optional
     public abstract Property<String> getVersionFormat();
+
+    @Optional
+    public abstract Property<String> getVersionPrefix();
 
     @Optional
     public abstract Property<Boolean> getSanitize();

--- a/src/main/java/org/jenkinsci/gradle/plugins/jpi/version/GenerateGitVersionTask.java
+++ b/src/main/java/org/jenkinsci/gradle/plugins/jpi/version/GenerateGitVersionTask.java
@@ -56,6 +56,7 @@ public abstract class GenerateGitVersionTask extends DefaultTask {
         queue.submit(GenerateGitVersion.class, p -> {
             p.getGitRoot().set(gitVersionExtension.getGitRoot());
             p.getAbbrevLength().set(gitVersionExtension.getAbbrevLength());
+            p.getVersionPrefix().set(gitVersionExtension.getVersionPrefix());
             p.getVersionFormat().set(gitVersionExtension.getVersionFormat());
             p.getSanitize().set(gitVersionExtension.getSanitize());
             p.getAllowDirty().set(gitVersionExtension.getAllowDirty());
@@ -64,7 +65,10 @@ public abstract class GenerateGitVersionTask extends DefaultTask {
     }
 
     public interface GenerateGitVersionParameters extends WorkParameters {
+
         DirectoryProperty getGitRoot();
+
+        Property<String> getVersionPrefix();
 
         Property<String> getVersionFormat();
 
@@ -86,6 +90,7 @@ public abstract class GenerateGitVersionTask extends DefaultTask {
                 GitVersionGenerator.GitVersion version = new GitVersionGenerator(
                         p.getGitRoot().get().getAsFile().toPath(),
                         p.getAbbrevLength().get(),
+                        p.getVersionPrefix().get(),
                         p.getVersionFormat().get(),
                         p.getAllowDirty().get(),
                         p.getSanitize().get()).generate();

--- a/src/main/java/org/jenkinsci/gradle/plugins/jpi/version/GenerateGitVersionTask.java
+++ b/src/main/java/org/jenkinsci/gradle/plugins/jpi/version/GenerateGitVersionTask.java
@@ -83,13 +83,13 @@ public abstract class GenerateGitVersionTask extends DefaultTask {
             GenerateGitVersionParameters p = getParameters();
             Path outputFile = p.getOutputFile().get().getAsFile().toPath();
             try {
-                String version = new GitVersionGenerator(
+                GitVersionGenerator.GitVersion version = new GitVersionGenerator(
                         p.getGitRoot().get().getAsFile().toPath(),
                         p.getAbbrevLength().get(),
                         p.getVersionFormat().get(),
                         p.getAllowDirty().get(),
                         p.getSanitize().get()).generate();
-                Files.write(outputFile, version.getBytes(StandardCharsets.UTF_8));
+                Files.write(outputFile, version.toString().getBytes(StandardCharsets.UTF_8));
             } catch (IOException e) {
                 throw new RuntimeException("Fail to write version file at " + outputFile, e);
             }

--- a/src/main/java/org/jenkinsci/gradle/plugins/jpi/version/GitVersionGenerator.java
+++ b/src/main/java/org/jenkinsci/gradle/plugins/jpi/version/GitVersionGenerator.java
@@ -14,15 +14,17 @@ import java.util.stream.StreamSupport;
 
 public class GitVersionGenerator {
     private final int abbrevLength;
+    private final String versionPrefix;
     private final String versionFormat;
     private final boolean sanitize;
     private final boolean allowDirty;
     private final Path gitRoot;
 
-    public GitVersionGenerator(Path gitRoot, int abbrevLength, String versionFormat, boolean allowDirty, boolean sanitize) {
+    public GitVersionGenerator(Path gitRoot, int abbrevLength, String versionPrefix, String versionFormat, boolean allowDirty, boolean sanitize) {
         this.gitRoot = gitRoot;
         // TODO abbrevLength should be 2 minimum
         this.abbrevLength = abbrevLength;
+        this.versionPrefix = versionPrefix;
         this.versionFormat = versionFormat;
         this.sanitize = sanitize;
         this.allowDirty = allowDirty;
@@ -43,7 +45,7 @@ public class GitVersionGenerator {
                 if (sanitize) {
                     abbrevHash = sanitize(abbrevHash);
                 }
-                return new GitVersion(head.getName(), String.format(versionFormat, headDepth, abbrevHash));
+                return new GitVersion(head.getName(), versionPrefix + String.format(versionFormat, headDepth, abbrevHash));
             }
         } catch (GitAPIException | IOException e) {
             throw new RuntimeException(e);

--- a/src/main/java/org/jenkinsci/gradle/plugins/jpi/version/GitVersionGenerator.java
+++ b/src/main/java/org/jenkinsci/gradle/plugins/jpi/version/GitVersionGenerator.java
@@ -28,7 +28,7 @@ public class GitVersionGenerator {
         this.allowDirty = allowDirty;
     }
 
-    public String generate() {
+    public GitVersion generate() {
         try (Git git = Git.open(gitRoot.toFile())) {
             Repository repo = git.getRepository();
             Status status = git.status().call();
@@ -43,7 +43,7 @@ public class GitVersionGenerator {
                 if (sanitize) {
                     abbrevHash = sanitize(abbrevHash);
                 }
-                return String.format(versionFormat, headDepth, abbrevHash);
+                return new GitVersion(head.getName(), String.format(versionFormat, headDepth, abbrevHash));
             }
         } catch (GitAPIException | IOException e) {
             throw new RuntimeException(e);
@@ -74,4 +74,28 @@ public class GitVersionGenerator {
             return StreamSupport.stream(walk.spliterator(), false).count();
         }
     }
+
+    static class GitVersion {
+        private final String fullHash;
+        private final String abbreviatedHash;
+
+        public GitVersion(String fullHash, String abbreviatedHash) {
+            this.fullHash = fullHash;
+            this.abbreviatedHash = abbreviatedHash;
+        }
+
+        @Override
+        public String toString() {
+            return abbreviatedHash + "\n" + fullHash;
+        }
+
+        public String getAbbreviatedHash() {
+            return abbreviatedHash;
+        }
+
+        public String getFullHash() {
+            return fullHash;
+        }
+    }
+
 }

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPomCustomizerIntegrationSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPomCustomizerIntegrationSpec.groovy
@@ -93,6 +93,7 @@ class JpiPomCustomizerIntegrationSpec extends IntegrationSpec {
                 jenkinsVersion = '${TestSupport.RECENT_JENKINS_VERSION}'
                 url = 'https://lorem-ipsum.org'
                 gitHubUrl = 'https://github.com/lorem/ipsum'
+                scmTag = 'my-tag'
                 developers {
                     developer {
                         id 'abayer'

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/version/GenerateGitVersionTaskSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/version/GenerateGitVersionTaskSpec.groovy
@@ -8,6 +8,8 @@ import org.jenkinsci.gradle.plugins.jpi.TestSupport
 
 import java.nio.file.Files
 
+import static org.jenkinsci.gradle.plugins.jpi.version.Util.isGitHash
+
 class GenerateGitVersionTaskSpec extends IntegrationSpec {
     private final String projectName = TestDataGenerator.generateName()
     private static final String GROUP_NAME = 'jpitest'
@@ -51,7 +53,8 @@ class GenerateGitVersionTaskSpec extends IntegrationSpec {
             .build()
 
         then:
-        inProjectDir('build/generated/version/version.txt').text ==~ /1\.\w{12}/
+        inProjectDir('build/generated/version/version.txt').readLines()[0] ==~ /1\.\w{12}/
+        isGitHash(inProjectDir('build/generated/version/version.txt').readLines()[1])
     }
 
     def 'should fail generate on non git repository'() {
@@ -98,7 +101,8 @@ class GenerateGitVersionTaskSpec extends IntegrationSpec {
             .build()
 
         then:
-        inProjectDir('build/generated/version/version.txt').text ==~ /1\.\w{12}/
+        inProjectDir('build/generated/version/version.txt').readLines()[0] ==~ /1\.\w{12}/
+        isGitHash(inProjectDir('build/generated/version/version.txt').readLines()[1])
     }
 
     def 'should generate with custom version format'() {
@@ -117,7 +121,8 @@ class GenerateGitVersionTaskSpec extends IntegrationSpec {
             .build()
 
         then:
-        inProjectDir('build/generated/version/version.txt').text ==~ /rc-1\.\w{10}/
+        inProjectDir('build/generated/version/version.txt').readLines()[0] ==~ /rc-1\.\w{10}/
+        isGitHash(inProjectDir('build/generated/version/version.txt').readLines()[1])
     }
 
     def 'should generate with custom version format from gradle property'() {
@@ -131,7 +136,8 @@ class GenerateGitVersionTaskSpec extends IntegrationSpec {
             .build()
 
         then:
-        inProjectDir('build/generated/version/version.txt').text ==~ /rc-1\.\w{12}/
+        inProjectDir('build/generated/version/version.txt').readLines()[0] ==~ /rc-1\.\w{12}/
+        isGitHash(inProjectDir('build/generated/version/version.txt').readLines()[1])
     }
 
     def 'should generate with custom git root'() {
@@ -150,7 +156,8 @@ class GenerateGitVersionTaskSpec extends IntegrationSpec {
             .build()
 
         then:
-        inProjectDir('build/generated/version/version.txt').text ==~ /1\.\w{12}/
+        inProjectDir('build/generated/version/version.txt').readLines()[0] ==~ /1\.\w{12}/
+        isGitHash(inProjectDir('build/generated/version/version.txt').readLines()[1])
     }
 
     def 'should set custom version file'() {
@@ -169,7 +176,8 @@ class GenerateGitVersionTaskSpec extends IntegrationSpec {
                 .build()
 
         then:
-        customVersionFile.text ==~ /1\.\w{12}/
+        customVersionFile.readLines()[0] ==~ /1\.\w{12}/
+        isGitHash(customVersionFile.readLines()[1])
     }
 
     def 'should set custom version file from gradle property'() {
@@ -184,7 +192,8 @@ class GenerateGitVersionTaskSpec extends IntegrationSpec {
                 .build()
 
         then:
-        customVersionFile.text ==~ /1\.\w{12}/
+        customVersionFile.readLines()[0] ==~ /1\.\w{12}/
+        isGitHash(customVersionFile.readLines()[1])
     }
 
     def 'should generate incrementals publication according to jenkins infra expectations'() {
@@ -199,14 +208,16 @@ class GenerateGitVersionTaskSpec extends IntegrationSpec {
                 .withArguments('clean', 'generateGitVersion', "-PgitVersionFile=${customVersionFile}")
                 .build()
 
-        def version = customVersionFile.toFile().text
+        def version = customVersionFile.readLines()[0]
+        def tag = customVersionFile.readLines()[1]
         // Note that overriding the version with `-Pversion` works only if the version is not set in the build.gradle
         gradleRunner()
-                .withArguments('build', 'publishToMavenLocal', "-Pversion=${version}", "-Dmaven.repo.local=${customM2}")
+                .withArguments('build', 'publishToMavenLocal', "-Pversion=${version}", "-Dmaven.repo.local=${customM2}", "-PscmTag=${tag}")
                 .build()
 
         then:
-        customVersionFile.text ==~ /1\.\w{12}/
+        customVersionFile.readLines()[0] ==~ /1\.\w{12}/
+        customVersionFile.readLines()[1] ==~ /\w{40}/
         def prefix = "${projectName}-${version}"
         customM2.resolve("${GROUP_NAME}/${projectName}/${version}").toFile().list() as Set == [
             "${prefix}-javadoc.jar",
@@ -216,6 +227,7 @@ class GenerateGitVersionTaskSpec extends IntegrationSpec {
             "${prefix}.module",
             "${prefix}.pom",
         ] as Set
+        customM2.resolve("${GROUP_NAME}/${projectName}/${version}/${prefix}.pom").text =~ /<tag>\w{40}<\/tag>/
     }
 
     def 'should be able to pass sanitize flag'() {

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/version/GenerateGitVersionTaskSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/version/GenerateGitVersionTaskSpec.groovy
@@ -220,6 +220,7 @@ class GenerateGitVersionTaskSpec extends IntegrationSpec {
         def customM2 = Files.createTempDirectory('custom-m2')
         given:
         build.text = customBuildFile('''
+            gitHubUrl = 'https://github.com/foo'
             gitVersion {
                 versionPrefix = version
             }

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/version/GitVersionGeneratorSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/version/GitVersionGeneratorSpec.groovy
@@ -8,6 +8,8 @@ import spock.lang.Specification
 import java.nio.file.Files
 import java.nio.file.Path
 
+import static org.jenkinsci.gradle.plugins.jpi.version.Util.isGitHash
+
 class GitVersionGeneratorSpec extends Specification {
 
     def 'generate version from git abbreviated hash'() {
@@ -18,7 +20,8 @@ class GitVersionGeneratorSpec extends Specification {
         def version = new GitVersionGenerator(gitRoot, 12, '%d.%s', false, false).generate()
 
         then:
-        version ==~ /3\.\w{12}/
+        version.abbreviatedHash ==~ /3\.\w{12}/
+        isGitHash(version.fullHash)
     }
 
     def 'generate version from git abbreviated hash with a custom format'() {
@@ -29,7 +32,8 @@ class GitVersionGeneratorSpec extends Specification {
         def version = new GitVersionGenerator(gitRoot, 12, 'rc.%d-%s', false, false).generate()
 
         then:
-        version ==~ /rc\.3-\w{12}/
+        version.abbreviatedHash ==~ /rc\.3-\w{12}/
+        isGitHash(version.fullHash)
     }
 
     @Ignore('TODO: generate git repo with collision')
@@ -41,7 +45,7 @@ class GitVersionGeneratorSpec extends Specification {
         def version = new GitVersionGenerator(gitRoot, 2, '%d.%s', false, false).generate()
 
         then:
-        version ==~ /3\.\w{2}/
+        version.abbreviatedHash ==~ /3\.\w{2}/
     }
 
     def 'cannot generate version from git because of untracked files'() {
@@ -96,7 +100,8 @@ class GitVersionGeneratorSpec extends Specification {
         def version = new GitVersionGenerator(gitRoot, 12, '%d.%s', true, false).generate()
 
         then:
-        version ==~ /3\.\w{12}/
+        version.abbreviatedHash ==~ /3\.\w{12}/
+        isGitHash(version.fullHash)
     }
 
     def 'can sanitize version from git'() {

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/version/GitVersionGeneratorSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/version/GitVersionGeneratorSpec.groovy
@@ -17,7 +17,7 @@ class GitVersionGeneratorSpec extends Specification {
         def gitRoot = generateGitRepo()
 
         when:
-        def version = new GitVersionGenerator(gitRoot, 12, '%d.%s', false, false).generate()
+        def version = new GitVersionGenerator(gitRoot, 12, '', '%d.%s', false, false).generate()
 
         then:
         version.abbreviatedHash ==~ /3\.\w{12}/
@@ -29,7 +29,7 @@ class GitVersionGeneratorSpec extends Specification {
         def gitRoot = generateGitRepo()
 
         when:
-        def version = new GitVersionGenerator(gitRoot, 12, 'rc.%d-%s', false, false).generate()
+        def version = new GitVersionGenerator(gitRoot, 12, '', 'rc.%d-%s', false, false).generate()
 
         then:
         version.abbreviatedHash ==~ /rc\.3-\w{12}/
@@ -42,7 +42,7 @@ class GitVersionGeneratorSpec extends Specification {
         def gitRoot = generateGitRepo()
 
         when:
-        def version = new GitVersionGenerator(gitRoot, 2, '%d.%s', false, false).generate()
+        def version = new GitVersionGenerator(gitRoot, 2, '', '%d.%s', false, false).generate()
 
         then:
         version.abbreviatedHash ==~ /3\.\w{2}/
@@ -54,7 +54,7 @@ class GitVersionGeneratorSpec extends Specification {
         Files.createFile(gitRoot.resolve('untracked')).text = 'bar'
 
         when:
-        new GitVersionGenerator(gitRoot, 12, '%d.%s', false, false).generate()
+        new GitVersionGenerator(gitRoot, 12, '', '%d.%s', false, false).generate()
 
         then:
         def exception = thrown(RuntimeException)
@@ -67,7 +67,7 @@ class GitVersionGeneratorSpec extends Specification {
         gitRoot.resolve('somefile').text = 'foo!'
 
         when:
-        new GitVersionGenerator(gitRoot, 12, '%d.%s', false, false).generate()
+        new GitVersionGenerator(gitRoot, 12, '', '%d.%s', false, false).generate()
 
         then:
         def exception = thrown(RuntimeException)
@@ -81,7 +81,7 @@ class GitVersionGeneratorSpec extends Specification {
         gitRoot.resolve('somefile').text = 'foo!'
 
         when:
-        new GitVersionGenerator(gitRoot, 12, '%d.%s', false, false).generate()
+        new GitVersionGenerator(gitRoot, 12, '', '%d.%s', false, false).generate()
 
         then:
         def exception = thrown(RuntimeException)
@@ -97,7 +97,7 @@ class GitVersionGeneratorSpec extends Specification {
         Files.createFile(gitRoot.resolve('untracked')).text = 'bar'
 
         when:
-        def version = new GitVersionGenerator(gitRoot, 12, '%d.%s', true, false).generate()
+        def version = new GitVersionGenerator(gitRoot, 12, '', '%d.%s', true, false).generate()
 
         then:
         version.abbreviatedHash ==~ /3\.\w{12}/
@@ -109,7 +109,7 @@ class GitVersionGeneratorSpec extends Specification {
         def gitRoot = generateGitRepo()
 
         when:
-        def version = new GitVersionGenerator(gitRoot, 12, 'ab-%d.%s', true, true).generate()
+        def version = new GitVersionGenerator(gitRoot, 12, '', 'ab-%d.%s', true, true).generate()
 
         then:
         !(version ==~ /ab-([ab][^_])/)

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/version/Util.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/version/Util.groovy
@@ -1,0 +1,13 @@
+package org.jenkinsci.gradle.plugins.jpi.version
+
+import java.util.regex.Pattern
+
+class Util {
+
+    static final Pattern GIT_HASH = ~/[a-f0-9]{40}/
+
+    static boolean isGitHash(String version) {
+        GIT_HASH.matcher(version).matches()
+    }
+
+}

--- a/src/test/resources/org/jenkinsci/gradle/plugins/jpi/complex-pom.xml
+++ b/src/test/resources/org/jenkinsci/gradle/plugins/jpi/complex-pom.xml
@@ -27,6 +27,7 @@
     </developers>
     <scm>
         <connection>scm:git:git://github.com/lorem/ipsum.git</connection>
+        <tag>my-tag</tag>
         <url>https://github.com/lorem/ipsum</url>
     </scm>
     <repositories>


### PR DESCRIPTION
This is another follow up of https://github.com/jenkinsci/gradle-jpi-plugin/issues/215 that is not sufficient to publish incrementals when running on ci.jenkins.io (hopefully the last one ?).
* It requires first to have `<tag>...</tag>` set in the published pom with the full git hash. 
This PR changes the `generateGitVersionTask` to also set the full Git hash in the `version.txt` in addition to the formatted one. It also adds a`scmTag` property to the `JpiExtension` that can be set via a Gradle property. Eventually the https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPluginWithGradle.groovy will do something like 
`-PscmTag=${versionFile.readLines()[1]}`
* Optionally users should be able to add a version prefix to the generate version, like a "major.minor" for example, ending up with for example `1.0-rc1.abcdef` or a real world example: https://ci.jenkins.io/job/Plugins/job/git-plugin/job/master/
This PR adds an optional `versionPrefix` to the `GitVersionExtension`

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
