### PR TITLE
fix: exclude transitive jar dependencies provided by JPI plugins

### DIFF
--- a/src/test/groovy/org/jenkinsci/gradle/plugins/jpi2/V2IntegrationTest.java
+++ b/src/test/groovy/org/jenkinsci/gradle/plugins/jpi2/V2IntegrationTest.java
@@ -1118,6 +1118,58 @@ class V2IntegrationTest {
     }
 
     @Test
+    void skipsJarDependenciesOfPluginDependenciesFromTransients() throws IOException {
+        // given
+        var ith = new IntegrationTestHelper(tempDir, "8.14");
+        initBuild(ith);
+        Files.write((getBasePluginConfig() +/* language=kotlin */ """
+                dependencies {
+                    annotationProcessor("org.projectlombok:lombok:1.18.38")
+                    compileOnly("org.projectlombok:lombok:1.18.38")
+                    implementation("org.jenkins-ci.plugins:jackson2-api:2.19.0-404.vb_b_0fd2fea_e10") // This will provide jackson-databind transitively
+                    implementation("com.auth0:java-jwt:4.5.0") // This also depends on jackson-databind. We should include this jar, but not jackson-databind in the WEB-INF/lib dir.
+                }
+                configurations.getByName("compileClasspath").shouldResolveConsistentlyWith(configurations.getByName("runtimeClasspath"))
+                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+        ith.mkDirInProjectDir("src/main/java/com/example/plugin");
+        Files.write(/* language=java */ """
+                package com.example.plugin;
+                import lombok.*;
+                import hudson.Extension;
+                import jakarta.inject.Inject;
+                import hudson.model.RootAction;
+                @Extension
+                @NoArgsConstructor
+                public class PluginAction implements RootAction {
+                    private String name;
+                    @Inject
+                    public PluginAction(String name) {
+                        this.name = name;
+                    }
+                    public String getUrlName() { return "example"; }
+                    public String getDisplayName() { return "Example plugin"; }
+                    public String getIconFileName() { return null; }
+                }
+                """.getBytes(StandardCharsets.UTF_8), ith.inProjectDir("src/main/java/com/example/plugin/PluginAction.java"));
+
+        // when
+        var gradleRunner = ith.gradleRunner();
+        var result = gradleRunner.withArguments("build").build();
+
+        // then
+        assertThat(result.getOutput()).contains("BUILD SUCCESSFUL");
+
+        var explodedWar = ith.inProjectDir("build/jpi");
+
+        var jpiLibsDir = new File(explodedWar, "WEB-INF/lib");
+        assertThat(jpiLibsDir).exists();
+
+        var jpiLibs = jpiLibsDir.list();
+        assertThat(jpiLibs).isNotNull()
+                .containsExactlyInAnyOrder("test-plugin-1.0.0.jar", "java-jwt-4.5.0.jar");
+    }
+
+    @Test
     void playsWellWithGitPlugin() throws IOException {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");


### PR DESCRIPTION
Filter out jar files from the JPI classpath that are already provided by JPI plugin dependencies, even when those same jars are also needed as transitive dependencies of other non-JPI dependencies.

This ensures that when a JPI plugin provides a library (like Jackson) and another dependency also transitively depends on the same library, the library jars are not duplicated in the final JPI package.
