### PR TITLE
chore: Add servlet-api to testCompile scope

### DIFF
--- a/src/main/java/org/jenkinsci/gradle/plugins/jpi/internal/DependencyLookup.java
+++ b/src/main/java/org/jenkinsci/gradle/plugins/jpi/internal/DependencyLookup.java
@@ -39,6 +39,7 @@ public class DependencyLookup {
             case "testCompileOnly":
                 deps.add(new MavenDependency("net.jcip:jcip-annotations:1.0"));
                 deps.add(findbugs);
+                deps.add(servlet);
                 return deps;
             case "generatedJenkinsTestImplementation":
                 deps.addAll(coreSet);

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/internal/DependencyLookupSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/internal/DependencyLookupSpec.groovy
@@ -81,11 +81,12 @@ class DependencyLookupSpec extends Specification {
 
         where:
         version                         | expected
-        '1.617'                         | [FINDBUGS_1, JCIP_ANNOTATIONS] as Set
-        '2.150.3'                       | [GOOGLE_FINDBUGS, JCIP_ANNOTATIONS] as Set
-        '2.222.3'                       | [SPOTBUGS, JCIP_ANNOTATIONS] as Set
-        '2.361.2-rc32710.c1a_5e8c179f6' | [SPOTBUGS, JCIP_ANNOTATIONS] as Set
-        '2.369-rc32854.076293e36922'    | [SPOTBUGS, JCIP_ANNOTATIONS] as Set
+        '1.617'                         | [FINDBUGS_1, JCIP_ANNOTATIONS, SERVLET_2_4] as Set
+        '2.150.3'                       | [GOOGLE_FINDBUGS, JCIP_ANNOTATIONS, SERVLET_3_1] as Set
+        '2.222.3'                       | [SPOTBUGS, JCIP_ANNOTATIONS, SERVLET_3_1] as Set
+        '2.361.2-rc32710.c1a_5e8c179f6' | [SPOTBUGS, JCIP_ANNOTATIONS, SERVLET_3_1] as Set
+        '2.369-rc32854.076293e36922'    | [SPOTBUGS, JCIP_ANNOTATIONS, SERVLET_3_1] as Set
+        '2.475'                         | [SPOTBUGS, JCIP_ANNOTATIONS, SERVLET_5_0] as Set
     }
 
     @Unroll


### PR DESCRIPTION
See: https://github.com/jenkinsci/gradle-jpi-plugin/pull/235#issuecomment-2661048621

This adds `servlet-api` to the `testCompile` scope to allow compilation of certain types to succeed in test code.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
