### PR TITLE
feat: Allow customizing serverTaskClasspath

### DIFF
--- a/src/main/java/org/jenkinsci/gradle/plugins/jpi2/ServerAction.java
+++ b/src/main/java/org/jenkinsci/gradle/plugins/jpi2/ServerAction.java
@@ -32,6 +32,7 @@ class ServerAction implements Action<JavaExec> {
         spec.classpath(serverTaskClasspath);
         spec.setStandardOutput(System.out);
         spec.setErrorOutput(System.err);
+        spec.getMainClass().set("executable.Main");
         spec.args(List.of(
                 "--webroot=" + projectRoot + "/build/jenkins/war",
                 "--pluginroot=" + projectRoot + "/build/jenkins/plugins",

--- a/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
+++ b/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
@@ -119,13 +119,13 @@ public class V2JpiPlugin implements Plugin<Project> {
 
         dependencies.add("compileOnly", "org.jenkins-ci.main:jenkins-core:" + jenkinsVersion);
         dependencies.add("compileOnly", "jakarta.servlet:jakarta.servlet-api:5.0.0");
-        dependencies.add("serverTaskClasspath", "org.jenkins-ci.main:jenkins-war:" + jenkinsVersion);
+        dependencies.add(serverTaskClasspath.getName(), "org.jenkins-ci.main:jenkins-war:" + jenkinsVersion);
 
         dependencies.add("testImplementation", "org.jenkins-ci.main:jenkins-core:" + jenkinsVersion);
         dependencies.add("testImplementation", "org.jenkins-ci.main:jenkins-war:" + jenkinsVersion);
         dependencies.add("testImplementation", "org.jenkins-ci.main:jenkins-test-harness:" + testHarnessVersion);
 
-        dependencies.add("jenkinsCore", "org.jenkins-ci.main:jenkins-core:" + jenkinsVersion);
+        dependencies.add(jenkinsCore.getName(), "org.jenkins-ci.main:jenkins-core:" + jenkinsVersion);
 
         dependencies.getComponents().all(HpiMetadataRule.class);
         configurePublishing(project, jpiTask, defaultRuntime);


### PR DESCRIPTION
We sometimes see this exception

```
2025-05-24 17:36:08.729+0000 [id=42]        WARNING hudson.model.Queue#load: Failed to load the queue file /Users/rsomasunderam/src/bb/CISYS/nflx-webservice-api-plugin/work/queue.xml
    java.lang.ClassNotFoundException: com/ctc/wstx/stax/WstxInputFactory
```

Fixing it requires adding this to dependencies

```
serverTaskClasspath "org.codehaus.woodstox:wstx-asl:3.2.7"
```

To support that, we need the `serverTaskClasspath` to support such a mode of execution.
