### PR TITLE
fix: Declare explicit dependency from `generateJenkinsServerHpl` on `processResources`

### DIFF
--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
@@ -177,6 +177,7 @@ class JpiPlugin implements Plugin<Project>, PluginDependencyProvider {
             t.upstreamManifest.set(jenkinsManifest.get().outputFile)
             t.description = 'Generate hpl (Hudson plugin link) for running locally'
             t.group = 'Jenkins Server'
+            t.dependsOn(gradleProject.tasks.getByName('processResources'))
         }
 
         def installPlugins = gradleProject.tasks.register(InstallJenkinsServerPluginsTask.TASK_NAME,


### PR DESCRIPTION
Without this we get this error.

```
> Task :blesk:processResources FAILED

[Incubating] Problems report is available at: .../build/reports/problems/problems-report.html

FAILURE: Build failed with an exception.

* What went wrong:
A problem was found with the configuration of task ':blesk:processResources' (type 'ProcessResources').
  - Gradle detected a problem with the following location: '.../blesk/build/resources/main'.

    Reason: Task ':blesk:generateJenkinsServerHpl' uses this output of task ':blesk:processResources' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.

    Possible solutions:
      1. Declare task ':blesk:processResources' as an input of ':blesk:generateJenkinsServerHpl'.
      2. Declare an explicit dependency on ':blesk:processResources' from ':blesk:generateJenkinsServerHpl' using Task#dependsOn.
      3. Declare an explicit dependency on ':blesk:processResources' from ':blesk:generateJenkinsServerHpl' using Task#mustRunAfter.

    For more information, please refer to https://docs.gradle.org/8.13/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.
```

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
