### PR TITLE
fix: Rename JPI files correctly

### DIFF
--- a/src/main/java/org/jenkinsci/gradle/plugins/jpi2/ConfigurePrepareServerAction.java
+++ b/src/main/java/org/jenkinsci/gradle/plugins/jpi2/ConfigurePrepareServerAction.java
@@ -35,23 +35,21 @@ class ConfigurePrepareServerAction implements Action<Sync> {
     public void execute(@NotNull Sync sync) {
         var jpi = jpiTaskProvider.get();
 
-        sync.from(jpi.getOutputs().getFiles())
-                .into(projectRoot + "/work/plugins");
+        sync.into(projectRoot + "/work/plugins");
+
+        sync.from(jpi);
 
         defaultRuntime.getResolvedConfiguration().getResolvedArtifacts()
                 .stream()
                 .filter(artifact -> HpiMetadataRule.PLUGIN_PACKAGINGS.contains(artifact.getExtension()))
                 .sorted(Comparator.comparing(ResolvedArtifact::getName))
                 .forEach(artifact ->
-                        sync.from(artifact.getFile()).into(projectRoot + "/work/plugins").rename(new Transformer<>() {
-                            @NotNull
-                            @Override
-                            public String transform(@NotNull String s) {
-                                return s.replace("-" + artifact.getModuleVersion().getId().getVersion(), "") // remove version from filename
-                                        .replace(".hpi", ".jpi") // change extension to jpi to prevent warnings
-                                        ;
-                            }
-                        }));
+                        sync.from(artifact.getFile())
+                                .rename(new DropVersionTransformer(
+                                        artifact.getModuleVersion().getId().getName(),
+                                        artifact.getModuleVersion().getId().getVersion()
+                                ))
+                );
 
         runtimeClasspath.getResolvedConfiguration().getResolvedArtifacts()
                 .stream()
@@ -60,7 +58,6 @@ class ConfigurePrepareServerAction implements Action<Sync> {
                 .forEach(it -> {
                     ComponentIdentifier componentIdentifier = it.getId().getComponentIdentifier();
                     if (componentIdentifier instanceof ProjectComponentIdentifier p) {
-                        System.err.println("Dependency project: " + p.getProjectPath());
                         var dependencyProject = project.getRootProject().getAllprojects().stream()
                                 .filter(c -> c.getPath().equals(p.getProjectPath()))
                                 .findFirst();
@@ -69,10 +66,27 @@ class ConfigurePrepareServerAction implements Action<Sync> {
 
                         var jpiTask = dependencyProject.get().getTasks().findByName("jpi");
                         if (jpiTask != null) {
-                            sync.from(jpiTask.getOutputs().getFiles())
-                                    .into(projectRoot + "/work/plugins");
+                            sync.from(jpiTask);
                         }
                     }
                 });
+    }
+
+    private static class DropVersionTransformer implements Transformer<String, String> {
+        private final String name;
+        private final String version;
+
+        public DropVersionTransformer(String name, String version) {
+            this.name = name;
+            this.version = version;
+        }
+
+        @NotNull
+        @Override
+        public String transform(@NotNull String s) {
+            return s.replace(name + "-" + version, name) // remove version from filename
+                    .replace(".hpi", ".jpi") // change extension to jpi to prevent warnings
+                    ;
+        }
     }
 }


### PR DESCRIPTION
We had a bug when you had a dependency called `foo-1.0.2.jpi` and another one called `bar-1.0.jpi`.

The older behavior would process the rename rule for `-1.0 -> EMPTY` first and then `-1.0.2 -> EMPTY`.
That replaced `bar-1.0.jpi` with `bar.jpi`.
But failed with foo and left us with `foo.2.jpi`.

Gradle stores a list of replacements on the same sync object.

This change stores full names as replacements rather than just versions.
