### PR TITLE
chore: Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ build/
 /classes
 /out
 /bin
+.kotlin/
+.vscode/


### PR DESCRIPTION
Using VSCode sometimes causes the `.vscode` dir to be created.
Gradle sometimes causes errors to be logged to `.kotlin`.
