### PR TITLE
Support remote execution by removing `jth.jenkins-war.path`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,18 +17,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up JDK 11
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: "11"
         distribution: "temurin"
-    - name: Cache Dependencies
-      uses: actions/cache@v3
-      with:
-        path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
-        restore-keys: ${{ runner.os }}-gradle 
+        cache: "gradle"
     - name: Build
       run: ./gradlew clean build testGradle8.4
     - name: Archive Codenarc Report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,15 +26,15 @@ jobs:
         cache: "gradle"
     - name: Build
       run: ./gradlew clean build testGradle8.4
-    - name: Archive Codenarc Report
-      uses: actions/upload-artifact@v3
-      if: ${{ always() }}
+    - name: Archive Codenarc Report on Failure
+      uses: actions/upload-artifact@v4
+      if: ${{ failure() }}
       with:
         name: codenarc-results
         path: build/reports/codenarc
-    - name: Archive Test Results
+    - name: Archive Test Results on Failure
       uses: actions/upload-artifact@v4
-      if: ${{ always() }}
+      if: ${{ failure() }}
       with:
-        name: test-results
+        name: ${{ matrix.os }}-ci-test-results
         path: build/reports/tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         name: codenarc-results
         path: build/reports/codenarc
     - name: Archive Test Results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() }}
       with:
         name: test-results

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -28,9 +28,9 @@ jobs:
         cache: "gradle"
     - name: Test ${{ matrix.gradle_version }}
       run: ./gradlew testGradle${{ matrix.gradle_version }}
-    - name: Archive Test Results
+    - name: Archive Test Results on Failure
       uses: actions/upload-artifact@v4
-      if: ${{ always() }}
+      if: ${{ failure() }}
       with:
-        name: test-results
+        name: ${{ matrix.os }}-${{ matrix.gradle_version }}-test-results
         path: build/reports/tests

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -19,18 +19,13 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         gradle_version: ["7.1.1", "8.0.2"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up JDK 11
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: "11"
         distribution: "temurin"
-    - name: Cache Dependencies
-      uses: actions/cache@v3
-      with:
-        path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
-        restore-keys: ${{ runner.os }}-gradle 
+        cache: "gradle"
     - name: Test ${{ matrix.gradle_version }}
       run: ./gradlew testGradle${{ matrix.gradle_version }}
     - name: Archive Test Results

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Test ${{ matrix.gradle_version }}
       run: ./gradlew testGradle${{ matrix.gradle_version }}
     - name: Archive Test Results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() }}
       with:
         name: test-results

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 import okio.buffer
 import okio.sink
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+import org.gradle.api.tasks.testing.logging.TestLogEvent
 import java.nio.file.StandardOpenOption
 
 buildscript {
@@ -149,9 +150,13 @@ tasks.addRule("Pattern: testGradle<ID>") {
     }
 }
 
+val isCi = providers.environmentVariable("CI")
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
     testLogging {
+        if (isCi.map { it.toBoolean() }.getOrElse(false)) {
+            events(TestLogEvent.FAILED, TestLogEvent.PASSED, TestLogEvent.SKIPPED)
+        }
         exceptionFormat = FULL
     }
 }

--- a/src/main/java/org/jenkinsci/gradle/plugins/jpi/internal/DependencyLookup.java
+++ b/src/main/java/org/jenkinsci/gradle/plugins/jpi/internal/DependencyLookup.java
@@ -45,7 +45,7 @@ public class DependencyLookup {
                 deps.add(testHarness);
                 return deps;
             case "declaredJenkinsWar":
-                deps.add(new MavenDependency("org.jenkins-ci.main:jenkins-war:" + jenkinsVersion + "@war"));
+                deps.add(new MavenDependency("org.jenkins-ci.main:jenkins-war:" + jenkinsVersion));
                 return deps;
         }
         return deps;

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPublishingAndConsumptionTest.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPublishingAndConsumptionTest.groovy
@@ -177,6 +177,7 @@ class JpiPublishingAndConsumptionTest extends IntegrationSpec {
                 'display-url-api-0.2.hpi',
                 'junit-1.3.hpi',
                 'script-security-1.13.hpi',
+                'jenkins-war-1.580.1.war',
         ] as Set
     }
 
