### PR TITLE
Fix misleading error message

### DIFF
--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
@@ -102,8 +102,8 @@ class JpiPlugin implements Plugin<Project>, PluginDependencyProvider {
             throw new GradleException('This version of the JPI plugin requires Gradle 6.3 or later.' +
                     'For older Gradle versions, please use version 0.46.0 of the JPI plugin.')
         } else if (current < GradleVersion.version('7.1')) {
-            throw new GradleException('This version of the JPI plugin requires Gradle 6.3 or later.' +
-                    'For older Gradle versions, please use version 0.46.0 of the JPI plugin.')
+            throw new GradleException('This version of the JPI plugin requires Gradle 7.1 or later.' +
+                    'For older Gradle versions, please use version 0.50.0 of the JPI plugin.')
         }
         UnsupportedGradleConfigurationVerifier.configureDeprecatedConfigurations(gradleProject)
 


### PR DESCRIPTION
Looks like a copy-pasta error, someone set minimum gradle version to 7.1 but the error recommends using 6.3+ :-(

### Testing done

Its error message text - nothing to test

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
