### PR TITLE
✨ `--add-opens` for JDK 17+

### DIFF
--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtension.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiExtension.groovy
@@ -83,6 +83,7 @@ class JpiExtension implements JpiExtensionBridge {
     private final SetProperty<String> maskedClassesFromCore
     private final ListProperty<PluginDeveloper> pluginDevelopers
     private final ListProperty<PluginLicense> pluginLicenses
+    private final ListProperty<String> testJvmArguments
     private final Property<String> incrementalsRepoUrl
     private final GitVersionExtension gitVersion
     private final Property<String> scmTag
@@ -113,6 +114,12 @@ class JpiExtension implements JpiExtensionBridge {
         this.maskedClassesFromCore = project.objects.setProperty(String).convention([])
         this.pluginDevelopers = project.objects.listProperty(PluginDeveloper)
         this.pluginLicenses = project.objects.listProperty(PluginLicense)
+        this.testJvmArguments = project.objects.listProperty(String)
+                .convention([
+                        '--add-opens', 'java.base/java.lang=ALL-UNNAMED',
+                        '--add-opens', 'java.base/java.io=ALL-UNNAMED',
+                        '--add-opens', 'java.base/java.util=ALL-UNNAMED',
+                ])
         this.generateTests = project.objects.property(Boolean).convention(false)
         this.requireEscapeByDefaultInJelly = project.objects.property(Boolean).convention(true)
         this.generatedTestClassName = project.objects.property(String).convention('InjectedTest')
@@ -519,6 +526,11 @@ class JpiExtension implements JpiExtensionBridge {
     @Override
     ListProperty<PluginLicense> getPluginLicenses() {
         pluginLicenses
+    }
+
+    @Override
+    ListProperty<String> getTestJvmArguments() {
+        testJvmArguments
     }
 
     GitVersionExtension getGitVersion() {

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
@@ -51,6 +51,7 @@ import org.gradle.api.tasks.testing.Test
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.gradle.util.GradleVersion
 import org.jenkinsci.gradle.plugins.jpi.internal.DependenciesPlugin
+import org.jenkinsci.gradle.plugins.jpi.internal.Jdk17Plugin
 import org.jenkinsci.gradle.plugins.jpi.internal.PluginDependencyProvider
 import org.jenkinsci.gradle.plugins.jpi.legacy.LegacyWorkaroundsPlugin
 import org.jenkinsci.gradle.plugins.jpi.localization.LocalizationPlugin
@@ -128,6 +129,7 @@ class JpiPlugin implements Plugin<Project>, PluginDependencyProvider {
 
         gradleProject.plugins.apply(JavaLibraryPlugin)
         gradleProject.plugins.apply(GroovyPlugin)
+        gradleProject.plugins.apply(Jdk17Plugin)
         gradleProject.plugins.apply(kotlinPlugin('org.jenkinsci.gradle.plugins.accmod.AccessModifierPlugin'))
         gradleProject.plugins.apply(kotlinPlugin('org.jenkinsci.gradle.plugins.manifest.JenkinsManifestPlugin'))
         gradleProject.plugins.apply(kotlinPlugin('org.jenkinsci.gradle.plugins.testing.JpiTestingPlugin'))

--- a/src/main/java/org/jenkinsci/gradle/plugins/jpi/internal/Jdk17Plugin.java
+++ b/src/main/java/org/jenkinsci/gradle/plugins/jpi/internal/Jdk17Plugin.java
@@ -1,0 +1,42 @@
+package org.jenkinsci.gradle.plugins.jpi.internal;
+
+import org.gradle.api.Action;
+import org.gradle.api.JavaVersion;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.TaskCollection;
+import org.gradle.api.tasks.testing.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class Jdk17Plugin implements Plugin<Project> {
+    @Override
+    public void apply(Project project) {
+        if (atLeastJdk17()) {
+            JpiExtensionBridge ext = project.getExtensions().getByType(JpiExtensionBridge.class);
+            List<String> args = ext.getTestJvmArguments().getOrElse(new LinkedList<>());
+            ConfigureJvmArgs configureJvmArgs = new ConfigureJvmArgs(args);
+            TaskCollection<Test> tests = project.getTasks().withType(Test.class);
+            tests.named("test").configure(configureJvmArgs);
+            tests.named("generatedJenkinsTest").configure(configureJvmArgs);
+        }
+    }
+
+    private static boolean atLeastJdk17() {
+        return JavaVersion.current().compareTo(JavaVersion.VERSION_17) >= 0;
+    }
+
+    private static class ConfigureJvmArgs implements Action<Test> {
+        private final List<String> jvmArgs;
+
+        private ConfigureJvmArgs(List<String> jvmArgs) {
+            this.jvmArgs = jvmArgs;
+        }
+
+        @Override
+        public void execute(Test test) {
+            test.jvmArgs(jvmArgs);
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/gradle/plugins/jpi/internal/JpiExtensionBridge.java
+++ b/src/main/java/org/jenkinsci/gradle/plugins/jpi/internal/JpiExtensionBridge.java
@@ -21,6 +21,7 @@ public interface JpiExtensionBridge {
     SetProperty<String> getMaskedClassesFromCore();
     ListProperty<PluginDeveloper> getPluginDevelopers();
     ListProperty<PluginLicense> getPluginLicenses();
+    ListProperty<String> getTestJvmArguments();
 
     Property<Boolean> getGenerateTests();
     Property<String> getGeneratedTestClassName();


### PR DESCRIPTION
Addresses #243.

Adds selectively to `generatedJenkinsTest` and `test`, so any tests introduced by users (such as `acceptanceTest`) do not automatically get this behavior.

Opens are user-configurable by adding to, clearing, or modifying the `ListProperty` in the extension.