### PR TITLE
chore: Stop building jpi

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -9,31 +9,7 @@ on:
   pull_request:
     branches: [ main ]
 
-
 jobs:
-  build-jpi:
-    name: jpi/${{ matrix.os }}/${{ matrix.gradle_version }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-        gradle_version: ["7.3", "8.0.2"]
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: "17"
-        distribution: "temurin"
-        cache: "gradle"
-    - name: Test ${{ matrix.gradle_version }}
-      run: ./gradlew :jpi:testGradle${{ matrix.gradle_version }}
-    - name: Archive Test Results on Failure
-      uses: actions/upload-artifact@v4
-      if: ${{ failure() }}
-      with:
-        name: ${{ matrix.os }}-${{ matrix.gradle_version }}-test-results
-        path: build/reports/tests
   build-jpi2:
     name: jpi2/${{ matrix.os }}/${{ matrix.gradle_version }}
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -7,8 +7,16 @@
 [regression-workflow]: https://github.com/jenkinsci/gradle-jpi-plugin/actions?query=workflow%3ARegression
 
 This repository contains two Gradle plugins for building Jenkins plugins.
-`org.jenkins-ci.jpi2` is the recommended plugin for modern Gradle builds and is the primary focus of this README.
-`org.jenkins-ci.jpi` remains available for older Gradle builds, and its documentation now lives in [docs/legacy-jpi.md](docs/legacy-jpi.md).
+
+- `org.jenkins-ci.jpi2` is the recommended plugin for modern Gradle builds and is the primary focus of this README.
+
+- `org.jenkins-ci.jpi` remains available for older Gradle builds, and its documentation now lives in [docs/legacy-jpi.md](docs/legacy-jpi.md).
+  It worked with Gradle 8.13.x and below.
+  The last meaningful update to the legacy plugin was in 2025-02 in [v0.53.1](https://github.com/jenkinsci/gradle-jpi-plugin/releases/tag/v0.53.1).
+  It was still being built until 2026-04, because we built both plugins in one build.
+  As of [v0.58.0](https://github.com/jenkinsci/gradle-jpi-plugin/releases/tag/v0.53.1), the legacy plugin is no longer built or published, but the source code is still available in the repository.
+  This allows us to modernize the gradle version used to build the plugin.
+
 If you are moving an existing build forward, start with [docs/migrating-to-jpi2.md](docs/migrating-to-jpi2.md).
 
 ## Choosing a plugin

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,9 +4,6 @@ val jpiMode = providers.gradleProperty("gradleJpiPlugin.mode")
     .orElse("all")
     .get()
 include("core")
-if (jpiMode == "all" || jpiMode == "jpi") {
-    include("jpi")
-}
 if (jpiMode == "all" || jpiMode == "jpi2") {
     include("jpi2")
 }


### PR DESCRIPTION
This change will make it so we only build jpi2.
This will allow us to build with newer gradle versions.

After #342, we've got feature parity.