### PR TITLE
:wrench: Update workflow config for new default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -5,9 +5,9 @@ name: Regression
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 
 jobs:


### PR DESCRIPTION
The default branch of this repository was updated to `main`, but required workflows were left activating on PRs to the previous name.