### PR TITLE
feat: Configure sezpoz

### DIFF
--- a/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
+++ b/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
@@ -113,11 +113,20 @@ public class V2JpiPlugin implements Plugin<Project> {
                     @Override
                     public void execute(@NotNull DependencySet dependencies) {
                         dependencies.add(project.getDependencies()
-                                .create("org.jenkins-ci.main:jenkins-war:" + project.getProperties().get(JENKINS_VERSION_PROPERTY)));
+                                .create("org.jenkins-ci.main:jenkins-war:" + getJenkinsVersion(project)));
                     }
                 });
             }
         });
+    }
+
+    private static String getJenkinsVersion(@NotNull Project project) {
+        Map<String, ?> projectProperties = project.getProperties();
+        if (projectProperties.containsKey(JENKINS_VERSION_PROPERTY)) {
+            return projectProperties.get(JENKINS_VERSION_PROPERTY).toString();
+        } else {
+            return "latest.release";
+        }
     }
 
     @NotNull
@@ -163,7 +172,7 @@ public class V2JpiPlugin implements Plugin<Project> {
                     public void execute(@NotNull DependencySet dependencies) {
                         addJarDependenciesFromJpis(project, jenkinsPlugin, dependencies);
                         dependencies.add(project.getDependencies()
-                                .create("org.jenkins-ci.main:jenkins-core:" + project.getProperties().get(JENKINS_VERSION_PROPERTY)));
+                                .create("org.jenkins-ci.main:jenkins-core:" + getJenkinsVersion(project)));
                     }
                 });
             }
@@ -233,7 +242,7 @@ public class V2JpiPlugin implements Plugin<Project> {
                 manifest.getAttributes().put("Short-Name", project.getName());
                 manifest.getAttributes().put("Long-Name", Optional.ofNullable(project.getDescription()).orElse(project.getName()));
 
-                manifest.getAttributes().put("Jenkins-Version", project.getProperties().get(JENKINS_VERSION_PROPERTY));
+                manifest.getAttributes().put("Jenkins-Version", getJenkinsVersion(project));
             }
         });
     }

--- a/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
+++ b/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
@@ -11,6 +11,8 @@ import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.java.archives.Manifest;
+import org.gradle.api.plugins.GroovyBasePlugin;
+import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaLibraryPlugin;
 import org.gradle.api.plugins.WarPlugin;
 import org.gradle.api.specs.Spec;
@@ -18,6 +20,8 @@ import org.gradle.api.tasks.Copy;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.War;
+import org.gradle.api.tasks.compile.GroovyCompile;
+import org.gradle.api.tasks.compile.JavaCompile;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -26,6 +30,7 @@ import java.util.stream.Collectors;
 @SuppressWarnings("Convert2Lambda")
 public class V2JpiPlugin implements Plugin<Project> {
 
+    public static final String ANNOTATION_PROCESSOR_CONFIGURATION = "annotationProcessor";
     public static final String COMPILE_ONLY_CONFIGURATION = "compileOnly";
     public static final String JENKINS_PLUGIN_COMPILE_ONLY_CONFIGURATION = "jenkinsPluginCompileOnly";
     public static final String JENKINS_PLUGIN_CONFIGURATION = "jenkinsPlugin";
@@ -54,6 +59,47 @@ public class V2JpiPlugin implements Plugin<Project> {
         final var projectRoot = project.getLayout().getProjectDirectory().getAsFile().getAbsolutePath();
         final var prepareServer = createPrepareServerTask(project, projectRoot, serverJenkinsPlugin);
         var serverTask = createServerTask(project, serverTaskClasspath, projectRoot, prepareServer);
+        configureSezpoz(project);
+    }
+
+    private static void configureSezpoz(@NotNull Project project) {
+        project.getPlugins().withType(JavaBasePlugin.class, new Action<>() {
+            @Override
+            public void execute(@NotNull JavaBasePlugin plugin) {
+                project.getTasks().named("compileJava", JavaCompile.class).configure(new Action<>() {
+                    @Override
+                    public void execute(@NotNull JavaCompile javaCompile) {
+                        javaCompile.getOptions().getCompilerArgs().add("-Asezpoz.quiet=true");
+                    }
+                });
+                project.getTasks().withType(JavaCompile.class, new Action<>() {
+                    @Override
+                    public void execute(@NotNull JavaCompile javaCompile) {
+                        javaCompile.getOptions().getCompilerArgs().add("-parameters");
+                    }
+                });
+            }
+        });
+
+        project.getPlugins().withType(GroovyBasePlugin.class, new Action<>() {
+            @Override
+            public void execute(@NotNull GroovyBasePlugin plugin) {
+                project.getTasks().named("compileGroovy", GroovyCompile.class).configure(new Action<>() {
+                    @Override
+                    public void execute(@NotNull GroovyCompile groovyCompile) {
+                        groovyCompile.getOptions().getCompilerArgs().add("-Asezpoz.quiet=true");
+                    }
+                });
+                project.getTasks().withType(GroovyCompile.class, new Action<>() {
+                    @Override
+                    public void execute(@NotNull GroovyCompile groovyCompile) {
+                        groovyCompile.getGroovyOptions().setJavaAnnotationProcessing(true);
+                    }
+                });
+            }
+        });
+
+        project.getDependencies().add(ANNOTATION_PROCESSOR_CONFIGURATION, project.getDependencies().create("net.java.sezpoz:sezpoz:1.13"));
     }
 
     @NotNull


### PR DESCRIPTION

This causes classes annotated with `@Extension` to be recognized using SPI in a way Jenkins
loads them correctly.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/jenkinsci/gradle-jpi-plugin/pull/274).
* #277
* #276
* #275
* __->__ #274
* #273