### PR TITLE
customize serverTaskClasspath

### DIFF
--- a/src/main/java/org/jenkinsci/gradle/plugins/jpi2/ConfigurePrepareServerAction.java
+++ b/src/main/java/org/jenkinsci/gradle/plugins/jpi2/ConfigurePrepareServerAction.java
@@ -19,13 +19,15 @@ import java.util.Comparator;
 class ConfigurePrepareServerAction implements Action<Sync> {
     private final TaskProvider<?> jpiTaskProvider;
     private final String projectRoot;
-    private final Configuration configuration;
+    private final Configuration defaultRuntime;
+    private final Configuration runtimeClasspath;
     private final Project project;
 
-    public ConfigurePrepareServerAction(TaskProvider<?> jpiTaskProvider, String projectRoot, Configuration configuration, Project project) {
+    public ConfigurePrepareServerAction(TaskProvider<?> jpiTaskProvider, String projectRoot, Configuration defaultRuntime, Configuration runtimeClasspath, Project project) {
         this.jpiTaskProvider = jpiTaskProvider;
         this.projectRoot = projectRoot;
-        this.configuration = configuration;
+        this.defaultRuntime = defaultRuntime;
+        this.runtimeClasspath = runtimeClasspath;
         this.project = project;
     }
 
@@ -36,7 +38,7 @@ class ConfigurePrepareServerAction implements Action<Sync> {
         sync.from(jpi.getOutputs().getFiles())
                 .into(projectRoot + "/work/plugins");
 
-        configuration.getResolvedConfiguration().getResolvedArtifacts()
+        defaultRuntime.getResolvedConfiguration().getResolvedArtifacts()
                 .stream()
                 .filter(artifact -> HpiMetadataRule.PLUGIN_PACKAGINGS.contains(artifact.getExtension()))
                 .sorted(Comparator.comparing(ResolvedArtifact::getName))
@@ -51,7 +53,7 @@ class ConfigurePrepareServerAction implements Action<Sync> {
                             }
                         }));
 
-        configuration.getResolvedConfiguration().getResolvedArtifacts()
+        runtimeClasspath.getResolvedConfiguration().getResolvedArtifacts()
                 .stream()
                 .filter(it -> it.getId().getComponentIdentifier() instanceof ProjectComponentIdentifier)
                 .sorted(Comparator.comparing(ResolvedArtifact::getName))

