### PR TITLE
Use `-parameters` for JavaCompile tasks

### DIFF
--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
@@ -234,6 +234,10 @@ class JpiPlugin implements Plugin<Project>, PluginDependencyProvider {
             groovyOptions.javaAnnotationProcessing = true
         }
 
+        gradleProject.tasks.withType(JavaCompile).configureEach {
+            it.options.compilerArgs << '-parameters'
+        }
+
         gradleProject.plugins.apply(DependenciesPlugin)
         configureRepositories(gradleProject)
         configureJpi(gradleProject, current >= GradleVersion.version('6.6'))

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiIntegrationSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiIntegrationSpec.groovy
@@ -659,4 +659,27 @@ class JpiIntegrationSpec extends IntegrationSpec {
         "'https://maven.example.org/'" | 'https://maven.example.org/'
     }
 
+    def 'should configure Java compile task'() {
+        given:
+        build << """\
+            jenkinsPlugin {
+                jenkinsVersion = '${TestSupport.RECENT_JENKINS_VERSION}'
+            }
+            tasks.withType(JavaCompile).configureEach {
+                doLast {
+                    println "compiler args=\${it.options.compilerArgs}"
+                }
+            }
+            """.stripIndent()
+        TestSupport.CALCULATOR.writeTo(inProjectDir('src/main/java'))
+
+        when:
+        def result = gradleRunner()
+            .withArguments('jpi', '-q')
+            .build()
+
+        then:
+        result.output.contains('compiler args=[-Asezpoz.quiet=true, -parameters]')
+    }
+
 }


### PR DESCRIPTION
See https://github.com/jenkinsci/plugin-pom/pull/415

Sets the `-parameters` option to javac, aligning with plugins built with maven-hpi-plugin.

### Testing done

- Unit test included
- Manually tested: built `gradle-plugin` with a dev version of `gradle-jpi-plugin`, ensured that the `o.k.s.BytecodeReadingParanamer#lookupParameterNames: Looking up parameter names for public hudson.util.FormValidation hudson.plugins.gradle.enriched.EnrichedSummaryConfig.doCheckHttpClientTimeoutInSeconds(int); update plugin to a version created with a newer harness` are gone

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
