### PR TITLE
chore: Drop spock dependency

### DIFF
--- a/jpi2/build.gradle.kts
+++ b/jpi2/build.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
 
     // Test dependencies
     testImplementation(testFixtures(project(":core")))
-    testImplementation(libs.spock.core)
     testImplementation(platform(libs.junit5.bom))
     testImplementation(libs.junit5.api)
     testImplementation(libs.assertj.core)


### PR DESCRIPTION
We don't have any spock tests.
This blocks upgrading gradle to newer versions.
