### PR TITLE
feat: Make plugin dependencies work with multimodule plugins

### DIFF
--- a/src/main/java/org/jenkinsci/gradle/plugins/jpi2/ConfigurePrepareServerAction.java
+++ b/src/main/java/org/jenkinsci/gradle/plugins/jpi2/ConfigurePrepareServerAction.java
@@ -19,13 +19,15 @@ import java.util.Comparator;
 class ConfigurePrepareServerAction implements Action<Sync> {
     private final TaskProvider<?> jpiTaskProvider;
     private final String projectRoot;
-    private final Configuration configuration;
+    private final Configuration defaultRuntime;
+    private final Configuration runtimeClasspath;
     private final Project project;
 
-    public ConfigurePrepareServerAction(TaskProvider<?> jpiTaskProvider, String projectRoot, Configuration configuration, Project project) {
+    public ConfigurePrepareServerAction(TaskProvider<?> jpiTaskProvider, String projectRoot, Configuration defaultRuntime, Configuration runtimeClasspath, Project project) {
         this.jpiTaskProvider = jpiTaskProvider;
         this.projectRoot = projectRoot;
-        this.configuration = configuration;
+        this.defaultRuntime = defaultRuntime;
+        this.runtimeClasspath = runtimeClasspath;
         this.project = project;
     }
 
@@ -36,7 +38,7 @@ class ConfigurePrepareServerAction implements Action<Sync> {
         sync.from(jpi.getOutputs().getFiles())
                 .into(projectRoot + "/work/plugins");
 
-        configuration.getResolvedConfiguration().getResolvedArtifacts()
+        defaultRuntime.getResolvedConfiguration().getResolvedArtifacts()
                 .stream()
                 .filter(artifact -> HpiMetadataRule.PLUGIN_PACKAGINGS.contains(artifact.getExtension()))
                 .sorted(Comparator.comparing(ResolvedArtifact::getName))
@@ -51,7 +53,7 @@ class ConfigurePrepareServerAction implements Action<Sync> {
                             }
                         }));
 
-        configuration.getResolvedConfiguration().getResolvedArtifacts()
+        runtimeClasspath.getResolvedConfiguration().getResolvedArtifacts()
                 .stream()
                 .filter(it -> it.getId().getComponentIdentifier() instanceof ProjectComponentIdentifier)
                 .sorted(Comparator.comparing(ResolvedArtifact::getName))

--- a/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
+++ b/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
@@ -100,7 +100,7 @@ public class V2JpiPlugin implements Plugin<Project> {
         });
 
         final var projectRoot = project.getLayout().getProjectDirectory().getAsFile().getAbsolutePath();
-        final var prepareServer = createPrepareServerTask(project, projectRoot, defaultRuntime, jpiTask);
+        final var prepareServer = createPrepareServerTask(project, projectRoot, defaultRuntime, runtimeClasspath, jpiTask);
 
         var serverTask = project.getTasks().register("server", JavaExec.class, new ServerAction(serverTaskClasspath, projectRoot, prepareServer));
         project.getPlugins().withType(JavaBasePlugin.class, new SezpozJavaAction(project));
@@ -159,8 +159,8 @@ public class V2JpiPlugin implements Plugin<Project> {
     }
 
     @NotNull
-    private static TaskProvider<?> createPrepareServerTask(@NotNull Project project, String projectRoot, Configuration serverJenkinsPlugin, TaskProvider<?> jpiTaskProvider) {
-        return project.getTasks().register("prepareServer", Sync.class, new ConfigurePrepareServerAction(jpiTaskProvider, projectRoot, serverJenkinsPlugin, project));
+    private static TaskProvider<?> createPrepareServerTask(@NotNull Project project, String projectRoot, Configuration defaultRuntime, Configuration runtimeClasspath, TaskProvider<?> jpiTaskProvider) {
+        return project.getTasks().register("prepareServer", Sync.class, new ConfigurePrepareServerAction(jpiTaskProvider, projectRoot, defaultRuntime, runtimeClasspath, project));
     }
 
     @NotNull

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi2/V2IntegrationTest.java
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi2/V2IntegrationTest.java
@@ -557,6 +557,10 @@ class V2IntegrationTest {
 
         // when
         testServerStarts(gradleRunner, ":plugin-four:server");
+
+        // then
+        var pluginThreeJpi = ith.inProjectDir("plugin-four/work/plugins/plugin-three-1.0.0.jpi"); // TODO Remove version from here
+        assertThat(pluginThreeJpi).exists();
     }
 
     @Test


### PR DESCRIPTION
The version number is hard to remove, but can be cleaned up separately.
