### PR TITLE
fix: normalize server plugin extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,14 @@ jenkinsPlugin {
     // can also be set via the gradle property 'jenkins.localizer.version'
     localizerVersion.set("1.31")
 
+    // plugin archive extension used for the built artifact (default: "jpi")
+    archiveExtension.set("jpi")
+
+    // when true, local run tasks rewrite plugin filenames in work/plugins to use .jpi
+    // this affects both server/prepareServer and hplRun/prepareRun
+    // defaults to false so local run setup preserves the configured archive extension
+    normalizePluginArchiveExtensionsForServer.set(false)
+
     // ID of the plugin, defaults to the project name
     pluginId.set("my-plugin")
 

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/ConfigurePrepareRunAction.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/ConfigurePrepareRunAction.java
@@ -3,6 +3,7 @@ package org.jenkinsci.gradle.plugins.jpi2;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ResolvedArtifact;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Sync;
 import org.gradle.api.tasks.TaskProvider;
 import org.jetbrains.annotations.NotNull;
@@ -16,11 +17,14 @@ class ConfigurePrepareRunAction implements Action<Sync> {
     private final TaskProvider<GenerateHplTask> hplTaskProvider;
     private final String projectRoot;
     private final Configuration defaultRuntime;
+    private final Provider<String> targetExtension;
 
-    ConfigurePrepareRunAction(TaskProvider<GenerateHplTask> hplTaskProvider, String projectRoot, Configuration defaultRuntime) {
+    ConfigurePrepareRunAction(TaskProvider<GenerateHplTask> hplTaskProvider, String projectRoot, Configuration defaultRuntime,
+                              Provider<String> targetExtension) {
         this.hplTaskProvider = hplTaskProvider;
         this.projectRoot = projectRoot;
         this.defaultRuntime = defaultRuntime;
+        this.targetExtension = targetExtension;
     }
 
     @Override
@@ -37,7 +41,7 @@ class ConfigurePrepareRunAction implements Action<Sync> {
                                 .rename(new DropVersionTransformer(
                                         artifact.getModuleVersion().getId().getName(),
                                         artifact.getModuleVersion().getId().getVersion(),
-                                        artifact.getExtension()
+                                        targetExtension.get()
                                 ))
                 );
     }

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
@@ -188,14 +188,17 @@ public class V2JpiPlugin implements Plugin<Project> {
         });
 
         final var projectRoot = project.getLayout().getProjectDirectory().getAsFile().getAbsolutePath();
-        final var prepareServer = createPrepareServerTask(project, projectRoot, defaultRuntime, jpiTask);
-        final var prepareRun = createPrepareRunTask(project, projectRoot, defaultRuntime, generateHpl);
+        var runtimePluginExtension = project.provider(() -> extension.getNormalizePluginArchiveExtensionsForServer().get()
+                ? JenkinsPluginExtension.DEFAULT_ARCHIVE_EXTENSION
+                : extension.getArchiveExtension().get());
+        final var prepareServer = createPrepareServerTask(project, projectRoot, defaultRuntime, jpiTask, runtimePluginExtension);
+        final var prepareRun = createPrepareRunTask(project, projectRoot, defaultRuntime, generateHpl, runtimePluginExtension);
 
         project.getGradle().projectsEvaluated(gradle -> {
             var projectByPath = project.getRootProject().getAllprojects().stream()
                     .collect(Collectors.toMap(Project::getPath, it -> it));
             var projectDependencies = getProjectDependencies(runtimeClasspath, projectByPath);
-            configureProjectDependencyJpis(prepareServer, getProjectDependencyJpis(projectDependencies, extension.getArchiveExtension().get()));
+            configureProjectDependencyJpis(prepareServer, getProjectDependencyJpis(projectDependencies, runtimePluginExtension.get()));
             configureProjectDependencyTasks(prepareRun, getProjectDependencyTasks(projectDependencies, GenerateHplTask.TASK_NAME));
         });
 
@@ -364,24 +367,25 @@ public class V2JpiPlugin implements Plugin<Project> {
 
     @NotNull
     private static TaskProvider<Sync> createPrepareServerTask(@NotNull Project project, String projectRoot, Configuration defaultRuntime,
-                                                              TaskProvider<?> jpiTaskProvider) {
+                                                              TaskProvider<?> jpiTaskProvider, Provider<String> targetExtension) {
         return project.getTasks().register("prepareServer", Sync.class, new ConfigurePrepareServerAction(
                 jpiTaskProvider,
                 projectRoot,
                 defaultRuntime,
                 project.provider(project::getName),
                 project.provider(() -> project.getVersion().toString()),
-                project.getExtensions().getByType(JenkinsPluginExtension.class).getArchiveExtension()
+                targetExtension
         ));
     }
 
     @NotNull
     private static TaskProvider<Sync> createPrepareRunTask(@NotNull Project project, String projectRoot, Configuration defaultRuntime,
-                                                           TaskProvider<GenerateHplTask> hplTaskProvider) {
+                                                           TaskProvider<GenerateHplTask> hplTaskProvider, Provider<String> targetExtension) {
         return project.getTasks().register("prepareRun", Sync.class, new ConfigurePrepareRunAction(
                 hplTaskProvider,
                 projectRoot,
-                defaultRuntime
+                defaultRuntime,
+                targetExtension
         ));
     }
 

--- a/jpi2/src/main/kotlin/org/jenkinsci/gradle/plugins/jpi2/JenkinsPluginExtension.kt
+++ b/jpi2/src/main/kotlin/org/jenkinsci/gradle/plugins/jpi2/JenkinsPluginExtension.kt
@@ -33,6 +33,15 @@ abstract class JenkinsPluginExtension @Inject constructor(private val project: P
         .convention(DEFAULT_ARCHIVE_EXTENSION)
 
     /**
+     * When true, local run tasks normalize plugin archives copied into `work/plugins` to use the standard `.jpi`
+     * extension, even if the built archive uses `.hpi`.
+     *
+     * Defaults to `false` so local run setup preserves the configured archive extension unless explicitly enabled.
+     */
+    val normalizePluginArchiveExtensionsForServer: Property<Boolean> = project.objects.property(Boolean::class.java)
+        .convention(false)
+
+    /**
      * The version of Jenkins core to compile and run against.
      * Can be set via the [JENKINS_VERSION_PROPERTY] Gradle property.
      * Defaults to [DEFAULT_JENKINS_VERSION].

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/ArchiveExtensionIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/ArchiveExtensionIntegrationTest.java
@@ -82,7 +82,7 @@ class ArchiveExtensionIntegrationTest extends V2IntegrationTestBase {
     }
 
     @Test
-    void prepareServerWithHpiExtensionProducesHpiInWorkPlugins() throws IOException {
+    void prepareServerWithHpiExtensionProducesHpiInWorkPluginsByDefault() throws IOException {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
@@ -100,6 +100,75 @@ class ArchiveExtensionIntegrationTest extends V2IntegrationTestBase {
         var jpi = ith.inProjectDir("work/plugins/test-plugin.jpi");
         assertThat(hpi).exists();
         assertThat(jpi).doesNotExist();
+    }
+
+    @Test
+    void prepareServerCanNormalizeHpiExtensionToJpiInWorkPlugins() throws IOException {
+        // given
+        var ith = new IntegrationTestHelper(tempDir, "8.14");
+        initBuild(ith);
+        Files.write((getBasePluginConfig() + /* language=kotlin */ """
+                jenkinsPlugin {
+                    archiveExtension.set("hpi")
+                    normalizePluginArchiveExtensionsForServer.set(true)
+                }
+                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+
+        // when
+        ith.gradleRunner().withArguments("prepareServer").build();
+
+        // then
+        var hpi = ith.inProjectDir("work/plugins/test-plugin.hpi");
+        var jpi = ith.inProjectDir("work/plugins/test-plugin.jpi");
+        assertThat(hpi).doesNotExist();
+        assertThat(jpi).exists();
+    }
+
+    @Test
+    void prepareRunWithHpiExtensionPreservesPluginExtensionsByDefault() throws IOException {
+        // given
+        var ith = new IntegrationTestHelper(tempDir, "8.14");
+        initBuild(ith);
+        Files.write((getBasePluginConfig() + /* language=kotlin */ """
+                jenkinsPlugin {
+                    archiveExtension.set("hpi")
+                }
+                dependencies {
+                    implementation("org.jenkins-ci.plugins:git:5.7.0")
+                }
+                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+
+        // when
+        ith.gradleRunner().withArguments("prepareRun").build();
+
+        // then
+        assertThat(ith.inProjectDir("work/plugins/test-plugin.hpl")).exists();
+        assertThat(ith.inProjectDir("work/plugins/git.hpi")).exists();
+        assertThat(ith.inProjectDir("work/plugins/git.jpi")).doesNotExist();
+    }
+
+    @Test
+    void prepareRunCanNormalizeHpiExtensionToJpiInWorkPlugins() throws IOException {
+        // given
+        var ith = new IntegrationTestHelper(tempDir, "8.14");
+        initBuild(ith);
+        Files.write((getBasePluginConfig() + /* language=kotlin */ """
+                jenkinsPlugin {
+                    archiveExtension.set("hpi")
+                    normalizePluginArchiveExtensionsForServer.set(true)
+                }
+                dependencies {
+                    implementation("org.jenkins-ci.plugins:git:5.7.0")
+                }
+                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+
+        // when
+        ith.gradleRunner().withArguments("prepareRun").build();
+
+        // then
+        assertThat(ith.inProjectDir("work/plugins/test-plugin.hpl")).exists();
+        assertThat(ith.inProjectDir("work/plugins/git.hpi")).doesNotExist();
+        assertThat(ith.inProjectDir("work/plugins/git.jpi")).exists();
     }
 
     @Test


### PR DESCRIPTION
## Summary
Add an opt-in jpi2 extension property to control whether prepareServer rewrites plugin filenames in work/plugins to .jpi.

## Why
Some builds want Jenkins-friendly .jpi names in the runtime plugins directory to avoid warning noise. Others package Jenkins for deployment and want prepareServer to preserve the configured archive extension unless they explicitly opt into normalization.

## Testing
- ./gradlew :jpi2:test --tests org.jenkinsci.gradle.plugins.jpi2.ArchiveExtensionIntegrationTest --tests org.jenkinsci.gradle.plugins.jpi2.OssPluginDependencyIntegrationTest