@@ -219,7 +220,9 @@ class JpiPublishingAndConsumptionTest extends IntegrationSpec {
         resolveConsumer('jenkinsRuntime') == [ 'producer-1.0.hpi', 'ant-1.2.hpi' ] as Set
         resolveConsumer('jenkinsTestRuntime') == [
                 'producer-1.0.hpi',
-                'ant-1.2.hpi' ] as Set
+                'ant-1.2.hpi',
+                'jenkins-war-1.580.1.war',
+        ] as Set
 
         when:
         consumerBuild << """
@@ -246,7 +249,9 @@ class JpiPublishingAndConsumptionTest extends IntegrationSpec {
         resolveConsumer('jenkinsTestRuntime') ==
                 [ 'producer-1.0.hpi',
                   'ant-1.2.hpi',
-                  'credentials-1.9.4.hpi' ] as Set
+                  'credentials-1.9.4.hpi',
+                  'jenkins-war-1.580.1.war',
+                ] as Set
 
         manifestEntry('consumer', 'Plugin-Dependencies') ==
                 'producer:1.0,credentials:1.9.4'
@@ -281,7 +286,7 @@ class JpiPublishingAndConsumptionTest extends IntegrationSpec {
         resolveConsumer('compile') == JENKINS_CORE_DEPS + [ 'producer-1.0.jar' ] as Set
         resolveConsumer('runtime') == [ 'producer-1.0.jar' ] as Set
         resolveConsumer('jenkinsRuntime') == [ 'producer-1.0.hpi' ] as Set
-        resolveConsumer('jenkinsTestRuntime') == [ 'producer-1.0.hpi' ] as Set
+        resolveConsumer('jenkinsTestRuntime') == [ 'producer-1.0.hpi', 'jenkins-war-1.580.1.war' ] as Set
     }
 
     private void publishProducer() {

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPublishingAndConsumptionTest.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPublishingAndConsumptionTest.groovy
@@ -85,7 +85,7 @@ class JpiPublishingAndConsumptionTest extends IntegrationSpec {
         when:
         consumerBuild << """
             jenkinsPlugin {
-                jenkinsVersion = '1.580.1'
+                jenkinsVersion = '${TestSupport.RECENT_JENKINS_VERSION}'
             }
             dependencies {
                 implementation 'org:producer:1.0'
@@ -99,7 +99,6 @@ class JpiPublishingAndConsumptionTest extends IntegrationSpec {
                 'commons-lang3-3.9.jar',
                 'jcip-annotations-1.0.jar',
                 'findbugs-annotations-1.3.9-1.jar',
-                'jsr305-2.0.1.jar',
         ] as Set
 
         resolveConsumer('runtime') == [
@@ -177,7 +176,7 @@ class JpiPublishingAndConsumptionTest extends IntegrationSpec {
                 'display-url-api-0.2.hpi',
                 'junit-1.3.hpi',
                 'script-security-1.13.hpi',
-                'jenkins-war-1.580.1.war',
+                'jenkins-war-2.401.3.war',
         ] as Set
     }
 
@@ -185,7 +184,7 @@ class JpiPublishingAndConsumptionTest extends IntegrationSpec {
         given:
         producerBuild << """\
             jenkinsPlugin {
-                jenkinsVersion = '1.580.1'
+                jenkinsVersion = '${TestSupport.RECENT_JENKINS_VERSION}'
             }
             java {
                 registerFeature('credentials') {
@@ -204,7 +203,7 @@ class JpiPublishingAndConsumptionTest extends IntegrationSpec {
         when:
         consumerBuild << """
             jenkinsPlugin {
-                jenkinsVersion = '1.580.1'
+                jenkinsVersion = '${TestSupport.RECENT_JENKINS_VERSION}'
             }
             dependencies {
                 implementation 'org:producer:1.0'
@@ -221,7 +220,7 @@ class JpiPublishingAndConsumptionTest extends IntegrationSpec {
         resolveConsumer('jenkinsTestRuntime') == [
                 'producer-1.0.hpi',
                 'ant-1.2.hpi',
-                'jenkins-war-1.580.1.war',
+                'jenkins-war-2.401.3.war',
         ] as Set
 
         when:
@@ -250,7 +249,7 @@ class JpiPublishingAndConsumptionTest extends IntegrationSpec {
                 [ 'producer-1.0.hpi',
                   'ant-1.2.hpi',
                   'credentials-1.9.4.hpi',
-                  'jenkins-war-1.580.1.war',
+                  'jenkins-war-2.401.3.war',
                 ] as Set
 
         manifestEntry('consumer', 'Plugin-Dependencies') ==
@@ -275,7 +274,7 @@ class JpiPublishingAndConsumptionTest extends IntegrationSpec {
         when:
         consumerBuild << """
             jenkinsPlugin {
-                jenkinsVersion = '1.580.1'
+                jenkinsVersion = '${TestSupport.RECENT_JENKINS_VERSION}'
             }
             dependencies {
                 implementation 'org:producer:1.0'
@@ -286,7 +285,7 @@ class JpiPublishingAndConsumptionTest extends IntegrationSpec {
         resolveConsumer('compile') == JENKINS_CORE_DEPS + [ 'producer-1.0.jar' ] as Set
         resolveConsumer('runtime') == [ 'producer-1.0.jar' ] as Set
         resolveConsumer('jenkinsRuntime') == [ 'producer-1.0.hpi' ] as Set
-        resolveConsumer('jenkinsTestRuntime') == [ 'producer-1.0.hpi', 'jenkins-war-1.580.1.war' ] as Set
+        resolveConsumer('jenkinsTestRuntime') == [ 'producer-1.0.hpi', 'jenkins-war-2.401.3.war' ] as Set
     }
 
     private void publishProducer() {
@@ -333,122 +332,103 @@ class JpiPublishingAndConsumptionTest extends IntegrationSpec {
     }
 
     private static final JENKINS_CORE_DEPS = [
-        'jenkins-core-1.580.1.jar',
-        'annotations-1.0.0.jar',
-        'servlet-api-2.4.jar',
-        'icon-set-1.0.3.jar',
-        'cli-1.580.1.jar',
-        'remoting-2.47.jar',
-        'version-number-1.1.jar',
-        'crypto-util-1.1.jar',
-        'jtidy-4aug2000r7-dev-hudson-1.jar',
-        'guice-4.0-beta-no_aop.jar',
-        'jna-posix-1.0.3.jar',
-        'jnr-posix-3.0.1.jar',
-        'trilead-putty-extension-1.2.jar',
-        'trilead-ssh2-build217-jenkins-5.jar',
-        'stapler-groovy-1.231.jar',
-        'stapler-jrebel-1.231.jar',
-        'windows-package-checker-1.0.jar',
-        'stapler-adjunct-zeroclipboard-1.3.5-1.jar',
-        'stapler-adjunct-timeline-1.4.jar',
-        'stapler-adjunct-codemirror-1.3.jar',
-        'bridge-method-annotation-1.13.jar',
-        'stapler-jelly-1.231.jar',
-        'stapler-1.231.jar',
-        'json-lib-2.4-jenkins-2.jar',
-        'commons-httpclient-3.1.jar',
-        'args4j-2.0.23.jar',
-        'bytecode-compatibility-transformer-1.5.jar',
-        'access-modifier-annotation-1.4.jar',
-        'annotation-indexer-1.7.jar',
-        'task-reactor-1.4.jar',
-        'localizer-1.10.jar',
-        'antlr-2.7.6.jar',
-        'xstream-1.4.7-jenkins-1.jar',
-        'jfreechart-1.0.9.jar',
-        'ant-1.8.3.jar',
-        'commons-fileupload-1.3.1-jenkins-1.jar',
-        'commons-io-2.4.jar',
-        'acegi-security-1.0.7.jar',
-        'ezmorph-1.0.6.jar',
-        'commons-lang-2.6.jar',
-        'commons-digester-2.1.jar',
-        'commons-jelly-tags-xml-1.1.jar',
-        'commons-jelly-1.1-jenkins-20120928.jar',
-        'commons-beanutils-1.8.3.jar',
-        'mail-1.4.4.jar',
-        'activation-1.1.1-hudson-1.jar',
-        'jaxen-1.1-beta-11.jar',
+        'access-modifier-annotation-1.31.jar',
+        'annotation-indexer-1.17.jar',
+        'ant-1.10.13.jar',
+        'ant-launcher-1.10.13.jar',
+        'antlr4-runtime-4.12.0.jar',
+        'args4j-2.33.jar',
+        'asm-9.5.jar',
+        'asm-analysis-9.5.jar',
+        'asm-commons-9.5.jar',
+        'asm-tree-9.5.jar',
+        'asm-util-9.5.jar',
+        'bridge-method-annotation-1.26.jar',
+        'checker-qual-3.12.0.jar',
+        'cli-2.401.3.jar',
+        'commons-beanutils-1.9.4.jar',
+        'commons-codec-1.15.jar',
+        'commons-collections-3.2.2.jar',
+        'commons-compress-1.23.0.jar',
+        'commons-discovery-0.5.jar',
+        'commons-fileupload-1.5.jar',
+        'commons-io-2.11.0.jar',
+        'commons-jelly-1.1-jenkins-20230124.jar',
+        'commons-jelly-tags-define-1.1-jenkins-20230124.jar',
         'commons-jelly-tags-fmt-1.0.jar',
-        'commons-jelly-tags-define-1.0.1-hudson-20071021.jar',
+        'commons-jelly-tags-xml-1.1.jar',
         'commons-jexl-1.1-jenkins-20111212.jar',
-        'groovy-all-1.8.9.jar',
-        'jline-0.9.94.jar',
-        'jansi-1.9.jar',
-        'spring-webmvc-2.5.6.SEC03.jar',
-        'spring-aop-2.5.6.SEC03.jar',
-        'spring-jdbc-1.2.9.jar',
-        'spring-context-support-2.5.6.SEC03.jar',
-        'spring-web-2.5.6.SEC03.jar',
-        'spring-dao-1.2.9.jar',
-        'spring-context-2.5.6.SEC03.jar',
-        'spring-beans-2.5.6.SEC03.jar',
-        'spring-core-2.5.6.SEC03.jar',
-        'xpp3-1.1.4c.jar',
-        'jstl-1.1.0.jar',
-        'commons-discovery-0.4.jar',
-        'commons-logging-1.1.3.jar',
-        'txw2-20110809.jar',
-        'commons-collections-3.2.1.jar',
-        'winp-1.22.jar',
-        'memory-monitor-1.8.jar',
-        'wstx-asl-3.2.9.jar',
-        'jmdns-3.4.0-jenkins-3.jar',
-        'akuma-1.9.jar',
-        'libpam4j-1.6.jar',
-        'libzfs-0.5.jar',
-        'jna-3.4.0.jar',
+        'commons-lang-2.6.jar',
+        'commons-logging-1.2.jar',
+        'crypto-util-1.8.jar',
+        'dom4j-2.1.4.jar',
         'embedded_su4j-1.1.jar',
-        'sezpoz-1.9.jar',
-        'j-interop-2.0.6-kohsuke-1.jar',
-        'robust-http-client-1.2.jar',
-        'commons-codec-1.8.jar',
-        'jbcrypt-0.3m.jar',
-        'guava-14.0.jar',
-        'jzlib-1.1.3.jar',
-        'constant-pool-scanner-1.2.jar',
+        'error_prone_annotations-2.18.0.jar',
+        'ezmorph-1.0.6.jar',
+        'failureaccess-1.0.1.jar',
+        'groovy-all-2.4.21.jar',
+        'guava-31.1-jre.jar',
+        'guice-6.0.0.jar',
+        'j-interop-2.0.8-kohsuke-1.jar',
+        'j-interopdeps-2.0.8-kohsuke-1.jar',
+        'j2objc-annotations-1.3.jar',
+        'jakarta.annotation-api-2.1.1.jar',
+        'jakarta.inject-api-2.0.1.jar',
+        'jakarta.servlet.jsp.jstl-api-1.2.7.jar',
+        'jansi-1.11.jar',
+        'javax.annotation-api-1.3.2.jar',
         'javax.inject-1.jar',
-        'aopalliance-1.0.jar',
-        'cglib-3.0.jar',
-        'jnr-ffi-1.0.7.jar',
-        'asm-util-4.0.jar',
-        'jnr-constants-0.8.5.jar',
-        'asm5-5.0.1.jar',
-        'jcommon-1.0.12.jar',
-        'ant-launcher-1.8.3.jar',
-        'oro-2.0.8.jar',
-        'junit-3.8.1.jar',
-        'stax-api-1.0-2.jar',
+        'javax.servlet-api-3.1.0.jar',
+        'jaxen-2.0.0.jar',
+        'jbcrypt-1.0.0.jar',
+        'jcifs-1.3.18-kohsuke-1.jar',
+        'jcip-annotations-1.0.jar',
+        'jcl-over-slf4j-2.0.7.jar',
+        'jcommon-1.0.23.jar',
+        'jenkins-core-2.401.3.jar',
+        'jenkins-stapler-support-1.1.jar',
+        'jfreechart-1.0.19.jar',
+        'jline-2.14.6.jar',
+        'jna-5.13.0.jar',
+        'json-lib-2.4-jenkins-3.jar',
+        'jsr305-3.0.2.jar',
+        'jzlib-1.1.3-kohsuke-1.jar',
+        'kxml2-2.3.0.jar',
+        'listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar',
+        'localizer-1.31.jar',
+        'log4j-over-slf4j-2.0.7.jar',
+        'memory-monitor-1.12.jar',
+        'mxparser-1.2.2.jar',
+        'producer-1.0.jar',
         'relaxngDatatype-20020414.jar',
-        'stax-api-1.0.1.jar',
-        'j-interopdeps-2.0.6-kohsuke-1.jar',
-        'jsr305-2.0.1.jar',
-        'asm-commons-4.0.jar',
-        'asm-analysis-4.0.jar',
-        'asm-tree-4.0.jar',
-        'asm-4.0.jar',
-        'jffi-1.2.7.jar',
-        'jnr-x86asm-1.0.2.jar',
-        'dom4j-1.6.1-jenkins-4.jar',
-        'javax.annotation-api-1.2.jar',
-        'tiger-types-1.3.jar',
-        'jdom-1.0.jar',
-        'xom-1.0b3.jar',
-        'jcifs-1.2.19.jar',
-        'xmlParserAPIs-2.6.1.jar',
-        'icu4j-2.6.1.jar',
-        'xalan-2.6.0.jar',
-        'tagsoup-0.9.7.jar',
+        'remoting-3107.v665000b_51092.jar',
+        'robust-http-client-1.2.jar',
+        'sezpoz-1.13.jar',
+        'slf4j-api-2.0.7.jar',
+        'spotbugs-annotations-4.7.3.jar',
+        'spring-aop-5.3.27.jar',
+        'spring-beans-5.3.27.jar',
+        'spring-context-5.3.27.jar',
+        'spring-core-5.3.27.jar',
+        'spring-expression-5.3.27.jar',
+        'spring-security-core-5.8.2.jar',
+        'spring-security-crypto-5.8.2.jar',
+        'spring-security-web-5.8.2.jar',
+        'spring-web-5.3.27.jar',
+        'stapler-1777.v7c6fe6d54a_0c.jar',
+        'stapler-adjunct-codemirror-1.3.jar',
+        'stapler-adjunct-timeline-1.5.jar',
+        'stapler-groovy-1777.v7c6fe6d54a_0c.jar',
+        'stapler-jelly-1777.v7c6fe6d54a_0c.jar',
+        'symbol-annotation-1.24.jar',
+        'task-reactor-1.8.jar',
+        'tiger-types-2.2.jar',
+        'txw2-20110809.jar',
+        'version-number-1.11.jar',
+        'websocket-spi-2.401.3.jar',
+        'windows-package-checker-1.2.jar',
+        'winp-1.30.jar',
+        'xpp3-1.1.4c.jar',
+        'xstream-1.4.20.jar',
     ] as Set
 }

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/internal/DependencyLookupSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/internal/DependencyLookupSpec.groovy
@@ -92,7 +92,7 @@ class DependencyLookupSpec extends Specification {
 
         then:
         actual == ([
-                new MavenDependency("org.jenkins-ci.main:jenkins-war:${version}@war"),
+                new MavenDependency("org.jenkins-ci.main:jenkins-war:${version}"),
         ] as Set)
 
         where:

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/testing/TestTaskIntegrationSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/testing/TestTaskIntegrationSpec.groovy
@@ -142,6 +142,7 @@ class TestTaskIntegrationSpec extends IntegrationSpec {
                 implementation 'org.jenkins-ci.plugins:gradle:1.35'
                 implementation 'org.jenkins-ci.plugins:junit:1.20'
                 runtimeOnly 'io.jenkins.plugins:javax-mail-api:1.6.2-10'
+                runtimeOnly 'org.jenkins-ci.plugins:script-security:1172.v35f6a_0b_8207e'
             }
             """.stripIndent()
         def srcTestJava = inProjectDir('src/test/java')

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/testing/TestTaskIntegrationSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/testing/TestTaskIntegrationSpec.groovy
@@ -55,11 +55,13 @@ class TestTaskIntegrationSpec extends IntegrationSpec {
 
         when:
         def result = gradleRunner()
-                .withArguments(taskPath, '-s')
+                .withArguments(taskPath, '-is')
                 .build()
 
         then:
         result.task(taskPath).outcome == TaskOutcome.NO_SOURCE
+        !result.output.contains('java.lang.ClassNotFoundException')
+        !result.output.contains('No SLF4J providers were found.')
     }
 
     def 'should work out of the box with JenkinsRule'() {
@@ -122,6 +124,8 @@ class TestTaskIntegrationSpec extends IntegrationSpec {
 
         then:
         result.task(taskPath).outcome == TaskOutcome.SUCCESS
+        !result.output.contains('java.lang.ClassNotFoundException')
+        !result.output.contains('No SLF4J providers were found.')
     }
 
     def 'should be installed by default'() {
@@ -137,6 +141,7 @@ class TestTaskIntegrationSpec extends IntegrationSpec {
             dependencies {
                 implementation 'org.jenkins-ci.plugins:gradle:1.35'
                 implementation 'org.jenkins-ci.plugins:junit:1.20'
+                runtimeOnly 'io.jenkins.plugins:javax-mail-api:1.6.2-10'
             }
             """.stripIndent()
         def srcTestJava = inProjectDir('src/test/java')
@@ -171,10 +176,12 @@ class TestTaskIntegrationSpec extends IntegrationSpec {
 
         when:
         def result = gradleRunner()
-                .withArguments(taskPath, '-s')
+                .withArguments(taskPath, '-is')
                 .build()
 
         then:
         result.task(taskPath).outcome == TaskOutcome.SUCCESS
+        !result.output.contains('java.lang.ClassNotFoundException')
+        !result.output.contains('No SLF4J providers were found.')
     }
 }


### PR DESCRIPTION
Remote execution does not work when `jth.jenkins-war.path` is configured to a path on the local system. The fallback behavior of discovering a war on the classpath does work.

<!-- Please describe your pull request here. -->

### Testing done

Updated tests that were asserting on the jenkins test runtime classpath. All remaining tests pass.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
