### PR TITLE
chore: Do not reference rules.groovy in rules-test.groovy

### DIFF
--- a/config/codenarc/rules-test.groovy
+++ b/config/codenarc/rules-test.groovy
@@ -1,18 +1,121 @@
 ruleset {
+    ruleset('rulesets/basic.xml')
+
+    ruleset('rulesets/braces.xml')
+
+    ruleset('rulesets/concurrency.xml')
+
+    ruleset('rulesets/convention.xml') {
+        // we don't care for now
+        exclude 'FieldTypeRequired'
+        // we don't care for now
+        exclude 'MethodParameterTypeRequired\t'
+        // we don't care for now
+        exclude 'MethodReturnTypeRequired'
+        // we don't care for now
+        exclude 'NoDef'
+        // we don't care for now
+        exclude 'VariableTypeRequired'
+
+        exclude 'CompileStatic'
+        exclude 'ImplicitClosureParameter'
+        exclude 'ImplicitReturnStatement'
+        exclude 'PublicMethodsBeforeNonPublicMethods'
+        exclude 'StaticFieldsBeforeInstanceFields'
+        exclude 'StaticMethodsBeforeInstanceMethods'
+
+    }
+
+    ruleset('rulesets/design.xml') {
+        // does not necessarily lead to better code
+        exclude 'Instanceof'
+        // needed for Worker Api
+        exclude 'AbstractClassWithoutAbstractMethod'
+    }
+
+    ruleset('rulesets/dry.xml') {
+        // does not necessarily lead to better code
+        exclude 'DuplicateListLiteral'
+        // does not necessarily lead to better code
+        exclude 'DuplicateMapLiteral'
+        // does not necessarily lead to better code
+        exclude 'DuplicateNumberLiteral'
+        // does not necessarily lead to better code
+        exclude 'DuplicateStringLiteral'
+    }
+
+    // these rules cause compilation failure warnings
+    // ruleset('rulesets/enhanced.xml')
+
+    ruleset('rulesets/exceptions.xml')
+
+    ruleset('rulesets/formatting.xml') {
+        // enforce at least one space after map entry colon
+        SpaceAroundMapEntryColon {
+            characterAfterColonRegex = /\s/
+            characterBeforeColonRegex = /./
+        }
+
+        // we don't care for now
+        exclude 'ClassJavadoc'
+        exclude 'ClassStartsWithBlankLine'
+        exclude 'ClassEndsWithBlankLine'
+        // No line length limit for tests
+        exclude 'LineLength'
+    }
+
+    ruleset('rulesets/generic.xml')
+
+    ruleset('rulesets/groovyism.xml')
+
+    ruleset('rulesets/imports.xml') {
+        // we order static imports after other imports because that's the default style in IDEA
+        MisorderedStaticImports {
+            comesBefore = false
+        }
+    }
+
+    ruleset('rulesets/logging.xml')
+
+    ruleset('rulesets/naming.xml') {
+        // Gradle encourages violations of this rule
+        exclude 'ConfusingMethodName'
+        // Spock encourages to violate this rule
+        exclude 'MethodName'
+    }
+
+    ruleset('rulesets/security.xml') {
+        // we don't care for the Enterprise Java Bean specification here
+        exclude 'JavaIoPackageAccess'
+    }
+
+    ruleset('rulesets/serialization.xml')
+
+    ruleset('rulesets/size.xml') {
+        NestedBlockDepth {
+            maxNestedBlockDepth = 6
+        }
+
+        // we don't care for now
+        exclude 'AbcMetric'
+        // we have no Cobertura coverage file yet
+        exclude 'CrapMetric'
+        // we don't care for now
+        exclude 'MethodSize'
+    }
+
+    ruleset('rulesets/unnecessary.xml') {
+        exclude 'UnnecessaryGetter'
+        // Spock ...
+        exclude 'UnnecessaryBooleanExpression'
+    }
+
+    ruleset('rulesets/unused.xml')
+
     ruleset('rulesets/junit.xml') {
         // Spock ...
         exclude 'JUnitPublicNonTestMethod'
         exclude 'JUnitPublicProperty'
     }
 
-    ruleset('file:config/codenarc/rules.groovy') {
-        // Spock encourages to violate this rule
-        exclude 'MethodName'
-        // OK for tests
-        exclude 'Instanceof'
-        // No line length limit for tests
-        exclude 'LineLength'
-        // Spock ...
-        exclude 'UnnecessaryBooleanExpression'
-    }
 }


### PR DESCRIPTION
This seems to be a behavior change in Gradle 8.

This change brings in all the config from rules.groovy into rules-test.groovy and appends what was in rules-test.groovy on it.

On Gradle 8, it used to fail with

```
> Task :codenarcTest FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':codenarcTest'.
> A failure occurred while executing org.gradle.api.plugins.quality.internal.CodeNarcAction
   > java.io.FileNotFoundException: rules.groovy (No such file or directory)
```

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
