### PR TITLE
Adding shared port allocation service

### DIFF
--- a/src/main/java/org/jenkinsci/gradle/plugins/jpi2/PortAllocationService.java
+++ b/src/main/java/org/jenkinsci/gradle/plugins/jpi2/PortAllocationService.java
@@ -6,24 +6,32 @@ import org.gradle.api.services.BuildServiceParameters;
 import java.io.IOException;
 import java.net.ServerSocket;
 
+/**
+ * A Shared Gradle build service that provides port allocation functionality.
+ * This service finds and reserves free ports for use during the build process.
+ */
 public abstract class PortAllocationService implements BuildService<BuildServiceParameters.None> {
     private static final int RETRY_LIMIT = 3;
 
     public int findAndReserveFreePort() {
         for (int attempt = 0; attempt < RETRY_LIMIT; attempt++) {
-            int port = findFreePort();
-            if (port != -1) {
+            int port = findFreePort(attempt);
+            if (port > 0) {
                 return port;
             }
         }
+
         throw new IllegalStateException("Could not reserve a free port after " + RETRY_LIMIT + " attempts");
     }
 
-    private int findFreePort() {
+    private int findFreePort(int attempt) {
         try (ServerSocket socket = new ServerSocket(0)) {
             socket.setReuseAddress(true);
             return socket.getLocalPort();
         } catch (IOException e) {
+            if (attempt == RETRY_LIMIT - 1) {
+                throw new IllegalStateException("Could not find a free port after " + RETRY_LIMIT + " attempts. Exception at server socket creation.", e);
+            }
             return -1;
         }
     }

--- a/src/main/java/org/jenkinsci/gradle/plugins/jpi2/PortAllocationService.java
+++ b/src/main/java/org/jenkinsci/gradle/plugins/jpi2/PortAllocationService.java
@@ -1,0 +1,31 @@
+package org.jenkinsci.gradle.plugins.jpi2;
+
+import org.gradle.api.services.BuildService;
+import org.gradle.api.services.BuildServiceParameters;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+public abstract class PortAllocationService implements BuildService<BuildServiceParameters.None> {
+    private static final int RETRY_LIMIT = 3;
+
+    public int findAndReserveFreePort() {
+        for (int attempt = 0; attempt < RETRY_LIMIT; attempt++) {
+            int port = findFreePort();
+            if (port != -1) {
+                return port;
+            }
+        }
+        throw new IllegalStateException("Could not reserve a free port after " + RETRY_LIMIT + " attempts");
+    }
+
+    private int findFreePort() {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            socket.setReuseAddress(true);
+            return socket.getLocalPort();
+        } catch (IOException e) {
+            return -1;
+        }
+    }
+}
+

--- a/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
+++ b/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
@@ -10,6 +10,7 @@ import org.gradle.api.plugins.JavaBasePlugin;
 import org.gradle.api.plugins.JavaLibraryPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.services.BuildServiceRegistry;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin;
@@ -130,7 +131,11 @@ public class V2JpiPlugin implements Plugin<Project> {
         dependencies.getComponents().all(HpiMetadataRule.class);
         configurePublishing(project, jpiTask, defaultRuntime);
 
-        project.getTasks().register("testServer", new ConfigureTestServerAction(project));
+        BuildServiceRegistry buildServices = project.getGradle().getSharedServices();
+        var portAllocationService = buildServices.registerIfAbsent("portAllocation", PortAllocationService.class, spec -> {
+        });
+
+        project.getTasks().register("testServer", new ConfigureTestServerAction(project, portAllocationService.get()));
     }
 
     private static void configurePublishing(@NotNull Project project, TaskProvider<?> jpiTask, Configuration runtimeClasspath) {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Adding a shared port allocation service to help make finding free port more reliable.

### Testing done
Did not add any new tests as port allocation service replaces old find free port function. Both are essentially finding a free port but one uses a shared build service. Build is passing.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
