### PR TITLE
perf: Allow testServer to use testDistribution

### DIFF
--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/ConfigureSynthesizeTestServerSourceAction.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/ConfigureSynthesizeTestServerSourceAction.java
@@ -1,0 +1,64 @@
+package org.jenkinsci.gradle.plugins.jpi2;
+
+import org.gradle.api.Action;
+import org.gradle.api.GradleException;
+import org.gradle.api.Task;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+@SuppressWarnings({
+        "Convert2Lambda", // Gradle doesn't like lambdas
+})
+class ConfigureSynthesizeTestServerSourceAction implements Action<Task> {
+    private static final String SYNTHESIZED_TEST_SOURCE_RESOURCE =
+            "org/jenkinsci/gradle/plugins/jpi2/SynthesizedTestServerTest.template";
+    private final File sourceFile;
+
+    ConfigureSynthesizeTestServerSourceAction(File sourceFile) {
+        this.sourceFile = sourceFile;
+    }
+
+    @Override
+    public void execute(@NotNull Task task) {
+        task.setGroup("verification");
+        task.setDescription("Generate the synthesized JUnit 5 test used by testServer");
+        task.getOutputs().file(sourceFile);
+        task.doLast(new Action<>() {
+            @Override
+            public void execute(@NotNull Task ignored) {
+                writeSource();
+            }
+        });
+    }
+
+    private void writeSource() {
+        try {
+            var parentDir = sourceFile.getParentFile();
+            if (parentDir != null) {
+                Files.createDirectories(parentDir.toPath());
+            }
+            Files.writeString(sourceFile.toPath(), synthesizedTestSource(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new GradleException("Unable to synthesize testServer JUnit source", e);
+        }
+    }
+
+    private static String synthesizedTestSource() {
+        try (var sourceStream = ConfigureSynthesizeTestServerSourceAction.class
+                .getClassLoader()
+                .getResourceAsStream(SYNTHESIZED_TEST_SOURCE_RESOURCE)) {
+            if (sourceStream == null) {
+                throw new GradleException("Unable to find synthesized test source template: "
+                        + SYNTHESIZED_TEST_SOURCE_RESOURCE);
+            }
+            return new String(sourceStream.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new GradleException("Unable to read synthesized test source template: "
+                    + SYNTHESIZED_TEST_SOURCE_RESOURCE, e);
+        }
+    }
+}

--- a/jpi2/src/main/resources/org/jenkinsci/gradle/plugins/jpi2/SynthesizedTestServerTest.template
+++ b/jpi2/src/main/resources/org/jenkinsci/gradle/plugins/jpi2/SynthesizedTestServerTest.template
@@ -1,0 +1,143 @@
+package org.jenkinsci.gradle.plugins.jpi2.generated;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class SynthesizedTestServerTest {
+    private static final List<String> FAILURE_MESSAGES = List.of(
+            "Failed Loading plugin",
+            "Jenkins stopped",
+            "java.io.IOException: Failed to load"
+    );
+
+    @Test
+    void serverStarts() throws Exception {
+        String encodedSystemProperties = System.getProperty("testServer.systemProperties", "");
+        List<String> systemProperties = List.of(encodedSystemProperties.split(","))
+                .stream()
+                .filter(it -> !it.isEmpty())
+                .map(it -> new String(Base64.getDecoder().decode(it), StandardCharsets.UTF_8))
+                .toList();
+
+        String encodedJvmArgs = System.getProperty("testServer.jvmArgs", "");
+        List<String> jvmArgs = List.of(encodedJvmArgs.split(","))
+                .stream()
+                .filter(it -> !it.isEmpty())
+                .map(it -> new String(Base64.getDecoder().decode(it), StandardCharsets.UTF_8))
+                .toList();
+        String encodedServerClasspathNames = System.getProperty("testServer.serverClasspathNames", "");
+        Set<String> requiredClasspathNames = new HashSet<>(List.of(encodedServerClasspathNames.split(","))
+                .stream()
+                .filter(it -> !it.isEmpty())
+                .map(it -> new String(Base64.getDecoder().decode(it), StandardCharsets.UTF_8))
+                .toList());
+        assertFalse(requiredClasspathNames.isEmpty(), "testServer.serverClasspathNames cannot be empty");
+        String runtimeClasspath = System.getProperty("java.class.path", "");
+        List<String> runtimeClasspathEntries = Arrays.asList(runtimeClasspath.split(java.util.regex.Pattern.quote(File.pathSeparator)));
+        List<String> serverClasspathEntries = runtimeClasspathEntries.stream()
+                .filter(it -> requiredClasspathNames.contains(new File(it).getName()))
+                .toList();
+        assertFalse(serverClasspathEntries.isEmpty(), "Unable to resolve server classpath entries in test JVM classpath");
+        String serverClasspath = String.join(File.pathSeparator, serverClasspathEntries);
+
+        int timeoutSeconds = Integer.parseInt(System.getProperty("testServer.timeoutSeconds", "120"));
+        String projectDirPath = System.getProperty("testServer.projectDir", System.getProperty("user.dir", "."));
+        String javaHome = System.getProperty("java.home");
+        int port = Integer.parseInt(System.getProperty("testServer.port", "8080"));
+        assertNotNull(javaHome, "java.home must be set");
+
+        List<String> commandLine = new ArrayList<>();
+        commandLine.add(new File(javaHome, "bin/java").getAbsolutePath());
+        commandLine.addAll(jvmArgs);
+        commandLine.addAll(systemProperties.stream().map(it -> "-D" + it).toList());
+        commandLine.add("-cp");
+        commandLine.add(serverClasspath);
+        commandLine.add("executable.Main");
+        commandLine.add("--webroot=build/jenkins/war");
+        commandLine.add("--pluginroot=build/jenkins/plugins");
+        commandLine.add("--extractedFilesFolder=build/jenkins/extracted");
+        commandLine.add("--commonLibFolder=work/lib");
+        commandLine.add("--httpPort=" + port);
+        assertFalse(commandLine.isEmpty(), "testServer command line cannot be empty");
+        System.err.println("Command: " + commandLine);
+
+        ProcessBuilder processBuilder = new ProcessBuilder(commandLine)
+                .directory(new File(projectDirPath))
+                .redirectErrorStream(true);
+        processBuilder.environment().put("JENKINS_HOME", new File(projectDirPath, "work").getAbsolutePath());
+        Process process = processBuilder.start();
+
+        AtomicBoolean timedOut = new AtomicBoolean(false);
+        Thread timerThread = new Thread(() -> {
+            try {
+                Thread.sleep(timeoutSeconds * 1000L);
+                timedOut.set(true);
+                System.err.println("Timeout reached, terminating Jenkins server");
+                process.destroy();
+            } catch (InterruptedException ignored) {
+                // Ignore
+            }
+        }, "testServer-timeout");
+        timerThread.setDaemon(true);
+        timerThread.start();
+
+        boolean foundSuccess = false;
+        try (var stdoutReader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            String stdout;
+            while ((stdout = stdoutReader.readLine()) != null) {
+                System.err.println("    " + stdout);
+                if (stdout.contains("Jenkins is fully up and running")) {
+                    process.destroy();
+                    foundSuccess = true;
+                    if (!process.waitFor(30, TimeUnit.SECONDS)) {
+                        process.destroyForcibly();
+                        process.waitFor(30, TimeUnit.SECONDS);
+                    }
+                    break;
+                }
+                if (FAILURE_MESSAGES.stream().anyMatch(stdout::contains)) {
+                    process.destroy();
+                    if (!process.waitFor(30, TimeUnit.SECONDS)) {
+                        process.destroyForcibly();
+                        process.waitFor(30, TimeUnit.SECONDS);
+                    }
+                    fail("Jenkins failed to start: " + stdout);
+                }
+            }
+        } finally {
+            timerThread.interrupt();
+        }
+
+        if (timedOut.get()) {
+            fail("Timed out after " + timeoutSeconds + "s waiting for Jenkins startup");
+        }
+
+        if (!process.waitFor(30, TimeUnit.SECONDS)) {
+            process.destroyForcibly();
+            process.waitFor(30, TimeUnit.SECONDS);
+        }
+        int exitCode = process.exitValue();
+        if (exitCode != 0 && !foundSuccess) {
+            fail("Jenkins failed to start with exit code " + exitCode);
+        }
+
+        assertTrue(foundSuccess, "Jenkins never reported successful startup");
+    }
+}

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/MultiModuleIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/MultiModuleIntegrationTest.java
@@ -86,7 +86,7 @@ class MultiModuleIntegrationTest extends V2IntegrationTestBase {
         GradleRunner gradleRunner = ith.gradleRunner();
 
         // when
-        testServerStarts(gradleRunner, ":plugin-four:server");
+        testServerStarts(gradleRunner, ":plugin-four:testServer");
 
         // then
         var pluginThreeJpi = ith.inProjectDir("plugin-four/work/plugins/plugin-three.jpi");

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/OssLibraryDependencyIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/OssLibraryDependencyIntegrationTest.java
@@ -60,6 +60,6 @@ class OssLibraryDependencyIntegrationTest extends V2IntegrationTestBase {
         GradleRunner gradleRunner = ith.gradleRunner();
 
         // when
-        testServerStarts(gradleRunner, "server");
+        testServerStarts(gradleRunner, "testServer");
     }
 }

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/OssPluginDependencyIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/OssPluginDependencyIntegrationTest.java
@@ -60,7 +60,7 @@ class OssPluginDependencyIntegrationTest extends V2IntegrationTestBase {
         GradleRunner gradleRunner = ith.gradleRunner();
 
         // when
-        testServerStarts(gradleRunner, "server");
+        testServerStarts(gradleRunner, "testServer");
 
         // the selected plugin
         var pluginsDir = ith.inProjectDir("work/plugins");

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/SimpleBuildIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/SimpleBuildIntegrationTest.java
@@ -58,6 +58,6 @@ class SimpleBuildIntegrationTest extends V2IntegrationTestBase {
         GradleRunner gradleRunner = ith.gradleRunner();
 
         // when
-        testServerStarts(gradleRunner, "server");
+        testServerStarts(gradleRunner, "testServer");
     }
 }


### PR DESCRIPTION
Gradle doesn't allow build distribution.
But it does allow test distribution if you have Develocity.

Prior to this change, the `testServer` task was a custom `Task` that launched the `server` task and validated that it launched successfully.

With this change, it's been turned into a `Test` task.
There is a synthesized JUnit5 test associated with it.
