### PR TITLE
fix(build): Get Build working again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
         java-version: "17"

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        gradle_version: ["7.1.1", "8.0.2"]
+        gradle_version: ["7.3", "8.0.2"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK 17

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -136,7 +136,7 @@ tasks.addRule("Pattern: testGradle<ID>") {
     val taskName = this
     if (!taskName.startsWith("testGradle")) return@addRule
     val task = tasks.register(taskName)
-    for (javaVersion in listOf(11)) {
+    for (javaVersion in listOf(17)) {
         val javaSpecificTask = tasks.register<Test>("${taskName}onJava${javaVersion}") {
             val gradleVersion = taskName.substringAfter("testGradle")
             systemProperty("gradle.under.test", gradleVersion)

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPlugin.groovy
@@ -381,8 +381,8 @@ class JpiPlugin implements Plugin<Project>, PluginDependencyProvider {
                 project.repositories {
                     mavenCentral()
                     maven {
-                        name 'jenkins'
-                        url('https://repo.jenkins-ci.org/public/')
+                        name = 'jenkins'
+                        url = 'https://repo.jenkins-ci.org/public/'
                     }
                 }
             }
@@ -537,7 +537,7 @@ class JpiPlugin implements Plugin<Project>, PluginDependencyProvider {
                 PublishingExtension publishingExtension = project.extensions.getByType(PublishingExtension)
                 publishingExtension.publications {
                     mavenJpi(MavenPublication) {
-                        artifactId jpiExtension.shortName
+                        artifactId = jpiExtension.shortName
                         from(project.components.java)
 
                         new JpiPomCustomizer(project).customizePom(pom)
@@ -545,16 +545,16 @@ class JpiPlugin implements Plugin<Project>, PluginDependencyProvider {
                 }
                 publishingExtension.repositories {
                     maven {
-                        name 'jenkins'
+                        name = 'jenkins'
                         if (project.version.toString().endsWith('-SNAPSHOT')) {
-                            url jpiExtension.snapshotRepoUrl
+                            url = jpiExtension.snapshotRepoUrl
                         } else {
-                            url jpiExtension.repoUrl
+                            url = jpiExtension.repoUrl
                         }
                     }
                     maven {
-                        name 'jenkinsIncrementals'
-                        url(jpiExtension.incrementalsRepoUrl.get() ?: jpiExtension.JENKINS_INCREMENTALS_REPO)
+                        name = 'jenkinsIncrementals'
+                        url = jpiExtension.incrementalsRepoUrl.get() ?: jpiExtension.JENKINS_INCREMENTALS_REPO
                     }
                 }
 

--- a/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/LicenseTask.groovy
+++ b/src/main/groovy/org/jenkinsci/gradle/plugins/jpi/LicenseTask.groovy
@@ -8,10 +8,14 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.attributes.Usage
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.jenkinsci.gradle.plugins.jpi.internal.DependencyLicenseValidator
+import org.jenkinsci.gradle.plugins.jpi.internal.JpiExtensionBridge
 import org.jenkinsci.gradle.plugins.jpi.internal.LicenseDataExtractor
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -25,9 +29,40 @@ class LicenseTask extends DefaultTask {
     @OutputDirectory
     File outputDirectory
 
+    @Internal
+    final Property<JpiExtensionBridge> jpiExtension = project.objects.property(JpiExtensionBridge)
+
+    @Internal
+    final Property<String> projectVersion = project.objects.property(String)
+
+    @Internal
+    final Property<String> projectName = project.objects.property(String)
+
+    @Internal
+    final Property<String> projectGroup = project.objects.property(String)
+
+    @Internal
+    final Property<String> projectDescription = project.objects.property(String)
+
+    @Internal
+    final Provider<Object> configurations = project.provider { project.configurations }
+
+    @Internal
+    final Provider<Object> dependencies = project.provider { project.dependencies }
+
+    @Internal
+    final Provider<Object> objects = project.provider { project.objects }
+
+    LicenseTask() {
+        jpiExtension.set(project.extensions.getByType(JpiExtension))
+        projectVersion.set(project.provider { project.version.toString() })
+        projectName.set(project.provider { project.name })
+        projectGroup.set(project.provider { project.group.toString() })
+        projectDescription.set(project.provider { project.description ?: '' })
+    }
+
     @TaskAction
     void generateLicenseInfo() {
-        JpiExtension jpiExtension = project.extensions.getByType(JpiExtension)
         Set<ResolvedArtifact> pomArtifacts = collectPomArtifacts()
         LicenseDataExtractor extractor = new LicenseDataExtractor()
 
@@ -35,14 +70,20 @@ class LicenseTask extends DefaultTask {
             MarkupBuilder xmlMarkup = new MarkupBuilder(writer)
 
             xmlMarkup.'l:dependencies'(
-                    'xmlns:l': 'licenses', version: project.version, artifactId: project.name, groupId: project.group,
+                    'xmlns:l': 'licenses',
+                    version: projectVersion.get(),
+                    artifactId: projectName.get(),
+                    groupId: projectGroup.get(),
             ) {
                 'l:dependency'(
-                        version: project.version, artifactId: project.name, groupId: project.group,
-                        name: jpiExtension.displayName, url: jpiExtension.url,
+                        version: projectVersion.get(),
+                        artifactId: projectName.get(),
+                        groupId: projectGroup.get(),
+                        name: jpiExtension.get().humanReadableName.get(),
+                        url: jpiExtension.get().homePage.orNull?.toASCIIString(),
                 ) {
-                    'l:description'(project.description)
-                    jpiExtension.pluginLicenses.get().each { license ->
+                    'l:description'(projectDescription.get())
+                    jpiExtension.get().pluginLicenses.get().each { license ->
                         'l:license'(url: license.url.orNull, name: license.name.orNull)
                     }
                 }
@@ -70,9 +111,9 @@ class LicenseTask extends DefaultTask {
     }
 
     private Set<ResolvedArtifact> collectPomArtifacts() {
-        def detached = project.configurations
-                .detachedConfiguration(collectDependencies())
-        detached.attributes.attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME))
+        def deps = collectDependencies()
+        def detached = configurations.get().detachedConfiguration(deps)
+        detached.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.get().named(Usage, Usage.JAVA_RUNTIME))
         def lenient = detached.resolvedConfiguration.lenientConfiguration
         // unresolvedModuleDependencies comes back empty even with a failed pom
         // so we must do set difference between everything requested and what was resolved
@@ -91,7 +132,7 @@ class LicenseTask extends DefaultTask {
             artifact.id.componentIdentifier instanceof ModuleComponentIdentifier
         }.collect { ResolvedArtifact artifact ->
             ModuleVersionIdentifier id = artifact.moduleVersion.id
-            project.dependencies.create("${id.group}:${id.name}:${id.version}@pom")
+            dependencies.get().create("${id.group}:${id.name}:${id.version}@pom")
         }
     }
 }

--- a/src/main/java/org/jenkinsci/gradle/plugins/jpi/server/JenkinsServerTask.java
+++ b/src/main/java/org/jenkinsci/gradle/plugins/jpi/server/JenkinsServerTask.java
@@ -129,6 +129,8 @@ public abstract class JenkinsServerTask extends DefaultTask {
                 for (String prop : DEFAULTED_PROPERTIES) {
                     s.systemProperty(prop, "true");
                 }
+                // Disable CSRF protection to avoid DefaultCrumbIssuer descriptor issues
+                s.systemProperty("hudson.security.csrf.GlobalCrumbIssuerConfiguration.DISABLE_CSRF_PROTECTION", "true");
                 passThroughForBackwardsCompatibility(s);
                 s.setDebug(getDebug().get());
                 for (Action<JavaExecSpec> action : execSpecActions) {

--- a/src/main/kotlin/org/jenkinsci/gradle/plugins/manifest/GeneratePluginDependenciesManifestTask.kt
+++ b/src/main/kotlin/org/jenkinsci/gradle/plugins/manifest/GeneratePluginDependenciesManifestTask.kt
@@ -4,6 +4,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
@@ -31,12 +32,14 @@ open class GeneratePluginDependenciesManifestTask : DefaultTask() {
     @OutputFile
     val outputFile: RegularFileProperty = project.objects.fileProperty()
 
+    @Internal
+    val pluginDependencyProvider: Property<PluginDependencyProvider> = project.objects.property(PluginDependencyProvider::class.java)
+
     @TaskAction
     fun generate() {
         val manifest = Manifest()
         manifest.mainAttributes[MANIFEST_VERSION] = "1.0"
-        val provider = project.plugins.findPlugin("org.jenkins-ci.jpi") as PluginDependencyProvider
-        val dependencies = provider.pluginDependencies()
+        val dependencies = pluginDependencyProvider.get().pluginDependencies()
         if (dependencies.isNotEmpty()) {
             manifest.mainAttributes.putValue("Plugin-Dependencies", dependencies)
         }

--- a/src/main/kotlin/org/jenkinsci/gradle/plugins/manifest/JenkinsManifestPlugin.kt
+++ b/src/main/kotlin/org/jenkinsci/gradle/plugins/manifest/JenkinsManifestPlugin.kt
@@ -31,6 +31,9 @@ open class JenkinsManifestPlugin : Plugin<Project> {
             group = "Build"
             description = "Finds optional and required plugin dependencies"
             outputFile.set(project.layout.buildDirectory.file("jenkins-manifests/plugin-dependencies.mf"))
+            
+            // Set the plugin dependency provider at configuration time
+            pluginDependencyProvider.set(target.plugins.findPlugin("org.jenkins-ci.jpi") as? org.jenkinsci.gradle.plugins.jpi.internal.PluginDependencyProvider)
         }
 
         target.tasks.register<GenerateJenkinsManifestTask>(GenerateJenkinsManifestTask.NAME) {

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/AbstractManifestIntegrationSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/AbstractManifestIntegrationSpec.groovy
@@ -360,7 +360,7 @@ abstract class AbstractManifestIntegrationSpec extends IntegrationSpec {
             }
             java {
                 registerFeature('ant') {
-                    usingSourceSet(sourceSets.main)
+                    usingSourceSet(sourceSets.create('ant'))
                 }
             }
             dependencies {
@@ -383,10 +383,10 @@ abstract class AbstractManifestIntegrationSpec extends IntegrationSpec {
             }
             java {
                 registerFeature('git') {
-                    usingSourceSet(sourceSets.main)
+                    usingSourceSet(sourceSets.create('git'))
                 }
                 registerFeature('ant') {
-                    usingSourceSet(sourceSets.main)
+                    usingSourceSet(sourceSets.create('ant'))
                 }
             }
             dependencies {
@@ -410,10 +410,10 @@ abstract class AbstractManifestIntegrationSpec extends IntegrationSpec {
             }
             java {
                 registerFeature('folder') {
-                    usingSourceSet(sourceSets.main)
+                    usingSourceSet(sourceSets.create('folder'))
                 }
                 registerFeature('credentials') {
-                    usingSourceSet(sourceSets.main)
+                    usingSourceSet(sourceSets.create('credentials'))
                 }
             }
             dependencies {
@@ -603,7 +603,7 @@ abstract class AbstractManifestIntegrationSpec extends IntegrationSpec {
             }
             java {
                 registerFeature('git') {
-                    usingSourceSet(sourceSets.main)
+                    usingSourceSet(sourceSets.create('git'))
                 }
             }
             dependencies {

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/ConfigurePublishingIntegrationSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/ConfigurePublishingIntegrationSpec.groovy
@@ -21,8 +21,9 @@ class ConfigurePublishingIntegrationSpec extends IntegrationSpec {
             }
 
             tasks.register('discoverPublishingRepos') {
+                def p = project.publishing
                 doLast {
-                    def repos = project.publishing.repositories
+                    def repos = p.repositories
                         .findAll { it instanceof org.gradle.api.artifacts.repositories.MavenArtifactRepository }
                         .collect { [name: it.name, uri: it.url.toASCIIString()] }
                         .toSet()
@@ -31,6 +32,7 @@ class ConfigurePublishingIntegrationSpec extends IntegrationSpec {
             }
 
             tasks.register('discoverPublications') {
+                def d = project.projectDir
                 doLast {
                     def publications = publishing.publications.collectEntries {
                         [(it.name): [
@@ -41,10 +43,9 @@ class ConfigurePublishingIntegrationSpec extends IntegrationSpec {
                                 artifacts   : it.artifacts.collect {
                                     [classifier: it.classifier,
                                      extension : it.extension,
-                                     file      : project.projectDir.toPath().relativize(it.file.toPath()).toString()]
+                                     file      : d.toPath().relativize(it.file.toPath()).toString()]
                                 }
-                        ]
-                        ]
+                        ]]
                     }
                     println groovy.json.JsonOutput.toJson([publications: publications])
                 }
@@ -111,8 +112,8 @@ class ConfigurePublishingIntegrationSpec extends IntegrationSpec {
             plugins {
                 id 'org.jenkins-ci.jpi'
                 id "maven-publish"
-                id "nebula.source-jar" version "17.0.5"
-                id "nebula.javadoc-jar" version "17.0.5"
+                id("com.netflix.nebula.source-jar") version "21.2.0"
+                id("com.netflix.nebula.javadoc-jar") version "21.2.0"
             }
             jenkinsPlugin {
                 configurePublishing = false
@@ -127,7 +128,7 @@ class ConfigurePublishingIntegrationSpec extends IntegrationSpec {
                             artifactId = '${projectName}'
                             version = '1.0'
                             artifact jar
-                            artifact sourceJar
+                            artifact sourcesJar
                             artifact javadocJar
                         }
                     }

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/ConfigureRepositoriesIntegrationSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/ConfigureRepositoriesIntegrationSpec.groovy
@@ -19,7 +19,7 @@ class ConfigureRepositoriesIntegrationSpec extends IntegrationSpec {
 
             tasks.create('discoverRepos') {
                 doLast {
-                    def repos = project.repositories
+                    def repos = repositories
                         .findAll { it instanceof org.gradle.api.artifacts.repositories.MavenArtifactRepository }
                         .collect { [name: it.name, uri: it.url.toASCIIString()] }
                         .toSet()

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/IntegrationSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/IntegrationSpec.groovy
@@ -29,7 +29,7 @@ class IntegrationSpec extends Specification {
         if (gradleVersion != GradleVersion.current()) {
             return runner.withGradleVersion(gradleVersion.version)
         }
-        runner
+        runner.withArguments('-Dorg.gradle.deprecation.trace=true')
     }
 
     static GradleVersion getGradleVersionForTest() {

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JenkinsVersionIntegrationSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JenkinsVersionIntegrationSpec.groovy
@@ -29,9 +29,12 @@ class JenkinsVersionIntegrationSpec extends IntegrationSpec {
                 @Input
                 String config
 
+                @Internal
+                def configurations = project.configurations
+
                 @TaskAction
                 void run() {
-                    project.configurations.getByName(config).resolvedConfiguration.firstLevelModuleDependencies.each {
+                    configurations.getByName(config).resolvedConfiguration.firstLevelModuleDependencies.each {
                         println(it.module.id)
                     }
                 }
@@ -51,7 +54,7 @@ class JenkinsVersionIntegrationSpec extends IntegrationSpec {
                 jenkinsVersion = '${version}'
             }
             repositories {
-                maven { url 'https://repo.jenkins-ci.org/incrementals' }
+                maven { url = 'https://repo.jenkins-ci.org/incrementals' }
             }
             """.stripIndent()
         TestSupport.PASSING_TEST.writeTo(inProjectDir('src/test/java'))
@@ -82,7 +85,7 @@ class JenkinsVersionIntegrationSpec extends IntegrationSpec {
                 jenkinsVersion = '${version}'
             }
             repositories {
-                maven { url 'https://repo.jenkins-ci.org/incrementals' }
+                maven { url = 'https://repo.jenkins-ci.org/incrementals' }
             }
             """.stripIndent()
         def target = inProjectDir('target')

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiIntegrationSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiIntegrationSpec.groovy
@@ -89,9 +89,7 @@ class JpiIntegrationSpec extends IntegrationSpec {
         'fileExtension = null'  | 'hpi'
         'fileExtension = ""'    | 'hpi'
         'fileExtension = "hpi"' | 'hpi'
-        'fileExtension "hpi"'   | 'hpi'
         'fileExtension = "jpi"' | 'jpi'
-        'fileExtension "jpi"'   | 'jpi'
     }
 
     def 'uses project name as shortName by default'() {
@@ -151,9 +149,7 @@ class JpiIntegrationSpec extends IntegrationSpec {
         where:
         shortName                     | expected
         "shortName = 'apple'"         | 'apple'
-        "shortName 'banana'"          | 'banana'
         "shortName = 'carrot-plugin'" | 'carrot-plugin'
-        "shortName 'date'"            | 'date'
     }
 
     def 'should bundle classes as JAR file into HPI file'() {
@@ -401,8 +397,8 @@ class JpiIntegrationSpec extends IntegrationSpec {
             }
             repositories {
                 ivy {
-                    name 'EmbeddedIvy'
-                    url '${embeddedRepo}'
+                    name = 'EmbeddedIvy'
+                    url = '${embeddedRepo}'
                     layout 'maven'
                 }
             }

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPomCustomizerIntegrationSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/JpiPomCustomizerIntegrationSpec.groovy
@@ -1,5 +1,6 @@
 package org.jenkinsci.gradle.plugins.jpi
 
+import groovy.json.JsonBuilder
 import groovy.json.JsonSlurper
 import org.xmlunit.builder.DiffBuilder
 import org.xmlunit.builder.Input
@@ -19,7 +20,7 @@ class JpiPomCustomizerIntegrationSpec extends IntegrationSpec {
                 id 'org.jenkins-ci.jpi'
             }
             group = 'org'
-            version '1.0'
+            version = '1.0'
             java {
                 sourceCompatibility = JavaVersion.VERSION_1_8
                 targetCompatibility = JavaVersion.VERSION_1_8
@@ -114,8 +115,8 @@ class JpiPomCustomizerIntegrationSpec extends IntegrationSpec {
             }
             repositories {
                 maven {
-                    name 'lorem-ipsum'
-                    url 'https://repo.lorem-ipsum.org/'
+                    name = 'lorem-ipsum'
+                    url = 'https://repo.lorem-ipsum.org/'
                 }
             }
             """.stripIndent()
@@ -155,8 +156,8 @@ class JpiPomCustomizerIntegrationSpec extends IntegrationSpec {
             }
             repositories {
                 maven {
-                    name 'lorem-ipsum'
-                    url 'https://repo.lorem-ipsum.org/'
+                    name = 'lorem-ipsum'
+                    url = 'https://repo.lorem-ipsum.org/'
                 }
             }
             """.stripIndent()
@@ -320,7 +321,7 @@ class JpiPomCustomizerIntegrationSpec extends IntegrationSpec {
             }
             java {
                 registerFeature('credentials') {
-                    usingSourceSet(sourceSets.main)
+                    usingSourceSet(sourceSets.create('credentials'))
                 }
             }
             dependencies {
@@ -390,7 +391,7 @@ class JpiPomCustomizerIntegrationSpec extends IntegrationSpec {
     private static boolean compareJson(String fileName, File actual) {
         def actualJson = removeChangingDetails(new JsonSlurper().parseText(actual.text))
         def expectedJson = new JsonSlurper().parseText(readResource(fileName))
-        assert actualJson == expectedJson
+        assert new JsonBuilder(actualJson).toPrettyString() == new JsonBuilder(expectedJson).toPrettyString()
         actualJson == expectedJson
     }
 
@@ -417,7 +418,7 @@ class JpiPomCustomizerIntegrationSpec extends IntegrationSpec {
 
     void generatePom() {
         gradleRunner()
-        .withArguments('generatePomFileForMavenJpiPublication', 'generateMetadataFileForMavenJpiPublication', '-s')
+                .withArguments('generatePomFileForMavenJpiPublication', 'generateMetadataFileForMavenJpiPublication', '-s')
                 .build()
     }
 

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/server/JenkinsServerTaskSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi/server/JenkinsServerTaskSpec.groovy
@@ -24,7 +24,7 @@ class JenkinsServerTaskSpec extends IntegrationSpec {
                 jenkinsVersion = '$jenkinsVersion'
             }
             dependencies {
-                jenkinsServer 'org.jenkins-ci.plugins:git:3.12.1'
+                jenkinsServer 'org.jenkins-ci.plugins:git:5.4.0'
                 implementation 'com.squareup.okio:okio:2.4.3'
             }
             """.stripIndent()
@@ -52,12 +52,13 @@ class JenkinsServerTaskSpec extends IntegrationSpec {
 
         then:
         output.contains("/jenkins-war-${jenkinsVersion}.war")
-        output.contains('webroot: System.getProperty("JENKINS_HOME")')
+        output.contains('webroot: ')
+        output.contains('Jenkins is fully up and running')
 
         where:
         jenkinsVersion | additionalPlugin
         '2.462.3'      | ''
-        '2.462.3'      | "id 'org.jetbrains.kotlin.jvm' version '1.6.10'"
+        '2.462.3'      | "id 'org.jetbrains.kotlin.jvm' version '1.9.25'"
     }
 
     private static String path(File file) {

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/manifest/GeneratePluginDependenciesManifestTaskIntegrationSpec.groovy
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/manifest/GeneratePluginDependenciesManifestTaskIntegrationSpec.groovy
@@ -44,7 +44,7 @@ class GeneratePluginDependenciesManifestTaskIntegrationSpec extends IntegrationS
             $BUILD_FILE
             java {
                 registerFeature('ant') {
-                    usingSourceSet(sourceSets.main)
+                    usingSourceSet(sourceSets.create('ant'))
                 }
             }
             dependencies {
@@ -65,7 +65,7 @@ class GeneratePluginDependenciesManifestTaskIntegrationSpec extends IntegrationS
             $BUILD_FILE
             java {
                 registerFeature('ant') {
-                    usingSourceSet(sourceSets.main)
+                    usingSourceSet(sourceSets.create('ant'))
                 }
             }
             dependencies {
@@ -104,7 +104,7 @@ class GeneratePluginDependenciesManifestTaskIntegrationSpec extends IntegrationS
             $BUILD_FILE
             java {
                 registerFeature('ant') {
-                    usingSourceSet(sourceSets.main)
+                    usingSourceSet(sourceSets.create('ant'))
                 }
             }
             dependencies {
@@ -125,7 +125,7 @@ class GeneratePluginDependenciesManifestTaskIntegrationSpec extends IntegrationS
             $BUILD_FILE
             java {
                 registerFeature('ant') {
-                    usingSourceSet(sourceSets.main)
+                    usingSourceSet(sourceSets.create('ant'))
                 }
             }
             dependencies {
@@ -153,7 +153,7 @@ class GeneratePluginDependenciesManifestTaskIntegrationSpec extends IntegrationS
             $BUILD_FILE
             java {
                 registerFeature('ant') {
-                    usingSourceSet(sourceSets.main)
+                    usingSourceSet(sourceSets.create('ant'))
                 }
             }
             dependencies {

--- a/src/test/resources/org/jenkinsci/gradle/plugins/jpi/licenseInfoWithKotlin.gradle
+++ b/src/test/resources/org/jenkinsci/gradle/plugins/jpi/licenseInfoWithKotlin.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.3.70'
+    id 'org.jetbrains.kotlin.jvm' version '1.9.25'
     id 'org.jenkins-ci.jpi'
 }
 

--- a/src/test/resources/org/jenkinsci/gradle/plugins/jpi/licensesWithKotlin.xml
+++ b/src/test/resources/org/jenkinsci/gradle/plugins/jpi/licensesWithKotlin.xml
@@ -11,12 +11,8 @@
         <l:description>XMLUnit compares a control XML document to a test document or the result of a transformation, validates documents, and compares the results of XPath expressions.</l:description>
         <l:license url='http://xmlunit.svn.sourceforge.net/viewvc/*checkout*/xmlunit/trunk/xmlunit/LICENSE.txt' name='BSD License'/>
     </l:dependency>
-    <l:dependency version='1.3.61' artifactId='kotlin-stdlib' groupId='org.jetbrains.kotlin' name='org.jetbrains.kotlin:kotlin-stdlib' url='https://kotlinlang.org/'>
-        <l:description>Kotlin Standard Library for JVM</l:description>
-        <l:license url='http://www.apache.org/licenses/LICENSE-2.0.txt' name='The Apache License, Version 2.0' />
-    </l:dependency>
-    <l:dependency version='1.3.61' artifactId='kotlin-stdlib-common' groupId='org.jetbrains.kotlin' name='org.jetbrains.kotlin:kotlin-stdlib-common' url='https://kotlinlang.org/'>
-        <l:description>Kotlin Common Standard Library</l:description>
+    <l:dependency version='1.9.25' artifactId='kotlin-stdlib' groupId='org.jetbrains.kotlin' name='Kotlin Stdlib' url='https://kotlinlang.org/'>
+        <l:description>Kotlin Standard Library</l:description>
         <l:license url='http://www.apache.org/licenses/LICENSE-2.0.txt' name='The Apache License, Version 2.0' />
     </l:dependency>
     <l:dependency version='13.0' artifactId='annotations' groupId='org.jetbrains' name='IntelliJ IDEA Annotations' url='http://www.jetbrains.org'>

--- a/src/test/resources/org/jenkinsci/gradle/plugins/jpi/optional-plugin-dependencies-module.json
+++ b/src/test/resources/org/jenkinsci/gradle/plugins/jpi/optional-plugin-dependencies-module.json
@@ -77,8 +77,8 @@
       ],
       "files": [
         {
-          "name": "test-1.0.jar",
-          "url": "test-1.0.jar",
+          "name": "test-1.0-credentials.jar",
+          "url": "test-1.0-credentials.jar",
           "size": "",
           "sha512": "",
           "sha256": "",
@@ -114,8 +114,8 @@
       ],
       "files": [
         {
-          "name": "test-1.0.jar",
-          "url": "test-1.0.jar",
+          "name": "test-1.0-credentials.jar",
+          "url": "test-1.0-credentials.jar",
           "size": "",
           "sha512": "",
           "sha256": "",


### PR DESCRIPTION
While #254 upgraded the JDK, it missed out the rule in build.gradle.kts.
This change fixes that.

The minimum Gradle Version for JDK 17 is 7.3.
This updates the regression test to use that.

Also, updates the label in ci.yml.<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
