### PR TITLE
feat: add `publishToJenkins()` shortcut for publishing repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ repositories {
 `jenkinsPublic()` adds the Jenkins public repository (`https://repo.jenkins-ci.org/public/`).
 `jenkinsIncrementals()` adds the Jenkins incrementals repository (`https://repo.jenkins-ci.org/incrementals/`).
 `jenkinsSnapshots()` adds the Jenkins snapshots repository (`https://repo.jenkins-ci.org/snapshots/`).
+These same shortcuts are available inside `publishing { repositories { } }` for configuring publish targets.
 
 jenkinsPlugin {
     jenkinsVersion.set("2.492.3")
@@ -134,6 +135,59 @@ jenkinsPlugin {
     }
 }
 ```
+
+### Publishing to Jenkins
+
+`jpi2` provides a `publishToJenkins()` shortcut for the `publishing { repositories { } }` block.
+It automatically selects the correct repository based on the project version:
+
+- Release versions publish to `https://repo.jenkins-ci.org/releases/`.
+- `-SNAPSHOT` versions publish to `https://repo.jenkins-ci.org/snapshots/`.
+- Incrementals versions (matching `-rc<N>.<hash>`) publish to `https://repo.jenkins-ci.org/incrementals/`.
+
+The repository uses Gradle `PasswordCredentials`.
+Set `jenkinsPublishUsername` and `jenkinsPublishPassword` in `~/.gradle/gradle.properties` or as environment variables (`ORG_GRADLE_PROJECT_jenkinsPublishUsername` and `ORG_GRADLE_PROJECT_jenkinsPublishPassword`).
+
+```kotlin
+import org.jenkinsci.gradle.plugins.jpi2.publishToJenkins
+
+publishing {
+    repositories {
+        publishToJenkins()
+    }
+}
+```
+
+In Groovy DSL, the import is not needed.
+
+```groovy
+publishing {
+    repositories {
+        publishToJenkins()
+    }
+}
+```
+
+### Publishing to a custom repository
+
+To publish to a private or internal Maven repository, configure it directly in `publishing { repositories { } }` using standard Gradle APIs.
+
+```kotlin
+publishing {
+    repositories {
+        maven {
+            name = "internal"
+            url = uri("https://maven.example.com/releases")
+            credentials {
+                username = providers.gradleProperty("internalUsername").get()
+                password = providers.gradleProperty("internalPassword").get()
+            }
+        }
+    }
+}
+```
+
+See the [Gradle publishing documentation](https://docs.gradle.org/current/userguide/publishing_maven.html#publishing_maven:repositories) for the full set of options including HTTP header credentials, AWS S3 repositories, and conditional repository selection.
 
 ### Running Jenkins locally
 

--- a/docs/migrating-to-jpi2.md
+++ b/docs/migrating-to-jpi2.md
@@ -40,6 +40,8 @@ repositories {
 `jenkinsPublic()` is the shorthand for the Jenkins public repository.
 `jenkinsIncrementals()` is the shorthand for the Jenkins incrementals repository.
 `jenkinsSnapshots()` is the shorthand for the Jenkins snapshots repository.
+These same shortcuts are available inside `publishing { repositories { } }`.
+`publishToJenkins()` is a convenience shortcut that automatically selects the right publishing repository based on the project version.
 
 ## 3. Update the `jenkinsPlugin` block
 
@@ -85,7 +87,9 @@ Handle these concerns directly in your build instead of expecting them on `jenki
 
 - `configureRepositories` is no longer needed because repositories are declared explicitly in `repositories { ... }`.
 - `configurePublishing` is no longer needed because `jpi2` always configures Maven publication wiring.
-- `repoUrl`, `snapshotRepoUrl`, and `incrementalsRepoUrl` do not have direct `jpi2` extension equivalents.
+- `repoUrl`, `snapshotRepoUrl`, and `incrementalsRepoUrl` are replaced by the `publishToJenkins()` shortcut in `publishing { repositories { } }`.
+  It selects the correct repository URL based on the project version and uses Gradle `PasswordCredentials` for authentication.
+  See the README for details.
 - `gitHubUrl` and `scmTag` do not have direct `jpi2` extension equivalents.
 - `disabledTestInjection` does not have a `jpi2` replacement on the extension.
 - `enableSpotBugs()`, `enableCheckstyle()`, and `enableJacoco()` are not built into `jpi2`.
@@ -94,6 +98,25 @@ Handle these concerns directly in your build instead of expecting them on `jenki
 That value is used by both `server` and `hplRun`.
 If you need a one-off override, pass `-Pjpi2.workDir=...`.
 The Gradle property takes precedence over `jenkinsPlugin.workDir`.
+
+If you were using custom `repoUrl` or `snapshotRepoUrl` values to publish to a private repository, configure it directly in `publishing { repositories { } }`.
+
+```kotlin
+publishing {
+    repositories {
+        maven {
+            name = "internal"
+            url = uri("https://maven.example.com/releases")
+            credentials {
+                username = providers.gradleProperty("internalUsername").get()
+                password = providers.gradleProperty("internalPassword").get()
+            }
+        }
+    }
+}
+```
+
+See the [Gradle publishing documentation](https://docs.gradle.org/current/userguide/publishing_maven.html#publishing_maven:repositories) for the full set of repository options.
 
 If you need custom publishing metadata, configure the generated `MavenPublication` directly.
 

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
@@ -70,6 +70,8 @@ public class V2JpiPlugin implements Plugin<Project> {
         project.getPlugins().apply(JavaLibraryPlugin.class);
         project.getPlugins().apply(MavenPublishPlugin.class);
         RepositoryShortcuts.registerRepositoryShortcuts(project.getRepositories());
+        var publishingExtension = project.getExtensions().getByType(PublishingExtension.class);
+        RepositoryShortcuts.registerRepositoryShortcuts(publishingExtension.getRepositories(), project);
 
         var extension = project.getExtensions().create("jenkinsPlugin", JenkinsPluginExtension.class, project);
         ((ExtensionAware) extension).getExtensions().create("gitVersion", GitVersionExtension.class,

--- a/jpi2/src/main/kotlin/org/jenkinsci/gradle/plugins/jpi2/RepositoryShortcuts.kt
+++ b/jpi2/src/main/kotlin/org/jenkinsci/gradle/plugins/jpi2/RepositoryShortcuts.kt
@@ -3,17 +3,24 @@
 package org.jenkinsci.gradle.plugins.jpi2
 
 import groovy.lang.Closure
+import org.gradle.api.Action
+import org.gradle.api.Project
 import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import org.gradle.api.artifacts.repositories.PasswordCredentials
 import org.gradle.api.plugins.ExtensionAware
 import java.net.URI
 
-internal const val JENKINS_PUBLIC_REPO_NAME = "jenkins-public"
-internal val JENKINS_PUBLIC_REPO_URL: URI = URI("https://repo.jenkins-ci.org/public/")
-internal const val JENKINS_INCREMENTALS_REPO_NAME = "jenkins-incrementals"
-internal val JENKINS_INCREMENTALS_REPO_URL: URI = URI("https://repo.jenkins-ci.org/incrementals/")
-internal const val JENKINS_SNAPSHOTS_REPO_NAME = "jenkins-snapshots"
-internal val JENKINS_SNAPSHOTS_REPO_URL: URI = URI("https://repo.jenkins-ci.org/snapshots/")
+internal const val JENKINS_PUBLIC_REPO_NAME = "jenkinsPublic"
+internal val JENKINS_PUBLIC_REPO_URL = URI("https://repo.jenkins-ci.org/public/")
+internal const val JENKINS_INCREMENTALS_REPO_NAME = "jenkinsIncrementals"
+internal val JENKINS_INCREMENTALS_REPO_URL = URI("https://repo.jenkins-ci.org/incrementals/")
+internal const val JENKINS_SNAPSHOTS_REPO_NAME = "jenkinsSnapshots"
+internal val JENKINS_SNAPSHOTS_REPO_URL = URI("https://repo.jenkins-ci.org/snapshots/")
+internal const val JENKINS_RELEASES_REPO_NAME = "jenkinsReleases"
+internal val JENKINS_RELEASES_REPO_URL = URI("https://repo.jenkins-ci.org/releases/")
+internal const val JENKINS_PUBLISH_REPO_NAME = "jenkinsPublish"
+private val INCREMENTALS_PATTERN = Regex(".*-rc\\d+\\.\\w+")
 
 fun RepositoryHandler.jenkinsPublic(): MavenArtifactRepository =
     maven {
@@ -32,6 +39,45 @@ fun RepositoryHandler.jenkinsSnapshots(): MavenArtifactRepository =
         name = JENKINS_SNAPSHOTS_REPO_NAME
         url = JENKINS_SNAPSHOTS_REPO_URL
     }
+
+private const val PROJECT_EXTRA_KEY = "org.jenkinsci.gradle.plugins.jpi2.project"
+
+fun RepositoryHandler.publishToJenkins(): MavenArtifactRepository {
+    val project = (this as ExtensionAware).extensions.extraProperties[PROJECT_EXTRA_KEY] as Project
+    val repo = maven {
+        name = JENKINS_PUBLISH_REPO_NAME
+        credentials(PasswordCredentials::class.java)
+    }
+    project.afterEvaluate(object : Action<Project> {
+        override fun execute(p: Project) {
+            val version = p.version.toString()
+            repo.url = when {
+                version.endsWith("-SNAPSHOT") -> JENKINS_SNAPSHOTS_REPO_URL
+                INCREMENTALS_PATTERN.matches(version) -> JENKINS_INCREMENTALS_REPO_URL
+                else -> JENKINS_RELEASES_REPO_URL
+            }
+        }
+    })
+    return repo
+}
+
+fun registerRepositoryShortcuts(repositories: RepositoryHandler, project: Project) {
+    if (repositories is ExtensionAware) {
+        repositories.extensions.extraProperties[PROJECT_EXTRA_KEY] = project
+        if (repositories.extensions.findByName("publishToJenkins") == null) {
+            repositories.extensions.add(
+                "publishToJenkins",
+                object : Closure<MavenArtifactRepository>(repositories, repositories) {
+                    @Suppress("unused")
+                    fun doCall(): MavenArtifactRepository {
+                        return repositories.publishToJenkins()
+                    }
+                }
+            )
+        }
+    }
+    registerRepositoryShortcuts(repositories)
+}
 
 fun registerRepositoryShortcuts(repositories: RepositoryHandler) {
     if (repositories is ExtensionAware) {

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/PublishingIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/PublishingIntegrationTest.java
@@ -76,7 +76,7 @@ class PublishingIntegrationTest extends V2IntegrationTestBase {
                 .extracting(Repository::getId, Repository::getUrl)
                 .containsExactlyInAnyOrder(
                         new Tuple("MavenRepo", "https://repo.maven.apache.org/maven2/"),
-                        new Tuple("jenkins-public", "https://repo.jenkins-ci.org/public/")
+                        new Tuple("jenkinsPublic", "https://repo.jenkins-ci.org/public/")
                 );
         var explodedWar = ith.inProjectDir("build/jpi");
 
@@ -167,8 +167,155 @@ class PublishingIntegrationTest extends V2IntegrationTestBase {
                 .extracting(Repository::getId, Repository::getUrl)
                 .containsExactlyInAnyOrder(
                         new Tuple("MavenRepo", "https://repo.maven.apache.org/maven2/"),
-                        new Tuple("jenkins-public", "https://repo.jenkins-ci.org/public/")
+                        new Tuple("jenkinsPublic", "https://repo.jenkins-ci.org/public/")
                 );
+    }
+
+    private static final String PUBLISH_TO_JENKINS_IMPORT = """
+            import org.jenkinsci.gradle.plugins.jpi2.publishToJenkins
+
+            """;
+
+    private static final String JENKINS_PUBLISH_USERNAME = "-PjenkinsPublishUsername=test";
+    private static final String JENKINS_PUBLISH_PASSWORD = "-PjenkinsPublishPassword=test";
+
+    @Test
+    void publishToJenkinsSelectsReleasesForReleaseVersion() throws IOException {
+        // given
+        var ith = new IntegrationTestHelper(tempDir, "8.14");
+        initBuild(ith);
+        com.google.common.io.Files.write((PUBLISH_TO_JENKINS_IMPORT + getBasePluginConfig() + /* language=kotlin */ """
+                publishing {
+                    repositories {
+                        publishToJenkins()
+                    }
+                }
+                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+
+        // when
+        var result = ith.gradleRunner().withArguments(
+                "publish", "--dry-run", JENKINS_PUBLISH_USERNAME, JENKINS_PUBLISH_PASSWORD).build();
+
+        // then
+        assertThat(result.getOutput()).contains("publishMavenJpiPublicationToJenkinsPublishRepository");
+    }
+
+    @Test
+    void publishToJenkinsSelectsSnapshotsForSnapshotVersion() throws IOException {
+        // given
+        var ith = new IntegrationTestHelper(tempDir, "8.14");
+        initBuild(ith);
+        com.google.common.io.Files.write((PUBLISH_TO_JENKINS_IMPORT + String.format(/* language=kotlin */ """
+                plugins {
+                    id("org.jenkins-ci.jpi2")
+                }
+                repositories {
+                    mavenCentral()
+                    jenkinsPublic()
+                }
+                tasks.named<JavaExec>("server") {
+                    args("--httpPort=%d")
+                }
+                tasks.named<JavaExec>("hplRun") {
+                    args("--httpPort=%d")
+                }
+                group = "com.example"
+                version = "1.0.0-SNAPSHOT"
+                publishing {
+                    repositories {
+                        publishToJenkins()
+                        maven {
+                            name = "local"
+                            url = uri("${rootDir}/build/repo")
+                        }
+                    }
+                }
+                """, RandomPortProvider.findFreePort(), RandomPortProvider.findFreePort()))
+                .getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+
+        // when
+        var result = ith.gradleRunner().withArguments(
+                "publishMavenJpiPublicationToJenkinsPublishRepository", "--dry-run",
+                JENKINS_PUBLISH_USERNAME, JENKINS_PUBLISH_PASSWORD).build();
+
+        // then
+        assertThat(result.getOutput()).contains("publishMavenJpiPublicationToJenkinsPublishRepository");
+    }
+
+    @Test
+    void publishToJenkinsSelectsIncrementalsForRcVersion() throws IOException {
+        // given
+        var ith = new IntegrationTestHelper(tempDir, "8.14");
+        initBuild(ith);
+        com.google.common.io.Files.write((PUBLISH_TO_JENKINS_IMPORT + String.format(/* language=kotlin */ """
+                plugins {
+                    id("org.jenkins-ci.jpi2")
+                }
+                repositories {
+                    mavenCentral()
+                    jenkinsPublic()
+                }
+                tasks.named<JavaExec>("server") {
+                    args("--httpPort=%d")
+                }
+                tasks.named<JavaExec>("hplRun") {
+                    args("--httpPort=%d")
+                }
+                group = "com.example"
+                version = "1.0-rc1234.abc123"
+                publishing {
+                    repositories {
+                        publishToJenkins()
+                        maven {
+                            name = "local"
+                            url = uri("${rootDir}/build/repo")
+                        }
+                    }
+                }
+                """, RandomPortProvider.findFreePort(), RandomPortProvider.findFreePort()))
+                .getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+
+        // when
+        var result = ith.gradleRunner().withArguments(
+                "publishMavenJpiPublicationToJenkinsPublishRepository", "--dry-run",
+                JENKINS_PUBLISH_USERNAME, JENKINS_PUBLISH_PASSWORD).build();
+
+        // then
+        assertThat(result.getOutput()).contains("publishMavenJpiPublicationToJenkinsPublishRepository");
+    }
+
+    @Test
+    void publishToJenkinsWorksInGroovyDsl() throws IOException {
+        // given
+        var ith = new IntegrationTestHelper(tempDir, "8.14");
+        initBuild(ith);
+        com.google.common.io.Files.write(/* language=groovy */ """
+                plugins {
+                    id "org.jenkins-ci.jpi2"
+                }
+                repositories {
+                    mavenCentral()
+                    jenkinsPublic()
+                }
+                group = "com.example"
+                version = "1.0.0"
+                publishing {
+                    repositories {
+                        publishToJenkins()
+                        maven {
+                            name = "local"
+                            url = uri("${rootDir}/build/repo")
+                        }
+                    }
+                }
+                """.getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle"));
+
+        // when
+        var result = ith.gradleRunner().withArguments(
+                "publish", "--dry-run", JENKINS_PUBLISH_USERNAME, JENKINS_PUBLISH_PASSWORD).build();
+
+        // then
+        assertThat(result.getOutput()).contains("publishMavenJpiPublicationToJenkinsPublishRepository");
     }
 
     @Test


### PR DESCRIPTION
The existing repository shortcuts (`jenkinsPublic`, `jenkinsIncrementals`, `jenkinsSnapshots`) were only useful for dependency resolution.
Publishing to the Jenkins community repositories required manual `maven { }` configuration with hardcoded URLs and separate credential handling.

`publishToJenkins()` is a single shortcut that:
- Selects the correct repository based on project version: `releases` for stable versions, `snapshots` for `-SNAPSHOT`, `incrementals` for `-rc` builds
- Uses Gradle `PasswordCredentials` so users supply `jenkinsPublishUsername` and `jenkinsPublishPassword` via `gradle.properties` or environment variables, replacing the legacy `~/.jenkins-ci.org` file approach
- Works in both Kotlin DSL (with import) and Groovy DSL

The existing shortcuts are also now registered on the publishing `RepositoryHandler`.

Documentation updated in README and migration guide with examples for both the Jenkins shortcut and custom repository publishing.
