### PR TITLE
docs: refocus plugin docs on jpi2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,383 +6,40 @@
 [ci-workflow]: https://github.com/jenkinsci/gradle-jpi-plugin/actions?query=workflow%3ACI
 [regression-workflow]: https://github.com/jenkinsci/gradle-jpi-plugin/actions?query=workflow%3ARegression
 
-This is a Gradle plugin for building [Jenkins](http://jenkins-ci.org)
-plugins, written in Groovy or Java.
+This repository contains two Gradle plugins for building Jenkins plugins.
+`org.jenkins-ci.jpi2` is the recommended plugin for modern Gradle builds and is the primary focus of this README.
+`org.jenkins-ci.jpi` remains available for older Gradle builds, and its documentation now lives in [docs/legacy-jpi.md](docs/legacy-jpi.md).
+If you are moving an existing build forward, start with [docs/migrating-to-jpi2.md](docs/migrating-to-jpi2.md).
+
+## Choosing a plugin
+
+Use `org.jenkins-ci.jpi2` for Gradle 8 and newer.
+Use `org.jenkins-ci.jpi` only when you must stay on an older Gradle release.
+The legacy plugin has additional compatibility notes and historical configuration examples in [docs/legacy-jpi.md](docs/legacy-jpi.md).
 
 ## :warning: New OSS Plugins Rejected
 
 As of December 2022, new OSS plugins will be [rejected by the Jenkins hosting team][213] until [hosting requirements][host-reqs] are met.
-
 Hosting requirements are well-defined and expected to be a small amount of work, but this is not prioritized.
 Contributions are welcome.
 Existing OSS plugins can continue to use this plugin.
-Plugins not hosted by the Jenkins infra team (internal-only plugins) are not impacted.
+Plugins not hosted by the Jenkins infra team, such as internal-only plugins, are not impacted.
 
 [213]: https://github.com/jenkinsci/gradle-jpi-plugin/issues/213
 [host-reqs]: https://github.com/jenkinsci/gradle-jpi-plugin/milestone/10
 
-## Compatibility with Gradle versions
+## JPI2 Quick Start
 
-The latest version of the JPI plugin requires **Gradle 7.1 or later** to make use of modern Gradle APIs.
-
-For Gradle versions 6.3-6.9.x, please use version `0.50.0` of the JPI plugin.
-
-For Gradle versions 6.0-6.2.1, please use version `0.46.0` of the JPI plugin.
-
-For Gradle versions 4.x or 5.x, please use version `0.38.0` of the JPI plugin.
-
-## Configuration
-
-Add the following to your build.gradle:
-
-```groovy
-plugins {
-  id 'org.jenkins-ci.jpi' version '0.52.0'
-}
-
-group = 'org.jenkins-ci.plugins'
-version = '1.2.0-SNAPSHOT'
-description = 'A description of your plugin'
-
-jenkinsPlugin {
-    // version of Jenkins core this plugin depends on, must be 1.420 or later
-    jenkinsVersion = '1.420'
-
-    // ID of the plugin, defaults to the project name without trailing '-plugin'
-    shortName = 'hello-world'
-
-    // human-readable name of plugin
-    displayName = 'Hello World plugin built with Gradle'
-
-    // URL for plugin on Jenkins wiki or elsewhere
-    url = 'http://wiki.jenkins-ci.org/display/JENKINS/SomePluginPage'
-
-    // plugin URL on GitHub, optional
-    gitHubUrl = 'https://github.com/jenkinsci/some-plugin'
-  
-    // scm tag eventually set in the published pom, optional
-    scmTag = 'v1.0.0'
-
-    // use the plugin class loader before the core class loader, defaults to false
-    pluginFirstClassLoader = true
-
-    // optional list of package prefixes that your plugin doesn't want to see from core
-    maskClasses = 'groovy.grape org.apache.commons.codec'
-
-    // optional version number from which this plugin release is configuration-compatible
-    compatibleSinceVersion = '1.1.0'
-
-    // set the directory from which the development server will run, defaults to 'work'
-    workDir = file('/tmp/jenkins')
-
-    // URL used to deploy the plugin, defaults to the value shown
-    // the system property 'jpi.repoUrl' can be used to override this option
-    repoUrl = 'https://repo.jenkins-ci.org/releases'
-
-    // URL used to deploy snapshots of the plugin, defaults to the value shown
-    // the system property 'jpi.snapshotRepoUrl' can be used to override this option
-    snapshotRepoUrl = 'https://repo.jenkins-ci.org/snapshots'
-
-    // enable injection of additional tests for checking the syntax of Jelly and other things
-    disabledTestInjection = false
-
-    // the output directory for the localizer task relative to the project root, defaults to the value shown
-    // for jpi2, configure tasks.named("localizeMessages") instead; see the jpi2 localization section below
-    localizerOutputDir = "${project.buildDir}/generated-src/localizer"
-
-    // disable configuration of Maven Central, the local Maven cache and the Jenkins Maven repository, defaults to true
-    configureRepositories = false
-
-    // skip configuration of publications and repositories for the Maven Publishing plugin, defaults to true
-    configurePublishing = false
-
-    // plugin file extension, either 'jpi' or 'hpi', defaults to 'hpi'
-    fileExtension = 'hpi'
-
-    // the developers section is optional, and corresponds to the POM developers section
-    developers {
-        developer {
-            id 'abayer'
-            name 'Andrew Bayer'
-            email 'andrew.bayer@gmail.com'
-        }
-    }
-
-    // the licenses section is optional, and corresponds to the POM licenses section
-    licenses {
-        license {
-            name 'Apache License, Version 2.0'
-            url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
-            distribution 'repo'
-            comments 'A business-friendly OSS license'
-        }
-    }
-
-    // Git based version generation is optional
-    gitVersion {
-        // Don't fail if changes are not committed (default: false)
-        allowDirty = true
-        // Customize version format (default: %d.%s where %d is the commit depth, %s the abbreviated sha)
-        versionFormat = 'rc-%d.%s'
-        // Sanitize the hash according to Jenkins requirements (default: false)  
-        sanitize = true 
-        // Customize abbreviated sha length (default: 12)
-        abbrevLength = 10
-        // Customize git root (default: project directory)
-        gitRoot = file('/some/external/git/repo')
-    }
-
-    // "Incrementals" custom repository (default: https://repo.jenkins-ci.org/incrementals)
-    incrementalsRepoUrl = 'https://custom'
-
-    // Enable quality check plugins
-    enableSpotBugs()
-    enableCheckstyle()
-    enableJacoco()
-}
-```
-
-Be sure to add the `jenkinsPlugin { ... }` section before any additional
-repositories are defined in your build.gradle.
-
-## Dependencies on other Jenkins Plugins
-
-If your plugin depends on other Jenkins plugins, you can use the same _configurations_ as in Gradle's `java-libary` plugin.
-See [the documentation](https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation) for details on the difference of `api` and `implementation` dependencies.
-For _optional dependencies_, you can use Gradle's [feature variants](https://docs.gradle.org/current/userguide/feature_variants.html).
-
-You can define both dependencies to Jenkins plugins and plain Java libraries.
-The JPI plugin will figure out what you are depending on and process it accordingly (Java libraries will be packaged in the your Jenkins plugin's hpi/jpi file).
-
-The additional `jenkinsServer` configuration can be used to install extra plugins for the `server` task (see below).
-
-Examples:
-
-    java {
-        // define features for 'optional dependencies'
-        registerFeature('ant') {
-            usingSourceSet(sourceSets.main)
-        }
-    }
-
-    dependencies {
-        implementation 'org.jenkinsci.plugins:git:1.1.15'
-        api 'org.jenkins-ci.plugins:credentials:1.9.4'
-
-        // dependency of the (optional) ant feature
-        antImplementation 'org.jenkins-ci.plugins:ant:1.2'
-
-        // dependency for testing only
-        testImplementation 'org.jenkins-ci.main:maven-plugin:1.480'
-
-        // addition dependencies for manual tests on the server started with `gradle server`
-        jenkinsServer 'org.jenkins-ci.plugins:ant:1.2'
-    }
-
-
-## Usage
-
-* `gradle jpi` - Build the Jenkins plugin file, which can then be
-  found in the build directory. The file will currently end in ".hpi".
-* `gradle publishToMavenLocal` - Build the Jenkins plugin and install it into your
-  local Maven repository.
-* `gradle publish` - Deploy your plugin to
-  the Jenkins Maven repository to be included in the Update Center.
-* `gradle server` - Start a local instance of Jenkins with the plugin pre-installed for testing
-  and debugging.
-
-### Running Jenkins Locally
-
-The `server` task creates a [hpl][hpl], installs plugins, and starts up Jenkins on port 8080. The server runs
-in the foreground.
-
-Plugins added to any of these configurations will be installed to `${jenkinsPlugin.workDir}/plugins`:
-- `api`
-- `implementation`
-- `runtimeOnly`
-- `jenkinsServer`
-
-#### Default System Properties
-
-Jenkins starts up with these system properties set to `true`:
-- `stapler.trace`
-- `stapler.jelly.noCache`
-- `debug.YUI`
-- `hudson.Main.development`
-
-Each can be overridden as described in the _Customizing Further_ section below.
-
-[hpl]: https://wiki.jenkins.io/display/JENKINS/Plugin+Structure#PluginStructure-DebugPluginLayout:.hpl
-
-
-#### Customizing Port
-
-Jenkins starts by default on port 8080. This can be changed with the `--port` flag or `port` property.
-
-For example to run on port 7000:
-
-```
-$ ./gradlew server --port=7000
-```
-
-or in build.gradle:
-
-```groovy
-tasks.named('server').configure {
-    it.port.set(7000)
-}
-```
-
-#### Customizing Further
-
-The `server` task accepts a [`JavaExecSpec`][javaexecspec] that allows extensive customization.
-
-Here's an example with common options:
-
-```groovy
-tasks.named('server').configure {
-    execSpec {
-        systemProperty 'some.property', 'true'
-        environment 'SOME_ENV_VAR', 'HelloWorld'
-        maxHeapSize = '2g'
-    }
-}
-```
-
-
-#### Debugging
-
-To start Jenkins in a suspended state with a debug port of 5005, add the `--debug-jvm` flag:
-
-```
-$ ./gradlew server --debug-jvm
-
-> Task :server
-Listening for transport dt_socket at address: 5005
-```
-
-Debug options can be customized by the `server` task's `execSpec` action:
-
-```groovy
-tasks.named('server').configure {
-    execSpec {
-        debugOptions {
-            port.set(6000)
-            suspend.set(false)
-        }
-    }
-}
-```
-```
-$ ./gradlew server --debug-jvm
-
-> Task :server
-Listening for transport dt_socket at address: 6000
-```
-
-
-
-#### Additional Server Dependencies
-
-Any additional dependencies for the `server` task's classpath can be added to the `jenkinsServerRuntimeOnly`
-configuration. This can be useful for alternative logging implementations.
-
-
-### Checking for Restricted APIs
-
-Starting with v0.41.0, we now [check for using `@Restricted`][restricted] types, methods, and fields.
-
-Initially this functionality will warn by default (see [#176][176]), but will eventually fail the build. To opt-into failing
-the build now, add this configuration to build.gradle:
-
-```gradle
-tasks.named('checkAccessModifier').configure {
-    ignoreFailures.set(false)
-}
-```
-
-`checkAccessModifier` will only be cached on success if `ignoreFailures` is `false`.
-
-### Disabling appending timestamp to the SNAPSHOT plugin version
-
-By default, `generateJenkinsManifest` task appends the current timestamp and the current username to the `-SNAPSHOT` plugin version.
-It leads to a non-repeatable outputs that affect the task cacheability.
-
-To opt-out from modifying the `-SNAPSHOT` plugin version, add this configuration to build.gradle:
-
-```gradle
-tasks.named('generateJenkinsManifest').configure {
-    dynamicSnapshotVersion.set(false)
-}
-```
-
-### Using Git based version
-[JEP-229](https://github.com/jenkinsci/jep/blob/master/jep/229/README.adoc#version-format) outlines requirements for creating sensible version numbers automatically.
-The plugin registers a `generateGitVersion` task that generates a Git based version in a text file (1st line an abbreviated hash, 2nd line the full hash). 
-This version scheme is typically used on ci.jenkins.io by first generating the version and then setting it when 
-building with `-Pversion=${versionFile.readLines()[0]}`. This works fine as long as no version is set in `build.gradle`.
-
-See [Configuration](#configuration) to customize the generation.
-
-### Using Jenkins "incrementals" repository
-[JEP-305](https://github.com/jenkinsci/jep/tree/master/jep/305) specifies how to deploy incremental versions.
-This applies mainly for the ci.jenkins.io infrastructure, for Gradle the logic is defined in https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPluginWithGradle.groovy.
-
-For local builds, the plugin defines the https://repo.jenkins-ci.org/incrementals/ repository. The `publish` task will not publish to this one by default, instead one should call
-the `publish*PublicationToJenkinsIncrementalsRepository` task(s) separately (so `publishMavenJpiPublicationToJenkinsIncrementalsRepository` for the default publication)
-It's also possible to specify a different repository, see [Configuration](#configuration).
-
-### Enabling quality checks
-To eventually publish reports to ci.jenkins.io, one can enable SpotBugs, Checkstyle or JaCoCo plugins:
-```
-jenkinsPlugin {
-    enableSpotBugs()
-    enableCheckstyle()
-    enableJacoco()
-}
-```
-When enabled, plugins are configured with sensitive defaults: only xml reports, checkstyle rules default to sun-checks.xml... still the plugins can be configured as usual, see their corresponding docs.
-
-## Disabling SHA256 and SHA512 checksums when releasing a plugin
-
-This section applies to the warning:
-
-```
-Cannot upload checksum for module-maven-metadata.xml. Remote repository doesn't support sha-256. Error: Could not PUT 'https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/<shortname>/maven-metadata.xml.sha256'. Received status code 403 from server: Forbidden
-Cannot upload checksum for module-maven-metadata.xml. Remote repository doesn't support sha-512. Error: Could not PUT 'https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/<shortname>/maven-metadata.xml.sha512'. Received status code 403 from server: Forbidden
-```
-
-When performing a release via `gradle publish`, gradle will automatically try to upload artifacts with SHA 256 and 512 checksums. This is not currently supported in the public artifact repository for Jenkins.  To disable this, you can pass [a command line argument][shasum] `gradle publish -Dorg.gradle.internal.publish.checksums.insecure` or include a `gradle.properties` file with the line `org.gradle.internal.publish.checksums.insecure=true`.
-
-
-[shasum]: https://docs.gradle.org/6.0.1/release-notes.html#publication-of-sha256-and-sha512-checksums
-
-## Gradle 4+
-
-Note that Gradle 4.0 changed the default layout of the classes folders. Where Gradle 3.x put all classes of groovy and java code into a single directory, Gradle 4 by default creates separate directories for all languages. Unfortunately, this breaks the way
-SezPoz (the library indexing the Extension annotations) works, meaning that all annotations from java code are effectively ignored.
-
-If you combine java and groovy code and both provide extensions you need to either:
-
-- Use joint compilation, i.e. put your java source files into the groovy source path (src/main/groovy)
-- or force Gradle to use the old layout by including something like `sourceSets.main.output.classesDir = new File(buildDir, "classes/main")` in your build.gradle as a workaround.
-
-# JPI2 Plugin (Next Generation)
-
-The JPI2 plugin (`org.jenkins-ci.jpi2`) is a modernized alternative to the original JPI plugin, designed with simpler dependency management.
-The JPI plugin (`org.jenkins-ci.jpi`) is still available, but parts of it don't work with Gradle 8+.
-
-## JPI2 Configuration
-
-Add the following to your `build.gradle.kts`.
+Add the plugin to your `build.gradle.kts`.
 
 ```kotlin
 plugins {
-    id("org.jenkins-ci.jpi2")
+    id("org.jenkins-ci.jpi2") version "<current-version>"
 }
 
-group = "com.example"
-version = "1.0.0"
+group = "org.jenkins-ci.plugins"
+version = "1.0.0-SNAPSHOT"
+description = "A Jenkins plugin built with Gradle"
 
 repositories {
     mavenCentral()
@@ -393,79 +50,32 @@ repositories {
 }
 
 jenkinsPlugin {
-    // version of Jenkins core this plugin depends on (default: 2.492.3)
-    // can also be set via the gradle property 'jenkins.version'
     jenkinsVersion.set("2.492.3")
-
-    // version of Jenkins test harness (default: 2414.v185474555e66)
-    // can also be set via the gradle property 'jenkins.testharness.version'
-    testHarnessVersion.set("2414.v185474555e66")
-
-    // version of the localizer generator used by localizeMessages (default: 1.31)
-    // can also be set via the gradle property 'jenkins.localizer.version'
-    localizerVersion.set("1.31")
-
-    // ID of the plugin, defaults to the project name
-    pluginId.set("my-plugin")
-
-    // human-readable name of the plugin, defaults to the project description or project name
-    displayName.set("My Plugin")
-
-    // URL for the plugin's home page; written to the `Url` manifest attribute and POM <url>
-    homePage.set(uri("https://github.com/jenkinsci/my-plugin"))
-
-    // earliest version of this plugin that is binary-compatible with the current version
-    // written to the `Compatible-Since-Version` manifest attribute
-    compatibleSinceVersion.set("1.1.0")
-
-    // use the plugin class loader before the core class loader (default: false)
-    // written to the `PluginFirstClassLoader` manifest attribute
-    pluginFirstClassLoader.set(true)
-
-    // class prefixes to hide from Jenkins core
-    // written to the `Mask-Classes` manifest attribute as a space-separated list
-    maskClasses.add("groovy.grape")
-    maskClasses.add("org.apache.commons.codec")
-
-    // the developers section corresponds to the POM <developers> section
-    // and the `Plugin-Developers` manifest attribute
-    developers {
-        developer {
-            id.set("rahulsom")
-            name.set("Rahul Somasunderam")
-            email.set("rahulsom@noreply.github.com")
-        }
-    }
-
-    // the licenses section corresponds to the POM <licenses> section
-    licenses {
-        license {
-            name.set("Apache License, Version 2.0")
-            url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-            distribution.set("repo")
-            comments.set("A business-friendly OSS license")
-        }
-    }
+    pluginId.set("hello-world")
+    displayName.set("Hello World")
+    homePage.set(uri("https://github.com/jenkinsci/hello-world-plugin"))
 }
 
 dependencies {
-    implementation("org.jenkins-ci.plugins:git:5.7.0")        // Plugin dependency
-    implementation("com.openai:openai-java:2.5.0")            // Library dependency
+    implementation("org.jenkins-ci.plugins:git:5.7.0")
 }
 ```
 
-## JPI2 Generated Manifest Entries
+The plugin archive defaults to the `jpi` extension.
+Set `archiveExtension` if you need `hpi` instead.
 
-The `jpi2` plugin now generates and merges additional Jenkins manifest entries into both the `jar` and `jpi` artifacts.
+```kotlin
+jenkinsPlugin {
+    archiveExtension.set("hpi")
+}
+```
 
-- `Support-Dynamic-Loading` is derived from the generated `@Extension` metadata (`META-INF/annotations/hudson.Extension.txt`).
-- `Support-Dynamic-Loading` is set to `true` when all discovered extensions are marked `dynamicLoadable=YES`, or when no extensions are present.
-- `Support-Dynamic-Loading` is omitted when at least one extension is `dynamicLoadable=MAYBE` and none are `NO`.
-- `Support-Dynamic-Loading` is set to `false` when any extension is `dynamicLoadable=NO`.
+## JPI2 Defaults
 
-## JPI2 Version Configuration
-
-Jenkins and test harness versions can be set in the `jenkinsPlugin` extension (as shown above) or via `gradle.properties`:
+`jpi2` defaults Jenkins core to `2.492.3`.
+`jpi2` defaults the Jenkins test harness to `2414.v185474555e66`.
+`jpi2` defaults the localizer generator to `1.31`.
+You can override those defaults in the `jenkinsPlugin` block or in `gradle.properties`.
 
 ```properties
 jenkins.version=2.492.3
@@ -473,22 +83,33 @@ jenkins.testharness.version=2414.v185474555e66
 jenkins.localizer.version=1.31
 ```
 
-The `gradle.properties` values serve as defaults; explicit values in the `jenkinsPlugin` block take precedence, including `localizerVersion`.
+## Dependencies
 
-### Localization source generation
+Use standard Gradle dependency configurations such as `implementation`, `api`, `runtimeOnly`, and `testImplementation`.
+Use Gradle feature variants for optional Jenkins plugin dependencies.
+The plugin will package plain Java libraries into the plugin archive and treat Jenkins plugin coordinates as plugin dependencies.
 
-JPI2 now registers a `localizeMessages` task that scans the main resources source set for `Messages.properties` files and generates matching Java sources using the same localizer input format as the original JPI plugin.
+## Common Tasks
 
-By default:
+- `./gradlew jpi` builds the plugin archive.
+- `./gradlew server` starts Jenkins with the built plugin installed.
+- `./gradlew hplRun` starts Jenkins with the current project wired in through HPL files for faster local iteration.
+- `./gradlew testHplRun` verifies that the HPL-based launch boots successfully and then shuts down.
+- `./gradlew localizeMessages` generates Java sources from `Messages.properties` files under `src/main/resources`.
+- `./gradlew generateGitVersion` writes a Git-derived version file for builds that use `versionSource.set(VersionSource.GIT)`.
 
-- `src/main/resources/**/Messages.properties` files are used as inputs
-- generated Java sources are written to `build/generated-src/localizer`
-- the generated sources are added to the main Java source set automatically
-- `compileJava`, `classes`, `build`, and `sourcesJar` will all include the generated localization sources
+## JPI2 Features
 
-You normally do not need to wire anything manually. A Java class in `src/main/java` can refer directly to a generated `Messages` class, and running `build` or `classes` will generate and compile it first.
+### Manifest generation
 
-To customize the output directory, configure the task directly:
+`jpi2` generates Jenkins manifest entries for both the `jar` and `jpi` artifacts.
+`Support-Dynamic-Loading` is derived from the generated `@Extension` metadata.
+
+### Localization
+
+`jpi2` registers a `localizeMessages` task that scans `src/main/resources/**/Messages.properties`.
+Generated sources are written to `build/generated-src/localizer` by default and are added to the main Java source set automatically.
+Configure the task directly if you want a different output directory.
 
 ```kotlin
 tasks.named<org.jenkinsci.gradle.plugins.jpi2.localization.LocalizationTask>("localizeMessages") {
@@ -496,68 +117,32 @@ tasks.named<org.jenkinsci.gradle.plugins.jpi2.localization.LocalizationTask>("lo
 }
 ```
 
-You can also run the task directly when you only want to refresh generated localization sources:
+### Version sources
 
-```shell
-./gradlew localizeMessages
-```
-
-### Plugin version source
-
-By default, the plugin uses the Gradle project version (`project.version`) for the JPI artifact, manifest, and publishing. You can choose a fixed version or a Git-derived version (similar to the JPI plugin's `generateGitVersion` task).
-
-**Use the project version (default):**
-
-```kotlin
-// No configuration needed; project.version is used
-version = "1.0.0"
-```
-
-**Use a fixed version:**
-
-```kotlin
-jenkinsPlugin {
-    versionSource.set(org.jenkinsci.gradle.plugins.jpi2.VersionSource.FIXED)
-    fixedVersion.set("2.0.0")
-}
-```
-
-You can also set the fixed version from a [Provider](https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Provider.html) for dynamic or lazy configuration:
-
-```kotlin
-jenkinsPlugin {
-    versionSource.set(org.jenkinsci.gradle.plugins.jpi2.VersionSource.FIXED)
-    fixedVersion.set(providers.provider { "2.0.0-beta" })
-}
-```
-
-**Use a version from Git (commit depth + abbreviated hash):**
-
-[JEP-229](https://github.com/jenkinsci/jep/blob/master/jep/229/README.adoc#version-format) describes version format requirements. The plugin registers a `generateGitVersion` task that writes a version file (first line = version string, second line = full hash). When `versionSource` is `GIT`, the `jpi` task depends on `generateGitVersion` and the generated version is used for the artifact and manifest.
+By default, `jpi2` uses `project.version`.
+Set `versionSource` to `FIXED` to publish a fixed string.
+Set `versionSource` to `GIT` to derive the version from the Git history.
 
 ```kotlin
 jenkinsPlugin {
     versionSource.set(org.jenkinsci.gradle.plugins.jpi2.VersionSource.GIT)
     gitVersion {
-        // Optional: format string (default: "%d.%s" for depth.hash)
-        versionFormat.set("%d.%s")
-        // Optional: prefix (e.g. "rc-")
-        // versionPrefix.set("rc-")
-        // Optional: allow uncommitted changes (default: false)
         allowDirty.set(true)
-        // Optional: abbreviated hash length (default: 12)
-        // abbrevLength.set(10)
-        // Optional: output file (default: build/generated/version/version.txt)
-        // outputFile.set(layout.buildDirectory.file("my-version.txt"))
+        versionFormat.set("%d.%s")
     }
 }
 ```
 
-You can also run `generateGitVersion` manually and use the first line of the output file (e.g. with `-Pversion=...`). Gradle properties `gitVersionFormat`, `gitVersionPrefix`, and `gitVersionFile` can override the corresponding `gitVersion` settings.
+### Running Jenkins locally
 
-### Server Customization
+The `server` task listens on port `8080` by default.
+Set `server.port` to change the HTTP port.
 
-The server task can be customized for different ports. The default is `8080`.
+```shell
+./gradlew server -Dserver.port=8090
+```
+
+You can also configure the task directly.
 
 ```kotlin
 tasks.named<JavaExec>("server") {
@@ -565,30 +150,9 @@ tasks.named<JavaExec>("server") {
 }
 ```
 
-That can also be set on the command line:
+## Migration And Legacy Docs
 
-```shell
-./gradlew server -Dserver.port=8090
-```
-
-### Running with HPL in JPI2
-
-JPI2 also registers:
-
-- `generateJenkinsServerHpl` to generate an HPL for the current plugin in `build/hpl`
-- `hplRun` to start Jenkins with the current plugin and project plugin dependencies installed as HPLs, which also lets a debugger hotswap changed classes more easily
-- `testHplRun` to verify that `hplRun` can boot Jenkins successfully and then stop
-
-This is useful when working in a multi-module plugin build because changes in dependent plugin projects can be rebuilt and reflected in the running Jenkins instance without rebuilding JPIs for each project dependency.
-
-## Examples
-
-Here are some real world examples of Jenkins plugins using the Gradle JPI plugin:
-
-* [Job DSL Plugin](https://github.com/jenkinsci/job-dsl-plugin)
-* [Selenium Axis Plugin](https://github.com/jenkinsci/selenium-axis-plugin)
-* [Doktor Plugin](https://github.com/jenkinsci/doktor-plugin)
-
-[javaexecspec]: https://docs.gradle.org/current/javadoc/org/gradle/process/JavaExecSpec.html
-[restricted]: https://tiny.cc/jenkins-restricted
-[176]: https://github.com/jenkinsci/gradle-jpi-plugin/issues/176
+Use [docs/migrating-to-jpi2.md](docs/migrating-to-jpi2.md) when moving an existing plugin from `org.jenkins-ci.jpi` to `org.jenkins-ci.jpi2`.
+Use [docs/legacy-jpi.md](docs/legacy-jpi.md) when you need the older `jpi` plugin documentation for historical or maintenance work.
+Release process notes still live in [RELEASING.md](RELEASING.md).
+Historical release notes still live in [CHANGELOG.md](CHANGELOG.md).

--- a/docs/legacy-jpi.md
+++ b/docs/legacy-jpi.md
@@ -1,0 +1,288 @@
+# Legacy JPI plugin
+
+This document preserves the `org.jenkins-ci.jpi` documentation for older Gradle builds.
+For Gradle 8 and newer, use `org.jenkins-ci.jpi2` instead.
+If you are moving an existing build forward, see [migrating-to-jpi2.md](migrating-to-jpi2.md).
+
+## Compatibility with Gradle versions
+
+The latest version of the legacy JPI plugin requires Gradle 7.1 or later.
+For Gradle versions 6.3 through 6.9.x, use version `0.50.0`.
+For Gradle versions 6.0 through 6.2.1, use version `0.46.0`.
+For Gradle versions 4.x or 5.x, use version `0.38.0`.
+Parts of the legacy plugin do not work on Gradle 8+.
+
+## Configuration
+
+Add the following to your `build.gradle`.
+
+```groovy
+plugins {
+  id 'org.jenkins-ci.jpi' version '<current-version>'
+}
+
+group = 'org.jenkins-ci.plugins'
+version = '1.2.0-SNAPSHOT'
+description = 'A description of your plugin'
+
+jenkinsPlugin {
+    // version of Jenkins core this plugin depends on, must be 1.420 or later
+    jenkinsVersion = '1.420'
+
+    // ID of the plugin, defaults to the project name without trailing '-plugin'
+    shortName = 'hello-world'
+
+    // human-readable name of plugin
+    displayName = 'Hello World plugin built with Gradle'
+
+    // URL for plugin on Jenkins wiki or elsewhere
+    url = 'http://wiki.jenkins-ci.org/display/JENKINS/SomePluginPage'
+
+    // plugin URL on GitHub, optional
+    gitHubUrl = 'https://github.com/jenkinsci/some-plugin'
+
+    // scm tag eventually set in the published pom, optional
+    scmTag = 'v1.0.0'
+
+    // use the plugin class loader before the core class loader, defaults to false
+    pluginFirstClassLoader = true
+
+    // optional list of package prefixes that your plugin doesn't want to see from core
+    maskClasses = 'groovy.grape org.apache.commons.codec'
+
+    // optional version number from which this plugin release is configuration-compatible
+    compatibleSinceVersion = '1.1.0'
+
+    // set the directory from which the development server will run, defaults to 'work'
+    workDir = file('/tmp/jenkins')
+
+    // URL used to deploy the plugin, defaults to the value shown
+    // the system property 'jpi.repoUrl' can be used to override this option
+    repoUrl = 'https://repo.jenkins-ci.org/releases'
+
+    // URL used to deploy snapshots of the plugin, defaults to the value shown
+    // the system property 'jpi.snapshotRepoUrl' can be used to override this option
+    snapshotRepoUrl = 'https://repo.jenkins-ci.org/snapshots'
+
+    // enable injection of additional tests for checking the syntax of Jelly and other things
+    disabledTestInjection = false
+
+    // the output directory for the localizer task relative to the project root, defaults to the value shown
+    localizerOutputDir = "${project.buildDir}/generated-src/localizer"
+
+    // disable configuration of Maven Central, the local Maven cache and the Jenkins Maven repository, defaults to true
+    configureRepositories = false
+
+    // skip configuration of publications and repositories for the Maven Publishing plugin, defaults to true
+    configurePublishing = false
+
+    // plugin file extension, either 'jpi' or 'hpi', defaults to 'hpi'
+    fileExtension = 'hpi'
+
+    // the developers section is optional, and corresponds to the POM developers section
+    developers {
+        developer {
+            id 'abayer'
+            name 'Andrew Bayer'
+            email 'andrew.bayer@gmail.com'
+        }
+    }
+
+    // the licenses section is optional, and corresponds to the POM licenses section
+    licenses {
+        license {
+            name 'Apache License, Version 2.0'
+            url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+            distribution 'repo'
+            comments 'A business-friendly OSS license'
+        }
+    }
+
+    // Git based version generation is optional
+    gitVersion {
+        // Don't fail if changes are not committed (default: false)
+        allowDirty = true
+        // Customize version format (default: %d.%s where %d is the commit depth, %s the abbreviated sha)
+        versionFormat = 'rc-%d.%s'
+        // Sanitize the hash according to Jenkins requirements (default: false)
+        sanitize = true
+        // Customize abbreviated sha length (default: 12)
+        abbrevLength = 10
+        // Customize git root (default: project directory)
+        gitRoot = file('/some/external/git/repo')
+    }
+
+    // "Incrementals" custom repository (default: https://repo.jenkins-ci.org/incrementals)
+    incrementalsRepoUrl = 'https://custom'
+
+    // Enable quality check plugins
+    enableSpotBugs()
+    enableCheckstyle()
+    enableJacoco()
+}
+```
+
+Add the `jenkinsPlugin { ... }` section before any additional repositories are defined in your build script.
+
+## Dependencies on other Jenkins plugins
+
+If your plugin depends on other Jenkins plugins, you can use the same configurations as in Gradle's `java-library` plugin.
+See the Gradle documentation for details on the difference between `api` and `implementation`.
+For optional dependencies, you can use Gradle feature variants.
+The legacy JPI plugin figures out whether each dependency is a Jenkins plugin or a plain Java library and processes it accordingly.
+Plain Java libraries are packaged into the resulting `hpi` or `jpi` archive.
+The additional `jenkinsServer` configuration can be used to install extra plugins for the `server` task.
+
+```groovy
+java {
+    registerFeature('ant') {
+        usingSourceSet(sourceSets.main)
+    }
+}
+
+dependencies {
+    implementation 'org.jenkinsci.plugins:git:1.1.15'
+    api 'org.jenkins-ci.plugins:credentials:1.9.4'
+
+    antImplementation 'org.jenkins-ci.plugins:ant:1.2'
+    testImplementation 'org.jenkins-ci.main:maven-plugin:1.480'
+    jenkinsServer 'org.jenkins-ci.plugins:ant:1.2'
+}
+```
+
+## Usage
+
+- `gradle jpi` builds the Jenkins plugin archive in the build directory.
+- `gradle publishToMavenLocal` builds the plugin and installs it into the local Maven repository.
+- `gradle publish` deploys the plugin to the Jenkins Maven repository.
+- `gradle server` starts a local Jenkins instance with the plugin preinstalled for testing and debugging.
+
+## Running Jenkins locally
+
+The `server` task creates an HPL file, installs plugins, and starts Jenkins on port `8080`.
+The server runs in the foreground.
+Plugins added to the `api`, `implementation`, `runtimeOnly`, and `jenkinsServer` configurations are installed to `${jenkinsPlugin.workDir}/plugins`.
+
+### Default system properties
+
+Jenkins starts with these system properties set to `true`.
+
+- `stapler.trace`
+- `stapler.jelly.noCache`
+- `debug.YUI`
+- `hudson.Main.development`
+
+### Customizing port
+
+Jenkins starts on port `8080` by default.
+Change the port with `--port` or with the task property.
+
+```shell
+./gradlew server --port=7000
+```
+
+```groovy
+tasks.named('server').configure {
+    it.port.set(7000)
+}
+```
+
+### Customizing further
+
+The `server` task accepts a `JavaExecSpec`, which allows extensive customization.
+
+```groovy
+tasks.named('server').configure {
+    execSpec {
+        systemProperty 'some.property', 'true'
+        environment 'SOME_ENV_VAR', 'HelloWorld'
+        maxHeapSize = '2g'
+    }
+}
+```
+
+### Debugging
+
+Add `--debug-jvm` to start Jenkins suspended with a debug port of `5005`.
+Customize those debug options through the `execSpec` block.
+
+```shell
+./gradlew server --debug-jvm
+```
+
+```groovy
+tasks.named('server').configure {
+    execSpec {
+        debugOptions {
+            port.set(6000)
+            suspend.set(false)
+        }
+    }
+}
+```
+
+### Additional server dependencies
+
+Add additional dependencies for the `server` task classpath to the `jenkinsServerRuntimeOnly` configuration.
+This is useful for alternative logging implementations.
+
+## Checking for restricted APIs
+
+Starting with `0.41.0`, the plugin checks for use of `@Restricted` types, methods, and fields.
+This behavior warns by default.
+Set `ignoreFailures` to `false` if you want the build to fail instead.
+
+```groovy
+tasks.named('checkAccessModifier').configure {
+    ignoreFailures.set(false)
+}
+```
+
+## Disabling timestamped `-SNAPSHOT` versions
+
+By default, `generateJenkinsManifest` appends the current timestamp and username to `-SNAPSHOT` plugin versions.
+Disable that behavior if you need reproducible outputs and better task cacheability.
+
+```groovy
+tasks.named('generateJenkinsManifest').configure {
+    dynamicSnapshotVersion.set(false)
+}
+```
+
+## Using Git based versioning
+
+The plugin registers a `generateGitVersion` task that writes a Git-based version to a text file.
+This is commonly used on `ci.jenkins.io` by generating the version first and then building with `-Pversion=${versionFile.readLines()[0]}`.
+See the configuration example above to customize the generation.
+
+## Using the Jenkins incrementals repository
+
+The plugin defines `https://repo.jenkins-ci.org/incrementals/` for local builds.
+The `publish` task does not publish there by default.
+Call the `publish*PublicationToJenkinsIncrementalsRepository` tasks separately when you want to publish incrementals.
+Use `incrementalsRepoUrl` to point at a different repository.
+
+## Enabling quality checks
+
+The legacy plugin can enable SpotBugs, Checkstyle, and JaCoCo with helper methods.
+When enabled, the plugin configures those tools with Jenkins-friendly defaults.
+
+```groovy
+jenkinsPlugin {
+    enableSpotBugs()
+    enableCheckstyle()
+    enableJacoco()
+}
+```
+
+## Disabling SHA256 and SHA512 checksums when releasing
+
+Gradle may try to upload SHA-256 and SHA-512 checksum files during `gradle publish`.
+The public Jenkins artifact repository does not currently support those uploads.
+Pass `-Dorg.gradle.internal.publish.checksums.insecure` or set `org.gradle.internal.publish.checksums.insecure=true` in `gradle.properties` to disable them.
+
+## Gradle 4+
+
+Gradle 4 changed the default layout of compiled classes directories.
+That change breaks how SezPoz discovers `@Extension` annotations when Java and Groovy sources are split across separate output folders.
+If you combine Java and Groovy code and both provide Jenkins extensions, either use joint compilation or force Gradle to use the older shared classes directory layout.

--- a/docs/migrating-to-jpi2.md
+++ b/docs/migrating-to-jpi2.md
@@ -1,0 +1,153 @@
+# Migrating from JPI to JPI2
+
+Use this guide when you want to move a plugin build from `org.jenkins-ci.jpi` to `org.jenkins-ci.jpi2`.
+The short version is that `jpi2` is the path for modern Gradle builds, while `jpi` is now the legacy option for older Gradle versions.
+
+## Before you start
+
+Plan to migrate when you need Gradle 8 or newer.
+Keep a copy of your current `jpi` build script nearby while you make the switch.
+If you need to stay on Gradle 7 or earlier for now, keep using `jpi` and refer to [legacy-jpi.md](legacy-jpi.md).
+
+## 1. Swap the plugin ID
+
+Replace the legacy plugin ID with `org.jenkins-ci.jpi2`.
+
+```groovy
+plugins {
+    id 'org.jenkins-ci.jpi' version '<old-version>'
+}
+```
+
+```kotlin
+plugins {
+    id("org.jenkins-ci.jpi2") version "<current-version>"
+}
+```
+
+## 2. Declare repositories explicitly
+
+The legacy plugin could configure repositories for you.
+`jpi2` expects you to declare the repositories you need in your build.
+
+```kotlin
+repositories {
+    mavenCentral()
+    maven {
+        name = "jenkins-releases"
+        url = uri("https://repo.jenkins-ci.org/releases/")
+    }
+}
+```
+
+## 3. Update the `jenkinsPlugin` block
+
+Several legacy settings map directly to `jpi2`.
+In Kotlin DSL, these can be written with direct assignment, which keeps the migrated block close to the old shape.
+
+- `jenkinsVersion = "..."` stays `jenkinsVersion = "..."`.
+- `shortName = "..."` becomes `pluginId = "..."`.
+- `displayName = "..."` stays `displayName = "..."`.
+- `url = "..."` becomes `homePage = uri("...")`.
+- `compatibleSinceVersion = "..."` stays `compatibleSinceVersion = "..."`.
+- `pluginFirstClassLoader = true` stays `pluginFirstClassLoader = true`.
+- `maskClasses = "a b"` becomes `maskClasses.add("a")` and `maskClasses.add("b")`.
+- `fileExtension = "hpi"` becomes `archiveExtension = "hpi"`.
+- `developers { ... }` and `licenses { ... }` still exist.
+
+Here is a minimal before and after example.
+
+```groovy
+jenkinsPlugin {
+    jenkinsVersion = '2.440.1'
+    shortName = 'example'
+    displayName = 'Example Plugin'
+    url = 'https://github.com/jenkinsci/example-plugin'
+    fileExtension = 'hpi'
+}
+```
+
+```kotlin
+jenkinsPlugin {
+    jenkinsVersion = "2.492.3"
+    pluginId = "example"
+    displayName = "Example Plugin"
+    homePage = uri("https://github.com/jenkinsci/example-plugin")
+    archiveExtension = "hpi"
+}
+```
+
+## 4. Move legacy-only settings out of the extension
+
+The `jpi2` extension intentionally drops several `jpi` convenience settings.
+Handle these concerns directly in your build instead of expecting them on `jenkinsPlugin`.
+
+- `configureRepositories` is no longer needed because repositories are declared explicitly in `repositories { ... }`.
+- `configurePublishing` is no longer needed because `jpi2` always configures Maven publication wiring.
+- `repoUrl`, `snapshotRepoUrl`, and `incrementalsRepoUrl` do not have direct `jpi2` extension equivalents.
+- `gitHubUrl` and `scmTag` do not have direct `jpi2` extension equivalents.
+- `workDir` is not a `jpi2` extension property.
+- `disabledTestInjection` does not have a `jpi2` replacement on the extension.
+- `enableSpotBugs()`, `enableCheckstyle()`, and `enableJacoco()` are not built into `jpi2`.
+
+If you need custom publishing metadata, configure the generated `MavenPublication` directly.
+
+```kotlin
+publishing {
+    publications.withType<MavenPublication>().configureEach {
+        pom {
+            scm {
+                connection.set("scm:git:https://github.com/jenkinsci/example-plugin.git")
+                developerConnection.set("scm:git:git@github.com:jenkinsci/example-plugin.git")
+                tag.set("HEAD")
+                url.set("https://github.com/jenkinsci/example-plugin")
+            }
+        }
+    }
+}
+```
+
+## 5. Update task customization
+
+Most day-to-day task names stay familiar, but a few details change.
+
+- `jpi` still builds the plugin archive.
+- `server` still starts a local Jenkins instance.
+- `hplRun` and `testHplRun` are new `jpi2` tasks for HPL-based development and verification.
+- `localizeMessages` is the supported localization task in both plugins.
+- `localizerOutputDir` should be replaced with direct configuration of the `localizeMessages` task.
+
+```kotlin
+tasks.named<org.jenkinsci.gradle.plugins.jpi2.localization.LocalizationTask>("localizeMessages") {
+    outputDir.set(layout.buildDirectory.dir("generated-src/localizer"))
+}
+```
+
+For the Jenkins HTTP port, set the `server.port` system property instead of using the legacy `server --port=...` convention.
+
+```shell
+./gradlew server -Dserver.port=8090
+```
+
+## 6. Decide how plugin versions should be produced
+
+Legacy `jpi` users often relied on `generateGitVersion`.
+`jpi2` still supports Git-based versions, but you now choose the source explicitly with `versionSource`.
+
+```kotlin
+jenkinsPlugin {
+    versionSource.set(org.jenkinsci.gradle.plugins.jpi2.VersionSource.GIT)
+    gitVersion {
+        allowDirty.set(true)
+        versionFormat.set("%d.%s")
+    }
+}
+```
+
+Use `VersionSource.PROJECT` when `project.version` should stay authoritative.
+Use `VersionSource.FIXED` when you want the plugin to publish a fixed string that is separate from `project.version`.
+
+## 7. Re-run your checks
+
+After the migration, run your normal verification tasks and then boot Jenkins locally.
+At a minimum, verify `./gradlew check`, `./gradlew jpi`, and either `./gradlew server` or `./gradlew hplRun`.


### PR DESCRIPTION
## Summary
- refocus the main README on the jpi2 plugin and call out that jpi is the legacy path for older Gradle versions
- move the legacy jpi documentation into its own doc for posterity
- add a migration guide for moving existing builds from jpi to jpi2