### PR TITLE
feat: add checkOverlappingSources to jpi2

### DIFF
--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/CheckOverlappingSourcesTask.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/CheckOverlappingSourcesTask.java
@@ -1,0 +1,91 @@
+package org.jenkinsci.gradle.plugins.jpi2;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
+import static java.util.stream.Collectors.joining;
+
+public abstract class CheckOverlappingSourcesTask extends DefaultTask {
+    public static final String NAME = "checkOverlappingSources";
+
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public abstract ConfigurableFileCollection getClassesDirs();
+
+    @OutputFile
+    public abstract RegularFileProperty getOutputFile();
+
+    @TaskAction
+    public void validate() {
+        var discovered = new ArrayList<File>();
+        Set<String> existingSezpozFiles = new HashSet<>();
+        for (File classDir : getClassesDirs().getFiles()) {
+            File annotationsDir = new File(classDir, "META-INF/annotations");
+            String[] files = annotationsDir.list();
+            if (files == null) {
+                continue;
+            }
+            for (String fileName : files) {
+                File path = new File(annotationsDir, fileName);
+                discovered.add(path);
+                if (!path.isFile()) {
+                    continue;
+                }
+                if (!existingSezpozFiles.add(fileName)) {
+                    throw new GradleException("Found overlapping Sezpoz file: " + fileName + ". Use joint compilation!");
+                }
+            }
+        }
+
+        var pluginImpls = new ArrayList<File>();
+        for (File classDir : getClassesDirs().getFiles()) {
+            File plugin = new File(classDir, "META-INF/services/hudson.Plugin");
+            if (plugin.exists()) {
+                pluginImpls.add(plugin);
+            }
+        }
+
+        if (pluginImpls.size() > 1) {
+            String implementations = pluginImpls.stream()
+                    .map(File::getPath)
+                    .collect(joining(", "));
+            throw new GradleException(
+                    "Found multiple directories containing Jenkins plugin implementations ('"
+                            + implementations
+                            + "'). Use joint compilation to work around this problem."
+            );
+        }
+        discovered.addAll(pluginImpls);
+
+        Path destination = getOutputFile().get().getAsFile().toPath();
+        try {
+            Files.createDirectories(destination.getParent());
+            try (BufferedWriter writer = Files.newBufferedWriter(destination, UTF_8, CREATE, TRUNCATE_EXISTING)) {
+                for (File file : discovered) {
+                    writer.append(file.getAbsolutePath()).append('\n');
+                }
+            }
+        } catch (IOException e) {
+            throw new GradleException("Failed to write to " + destination, e);
+        }
+    }
+}

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
@@ -123,6 +123,17 @@ public class V2JpiPlugin implements Plugin<Project> {
         SourceSet main = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME);
         main.getResources().getSrcDirs().add(project.file("src/main/webapp"));
         project.getPlugins().apply(LocalizationPlugin.class);
+        var checkOverlappingSources = project.getTasks().register(
+                CheckOverlappingSourcesTask.NAME,
+                CheckOverlappingSourcesTask.class,
+                task -> {
+                    task.setGroup("Verification");
+                    task.setDescription("Checks for overlapping generated Jenkins metadata across main source outputs.");
+                    task.getClassesDirs().from(main.getOutput().getClassesDirs());
+                    task.getOutputFile().set(project.getLayout().getBuildDirectory().file("check-overlap/discovered.txt"));
+                    task.dependsOn(project.getTasks().named("classes"));
+                });
+        project.getTasks().named("check", task -> task.dependsOn(checkOverlappingSources));
 
         var optionalManifest = project.getTasks().register(
                 GenerateOptionalJenkinsManifestTask.NAME,

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/CheckOverlappingSourcesIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/CheckOverlappingSourcesIntegrationTest.java
@@ -1,0 +1,92 @@
+package org.jenkinsci.gradle.plugins.jpi2;
+
+import com.google.common.io.Files;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.jenkinsci.gradle.plugins.jpi.IntegrationTestHelper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "TempDir doesn't appear to work correctly on Windows")
+class CheckOverlappingSourcesIntegrationTest extends V2IntegrationTestBase {
+
+    @Test
+    void checkLifecycleRunsCheckOverlappingSources() throws IOException {
+        var ith = new IntegrationTestHelper(tempDir, "8.14");
+        configureSimpleBuild(ith);
+
+        var firstRun = ith.gradleRunner().withArguments("check").build();
+        var secondRun = ith.gradleRunner().withArguments("check").build();
+
+        assertThat(firstRun.task(":checkOverlappingSources").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(secondRun.task(":checkOverlappingSources").getOutcome()).isEqualTo(TaskOutcome.UP_TO_DATE);
+        assertThat(ith.inProjectDir("build/check-overlap/discovered.txt")).exists();
+    }
+
+    @Test
+    void checkOverlappingSourcesFailsForMultiplePluginImplementations() throws IOException {
+        var ith = new IntegrationTestHelper(tempDir, "8.14");
+        initBuild(ith);
+        Files.write((getBasePluginConfig() + /* language=kotlin */ """
+                apply(plugin = "groovy")
+                dependencies {
+                    implementation(localGroovy())
+                }
+                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+        ith.mkDirInProjectDir("src/main/java/com/example");
+        ith.mkDirInProjectDir("src/main/groovy/com/example");
+        Files.write((/* language=java */ """
+                package com.example;
+                public class JavaPlugin extends hudson.Plugin {
+                }
+                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("src/main/java/com/example/JavaPlugin.java"));
+        Files.write((/* language=groovy */ """
+                package com.example
+                class GroovyPlugin extends hudson.Plugin {
+                }
+                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("src/main/groovy/com/example/GroovyPlugin.groovy"));
+
+        var result = ith.gradleRunner().withArguments("checkOverlappingSources").buildAndFail();
+
+        assertThat(result.getOutput())
+                .contains(":checkOverlappingSources FAILED")
+                .contains("Found multiple directories containing Jenkins plugin implementations");
+    }
+
+    @Test
+    void checkOverlappingSourcesFailsForOverlappingSezpozFiles() throws IOException {
+        var ith = new IntegrationTestHelper(tempDir, "8.14");
+        initBuild(ith);
+        Files.write((getBasePluginConfig() + /* language=kotlin */ """
+                apply(plugin = "groovy")
+                dependencies {
+                    implementation(localGroovy())
+                }
+                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+        ith.mkDirInProjectDir("src/main/java/com/example");
+        ith.mkDirInProjectDir("src/main/groovy/com/example");
+        Files.write((/* language=java */ """
+                package com.example;
+                @hudson.Extension
+                public class JavaExtension {
+                }
+                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("src/main/java/com/example/JavaExtension.java"));
+        Files.write((/* language=groovy */ """
+                package com.example
+                @hudson.Extension
+                class GroovyExtension {
+                }
+                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("src/main/groovy/com/example/GroovyExtension.groovy"));
+
+        var result = ith.gradleRunner().withArguments("checkOverlappingSources").buildAndFail();
+
+        assertThat(result.getOutput())
+                .contains(":checkOverlappingSources FAILED")
+                .contains("Found overlapping Sezpoz file:");
+    }
+}


### PR DESCRIPTION
## Summary
Add  support to the  plugin.
Register the task in the verification lifecycle so  depends on it.
Add integration tests for the success path and both overlapping-source failure modes.

## Testing
ngw :jpi2:check