### PR TITLE
fix: normalize hpl run plugin filenames

### DIFF
--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/ConfigurePrepareRunAction.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/ConfigurePrepareRunAction.java
@@ -14,6 +14,8 @@ import java.util.Comparator;
  * Action to configure the prepareRun task.
  */
 class ConfigurePrepareRunAction implements Action<Sync> {
+    private static final String JPI_EXTENSION = "jpi";
+
     private final TaskProvider<GenerateHplTask> hplTaskProvider;
     private final Provider<String> workDir;
     private final Configuration defaultRuntime;
@@ -40,7 +42,7 @@ class ConfigurePrepareRunAction implements Action<Sync> {
                                 .rename(new DropVersionTransformer(
                                         artifact.getModuleVersion().getId().getName(),
                                         artifact.getModuleVersion().getId().getVersion(),
-                                        artifact.getExtension()
+                                        JPI_EXTENSION
                                 ))
                 );
     }

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/OssPluginDependencyIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/OssPluginDependencyIntegrationTest.java
@@ -96,4 +96,22 @@ class OssPluginDependencyIntegrationTest extends V2IntegrationTestBase {
                         "workflow-step-api.jpi"
                 );
     }
+
+    @Test
+    void gradleBuildWithOssPluginDependencyShouldPrepareRunWithJpiPlugins() throws IOException {
+        // given
+        var ith = new IntegrationTestHelper(tempDir, "8.14");
+        configureBuildWithOssPluginDependency(ith);
+
+        // when
+        ith.gradleRunner().withArguments("prepareRun").build();
+
+        // then
+        var pluginsDir = ith.inProjectDir("work/plugins");
+        assertThat(pluginsDir).exists();
+
+        var files = Arrays.stream(Objects.requireNonNull(pluginsDir.list())).sorted().toList();
+        assertThat(files).contains("git.jpi", "test-plugin.hpl", "workflow-step-api.jpi");
+        assertThat(files).noneMatch(it -> it.endsWith(".hpi"));
+    }
 }


### PR DESCRIPTION
## Summary
Normalize dependency plugin filenames to .jpi during prepareRun so hplRun matches prepareServer and Jenkins does not log nonstandard filename warnings for copied plugin dependencies.

Add a regression test that verifies prepareRun copies plugin dependencies as .jpi files and leaves no .hpi files in work/plugins.

## Verification
- Passed: ./gradlew :jpi2:test --tests org.jenkinsci.gradle.plugins.jpi2.OssPluginDependencyIntegrationTest
- Reproduced against an internal project with --include-build and confirmed the ClassicPluginStrategy nonstandard-name .hpi warnings no longer appear during :testHplRun