--- a/src/main/java/org/jenkinsci/gradle/plugins/jpi2/ConfigurePrepareServerAction.java
+++ b/src/main/java/org/jenkinsci/gradle/plugins/jpi2/ConfigurePrepareServerAction.java
@@ -35,23 +35,21 @@ class ConfigurePrepareServerAction implements Action<Sync> {
     public void execute(@NotNull Sync sync) {
         var jpi = jpiTaskProvider.get();
 
-        sync.from(jpi.getOutputs().getFiles())
-                .into(projectRoot + "/work/plugins");
+        sync.into(projectRoot + "/work/plugins");
+
+        sync.from(jpi);
 
         defaultRuntime.getResolvedConfiguration().getResolvedArtifacts()
                 .stream()
                 .filter(artifact -> HpiMetadataRule.PLUGIN_PACKAGINGS.contains(artifact.getExtension()))
                 .sorted(Comparator.comparing(ResolvedArtifact::getName))
                 .forEach(artifact ->
-                        sync.from(artifact.getFile()).into(projectRoot + "/work/plugins").rename(new Transformer<>() {
-                            @NotNull
-                            @Override
-                            public String transform(@NotNull String s) {
-                                return s.replace("-" + artifact.getModuleVersion().getId().getVersion(), "") // remove version from filename
-                                        .replace(".hpi", ".jpi") // change extension to jpi to prevent warnings
-                                        ;
-                            }
-                        }));
+                        sync.from(artifact.getFile())
+                                .rename(new DropVersionTransformer(
+                                        artifact.getModuleVersion().getId().getName(),
+                                        artifact.getModuleVersion().getId().getVersion()
+                                ))
+                );
 
         runtimeClasspath.getResolvedConfiguration().getResolvedArtifacts()
                 .stream()
@@ -60,7 +58,6 @@ class ConfigurePrepareServerAction implements Action<Sync> {
                 .forEach(it -> {
                     ComponentIdentifier componentIdentifier = it.getId().getComponentIdentifier();
                     if (componentIdentifier instanceof ProjectComponentIdentifier p) {
-                        System.err.println("Dependency project: " + p.getProjectPath());
                         var dependencyProject = project.getRootProject().getAllprojects().stream()
                                 .filter(c -> c.getPath().equals(p.getProjectPath()))
                                 .findFirst();
@@ -69,10 +66,27 @@ class ConfigurePrepareServerAction implements Action<Sync> {
 
                         var jpiTask = dependencyProject.get().getTasks().findByName("jpi");
                         if (jpiTask != null) {
-                            sync.from(jpiTask.getOutputs().getFiles())
-                                    .into(projectRoot + "/work/plugins");
+                            sync.from(jpiTask);
                         }
                     }
                 });
+    }
+
+    private static class DropVersionTransformer implements Transformer<String, String> {
+        private final String name;
+        private final String version;
+
+        public DropVersionTransformer(String name, String version) {
+            this.name = name;
+            this.version = version;
+        }
+
+        @NotNull
+        @Override
+        public String transform(@NotNull String s) {
+            return s.replace(name + "-" + version, name) // remove version from filename
+                    .replace(".hpi", ".jpi") // change extension to jpi to prevent warnings
+                    ;
+        }
     }
 }

--- a/src/main/java/org/jenkinsci/gradle/plugins/jpi2/ServerAction.java
+++ b/src/main/java/org/jenkinsci/gradle/plugins/jpi2/ServerAction.java
@@ -32,6 +32,7 @@ class ServerAction implements Action<JavaExec> {
         spec.classpath(serverTaskClasspath);
         spec.setStandardOutput(System.out);
         spec.setErrorOutput(System.err);
+        spec.getMainClass().set("executable.Main");
         spec.args(List.of(
                 "--webroot=" + projectRoot + "/build/jenkins/war",
                 "--pluginroot=" + projectRoot + "/build/jenkins/plugins",

--- a/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
+++ b/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
@@ -100,7 +100,7 @@ public class V2JpiPlugin implements Plugin<Project> {
         });
 
         final var projectRoot = project.getLayout().getProjectDirectory().getAsFile().getAbsolutePath();
-        final var prepareServer = createPrepareServerTask(project, projectRoot, defaultRuntime, jpiTask);
+        final var prepareServer = createPrepareServerTask(project, projectRoot, defaultRuntime, runtimeClasspath, jpiTask);
 
         var serverTask = project.getTasks().register("server", JavaExec.class, new ServerAction(serverTaskClasspath, projectRoot, prepareServer));
         project.getPlugins().withType(JavaBasePlugin.class, new SezpozJavaAction(project));
@@ -159,8 +159,8 @@ public class V2JpiPlugin implements Plugin<Project> {
     }
 
     @NotNull
-    private static TaskProvider<?> createPrepareServerTask(@NotNull Project project, String projectRoot, Configuration serverJenkinsPlugin, TaskProvider<?> jpiTaskProvider) {
-        return project.getTasks().register("prepareServer", Sync.class, new ConfigurePrepareServerAction(jpiTaskProvider, projectRoot, serverJenkinsPlugin, project));
+    private static TaskProvider<?> createPrepareServerTask(@NotNull Project project, String projectRoot, Configuration defaultRuntime, Configuration runtimeClasspath, TaskProvider<?> jpiTaskProvider) {
+        return project.getTasks().register("prepareServer", Sync.class, new ConfigurePrepareServerAction(jpiTaskProvider, projectRoot, defaultRuntime, runtimeClasspath, project));
     }
 
     @NotNull

--- a/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
+++ b/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
@@ -119,13 +119,13 @@ public class V2JpiPlugin implements Plugin<Project> {
 
         dependencies.add("compileOnly", "org.jenkins-ci.main:jenkins-core:" + jenkinsVersion);
         dependencies.add("compileOnly", "jakarta.servlet:jakarta.servlet-api:5.0.0");
-        dependencies.add("serverTaskClasspath", "org.jenkins-ci.main:jenkins-war:" + jenkinsVersion);
+        dependencies.add(serverTaskClasspath.getName(), "org.jenkins-ci.main:jenkins-war:" + jenkinsVersion);
 
         dependencies.add("testImplementation", "org.jenkins-ci.main:jenkins-core:" + jenkinsVersion);
         dependencies.add("testImplementation", "org.jenkins-ci.main:jenkins-war:" + jenkinsVersion);
         dependencies.add("testImplementation", "org.jenkins-ci.main:jenkins-test-harness:" + testHarnessVersion);
 
-        dependencies.add("jenkinsCore", "org.jenkins-ci.main:jenkins-core:" + jenkinsVersion);
+        dependencies.add(jenkinsCore.getName(), "org.jenkins-ci.main:jenkins-core:" + jenkinsVersion);
 
         dependencies.getComponents().all(HpiMetadataRule.class);
         configurePublishing(project, jpiTask, defaultRuntime);

--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi2/V2IntegrationTest.java
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi2/V2IntegrationTest.java
@@ -557,6 +557,10 @@ class V2IntegrationTest {
 
         // when
         testServerStarts(gradleRunner, ":plugin-four:server");
+
+        // then
+        var pluginThreeJpi = ith.inProjectDir("plugin-four/work/plugins/plugin-three-1.0.0.jpi"); // TODO Remove version from here
+        assertThat(pluginThreeJpi).exists();
     }
 
     @Test


### PR DESCRIPTION
- **refactor: Make getDirectJarDependencies use less mutation**
- **feat: Make plugin dependencies work with multimodule plugins**
- **fix: Rename JPI files correctly**
- **feat: Allow customizing serverTaskClasspath**
