### PR TITLE
refactor: replace Guava `Files` with JDK `java.nio.file.Files`

### DIFF
--- a/jpi2/build.gradle.kts
+++ b/jpi2/build.gradle.kts
@@ -24,7 +24,6 @@ dependencies {
     testImplementation(libs.awaitility)
     testImplementation(libs.commons.io)
     testImplementation(libs.maven.model)
-    testImplementation(libs.guava)
     testCompileOnly(libs.develocity.testing.annotations)
     testCompileOnly(libs.jetbrains.annotations)
     testRuntimeOnly(libs.junit5.jupiter)

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/AccessModifierIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/AccessModifierIntegrationTest.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.gradle.plugins.jpi2;
 
-import com.google.common.io.Files;
+import java.nio.file.Files;
 import org.jenkinsci.gradle.plugins.jpi.IntegrationTestHelper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
@@ -19,16 +19,16 @@ class AccessModifierIntegrationTest extends V2IntegrationTestBase {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write(getBasePluginConfig().getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), getBasePluginConfig().getBytes(StandardCharsets.UTF_8));
         ith.mkDirInProjectDir("src/main/java/com/example/plugin");
-        Files.write((/* language=java */ """
+        Files.write(ith.inProjectDir("src/main/java/com/example/plugin/Example.java").toPath(), (/* language=java */ """
                 package com.example.plugin;
                 public class Example {
                     public String value() {
                         return "ok";
                     }
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("src/main/java/com/example/plugin/Example.java"));
+                """).getBytes(StandardCharsets.UTF_8));
 
         // when
         var result = ith.gradleRunner().withArguments("check").build();
@@ -43,14 +43,14 @@ class AccessModifierIntegrationTest extends V2IntegrationTestBase {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getBasePluginConfig() + /* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig() + /* language=kotlin */ """
                 tasks.named<org.jenkinsci.gradle.plugins.jpi2.accmod.CheckAccessModifierTask>("checkAccessModifier") {
                     ignoreFailures.set(false)
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
         ith.mkDirInProjectDir("src/main/java/org/example/restricted");
         ith.mkDirInProjectDir("src/main/java/org/example/blessed");
-        Files.write((/* language=java */ """
+        Files.write(ith.inProjectDir("src/main/java/org/example/restricted/OhNo.java").toPath(), (/* language=java */ """
                 package org.example.restricted;
                 import org.kohsuke.accmod.Restricted;
                 import org.kohsuke.accmod.restrictions.DoNotUse;
@@ -60,8 +60,8 @@ class AccessModifierIntegrationTest extends V2IntegrationTestBase {
                         return a + b;
                     }
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("src/main/java/org/example/restricted/OhNo.java"));
-        Files.write((/* language=java */ """
+                """).getBytes(StandardCharsets.UTF_8));
+        Files.write(ith.inProjectDir("src/main/java/org/example/blessed/Consumer.java").toPath(), (/* language=java */ """
                 package org.example.blessed;
                 import org.example.restricted.OhNo;
                 public class Consumer {
@@ -69,7 +69,7 @@ class AccessModifierIntegrationTest extends V2IntegrationTestBase {
                         return new OhNo().add(1, 2);
                     }
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("src/main/java/org/example/blessed/Consumer.java"));
+                """).getBytes(StandardCharsets.UTF_8));
 
         // when
         var result = ith.gradleRunner().withArguments("checkAccessModifier").buildAndFail();

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/ArchiveExtensionIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/ArchiveExtensionIntegrationTest.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.gradle.plugins.jpi2;
 
-import com.google.common.io.Files;
+import java.nio.file.Files;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
@@ -39,11 +39,11 @@ class ArchiveExtensionIntegrationTest extends V2IntegrationTestBase {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getBasePluginConfig() + /* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig() + /* language=kotlin */ """
                 jenkinsPlugin {
                     archiveExtension.set("hpi")
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
 
         // when
         ith.gradleRunner().withArguments("jpi").build();
@@ -60,11 +60,11 @@ class ArchiveExtensionIntegrationTest extends V2IntegrationTestBase {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getBasePluginConfig() + /* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig() + /* language=kotlin */ """
                 jenkinsPlugin {
                     archiveExtension.set("hpi")
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
 
         // when
         ith.gradleRunner().withArguments("publish").build();
@@ -86,11 +86,11 @@ class ArchiveExtensionIntegrationTest extends V2IntegrationTestBase {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getBasePluginConfig() + /* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig() + /* language=kotlin */ """
                 jenkinsPlugin {
                     archiveExtension.set("hpi")
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
 
         // when
         ith.gradleRunner().withArguments("prepareServer").build();

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/CheckOverlappingSourcesIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/CheckOverlappingSourcesIntegrationTest.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.gradle.plugins.jpi2;
 
-import com.google.common.io.Files;
+import java.nio.file.Files;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.jenkinsci.gradle.plugins.jpi.IntegrationTestHelper;
 import org.junit.jupiter.api.Test;
@@ -32,24 +32,24 @@ class CheckOverlappingSourcesIntegrationTest extends V2IntegrationTestBase {
     void checkOverlappingSourcesFailsForMultiplePluginImplementations() throws IOException {
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getBasePluginConfig() + /* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig() + /* language=kotlin */ """
                 apply(plugin = "groovy")
                 dependencies {
                     implementation(localGroovy())
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
         ith.mkDirInProjectDir("src/main/java/com/example");
         ith.mkDirInProjectDir("src/main/groovy/com/example");
-        Files.write((/* language=java */ """
+        Files.write(ith.inProjectDir("src/main/java/com/example/JavaPlugin.java").toPath(), (/* language=java */ """
                 package com.example;
                 public class JavaPlugin extends hudson.Plugin {
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("src/main/java/com/example/JavaPlugin.java"));
-        Files.write((/* language=groovy */ """
+                """).getBytes(StandardCharsets.UTF_8));
+        Files.write(ith.inProjectDir("src/main/groovy/com/example/GroovyPlugin.groovy").toPath(), (/* language=groovy */ """
                 package com.example
                 class GroovyPlugin extends hudson.Plugin {
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("src/main/groovy/com/example/GroovyPlugin.groovy"));
+                """).getBytes(StandardCharsets.UTF_8));
 
         var result = ith.gradleRunner().withArguments("checkOverlappingSources").buildAndFail();
 
@@ -62,26 +62,26 @@ class CheckOverlappingSourcesIntegrationTest extends V2IntegrationTestBase {
     void checkOverlappingSourcesFailsForOverlappingSezpozFiles() throws IOException {
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getBasePluginConfig() + /* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig() + /* language=kotlin */ """
                 apply(plugin = "groovy")
                 dependencies {
                     implementation(localGroovy())
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
         ith.mkDirInProjectDir("src/main/java/com/example");
         ith.mkDirInProjectDir("src/main/groovy/com/example");
-        Files.write((/* language=java */ """
+        Files.write(ith.inProjectDir("src/main/java/com/example/JavaExtension.java").toPath(), (/* language=java */ """
                 package com.example;
                 @hudson.Extension
                 public class JavaExtension {
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("src/main/java/com/example/JavaExtension.java"));
-        Files.write((/* language=groovy */ """
+                """).getBytes(StandardCharsets.UTF_8));
+        Files.write(ith.inProjectDir("src/main/groovy/com/example/GroovyExtension.groovy").toPath(), (/* language=groovy */ """
                 package com.example
                 @hudson.Extension
                 class GroovyExtension {
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("src/main/groovy/com/example/GroovyExtension.groovy"));
+                """).getBytes(StandardCharsets.UTF_8));
 
         var result = ith.gradleRunner().withArguments("checkOverlappingSources").buildAndFail();
 

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/DependencyFilteringIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/DependencyFilteringIntegrationTest.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.gradle.plugins.jpi2;
 
-import com.google.common.io.Files;
+import java.nio.file.Files;
 import org.jenkinsci.gradle.plugins.jpi.IntegrationTestHelper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
@@ -20,16 +20,16 @@ class DependencyFilteringIntegrationTest extends V2IntegrationTestBase {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getBasePluginConfig() +/* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig() +/* language=kotlin */ """
                 dependencies {
                     annotationProcessor("org.projectlombok:lombok:1.18.38")
                     compileOnly("org.projectlombok:lombok:1.18.38")
                     runtimeOnly("com.google.inject:guice:5.1.0") // This is an older version of Guice that should get upgraded
                 }
                 configurations.getByName("compileClasspath").shouldResolveConsistentlyWith(configurations.getByName("runtimeClasspath"))
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
         ith.mkDirInProjectDir("src/main/java/com/example/plugin");
-        Files.write(/* language=java */ """
+        Files.write(ith.inProjectDir("src/main/java/com/example/plugin/PluginAction.java").toPath(), /* language=java */ """
                 package com.example.plugin;
                 import lombok.*;
                 import hudson.Extension;
@@ -47,7 +47,7 @@ class DependencyFilteringIntegrationTest extends V2IntegrationTestBase {
                     public String getDisplayName() { return "Example plugin"; }
                     public String getIconFileName() { return null; }
                 }
-                """.getBytes(StandardCharsets.UTF_8), ith.inProjectDir("src/main/java/com/example/plugin/PluginAction.java"));
+                """.getBytes(StandardCharsets.UTF_8));
 
         // when
         var gradleRunner = ith.gradleRunner();
@@ -71,7 +71,7 @@ class DependencyFilteringIntegrationTest extends V2IntegrationTestBase {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getBasePluginConfig() +/* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig() +/* language=kotlin */ """
                 dependencies {
                     annotationProcessor("org.projectlombok:lombok:1.18.38")
                     compileOnly("org.projectlombok:lombok:1.18.38")
@@ -79,9 +79,9 @@ class DependencyFilteringIntegrationTest extends V2IntegrationTestBase {
                     implementation("com.fasterxml.jackson.core:jackson-databind:2.19.0") // This is a jar dependency that should not be included in the JPI
                 }
                 configurations.getByName("compileClasspath").shouldResolveConsistentlyWith(configurations.getByName("runtimeClasspath"))
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
         ith.mkDirInProjectDir("src/main/java/com/example/plugin");
-        Files.write(/* language=java */ """
+        Files.write(ith.inProjectDir("src/main/java/com/example/plugin/PluginAction.java").toPath(), /* language=java */ """
                 package com.example.plugin;
                 import lombok.*;
                 import hudson.Extension;
@@ -99,7 +99,7 @@ class DependencyFilteringIntegrationTest extends V2IntegrationTestBase {
                     public String getDisplayName() { return "Example plugin"; }
                     public String getIconFileName() { return null; }
                 }
-                """.getBytes(StandardCharsets.UTF_8), ith.inProjectDir("src/main/java/com/example/plugin/PluginAction.java"));
+                """.getBytes(StandardCharsets.UTF_8));
 
         // when
         var gradleRunner = ith.gradleRunner();
@@ -123,7 +123,7 @@ class DependencyFilteringIntegrationTest extends V2IntegrationTestBase {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getBasePluginConfig() +/* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig() +/* language=kotlin */ """
                 dependencies {
                     annotationProcessor("org.projectlombok:lombok:1.18.38")
                     compileOnly("org.projectlombok:lombok:1.18.38")
@@ -131,9 +131,9 @@ class DependencyFilteringIntegrationTest extends V2IntegrationTestBase {
                     implementation("com.auth0:java-jwt:4.5.0") // This also depends on jackson-databind. We should include this jar, but not jackson-databind in the WEB-INF/lib dir.
                 }
                 configurations.getByName("compileClasspath").shouldResolveConsistentlyWith(configurations.getByName("runtimeClasspath"))
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
         ith.mkDirInProjectDir("src/main/java/com/example/plugin");
-        Files.write(/* language=java */ """
+        Files.write(ith.inProjectDir("src/main/java/com/example/plugin/PluginAction.java").toPath(), /* language=java */ """
                 package com.example.plugin;
                 import lombok.*;
                 import hudson.Extension;
@@ -151,7 +151,7 @@ class DependencyFilteringIntegrationTest extends V2IntegrationTestBase {
                     public String getDisplayName() { return "Example plugin"; }
                     public String getIconFileName() { return null; }
                 }
-                """.getBytes(StandardCharsets.UTF_8), ith.inProjectDir("src/main/java/com/example/plugin/PluginAction.java"));
+                """.getBytes(StandardCharsets.UTF_8));
 
         // when
         var gradleRunner = ith.gradleRunner();
@@ -175,13 +175,13 @@ class DependencyFilteringIntegrationTest extends V2IntegrationTestBase {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getBasePluginConfig() + /* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig() + /* language=kotlin */ """
                 dependencies {
                     implementation("org.jenkins-ci.plugins:git:5.7.0")
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
         ith.mkDirInProjectDir("src/main/java/com/example/plugin");
-        Files.write(/* language=java */ """
+        Files.write(ith.inProjectDir("src/main/java/com/example/plugin/PluginAction.java").toPath(), /* language=java */ """
                 package com.example.plugin;
                 import hudson.plugins.git.Branch;
                 public class PluginAction {
@@ -191,7 +191,7 @@ class DependencyFilteringIntegrationTest extends V2IntegrationTestBase {
                         this.name = name;
                     }
                 }
-                """.getBytes(StandardCharsets.UTF_8), ith.inProjectDir("src/main/java/com/example/plugin/PluginAction.java"));
+                """.getBytes(StandardCharsets.UTF_8));
 
         // when
         var gradleRunner = ith.gradleRunner();
@@ -215,14 +215,14 @@ class DependencyFilteringIntegrationTest extends V2IntegrationTestBase {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getBasePluginConfig() +/* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig() +/* language=kotlin */ """
                 dependencies {
                     annotationProcessor("org.projectlombok:lombok:1.18.38")
                     compileOnly("org.projectlombok:lombok:1.18.38")
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
         ith.mkDirInProjectDir("src/main/java/com/example/plugin");
-        Files.write(/* language=java */ """
+        Files.write(ith.inProjectDir("src/main/java/com/example/plugin/PluginAction.java").toPath(), /* language=java */ """
                 package com.example.plugin;
                 import lombok.*;
                 import hudson.Extension;
@@ -240,7 +240,7 @@ class DependencyFilteringIntegrationTest extends V2IntegrationTestBase {
                     public String getDisplayName() { return "Example plugin"; }
                     public String getIconFileName() { return null; }
                 }
-                """.getBytes(StandardCharsets.UTF_8), ith.inProjectDir("src/main/java/com/example/plugin/PluginAction.java"));
+                """.getBytes(StandardCharsets.UTF_8));
 
         // when
         var gradleRunner = ith.gradleRunner();

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/DependencyResolutionIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/DependencyResolutionIntegrationTest.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.gradle.plugins.jpi2;
 
-import com.google.common.io.Files;
+import java.nio.file.Files;
 import org.apache.commons.io.IOUtils;
 import org.gradle.testkit.runner.GradleRunner;
 import org.jenkinsci.gradle.plugins.jpi.IntegrationTestHelper;
@@ -24,9 +24,9 @@ class DependencyResolutionIntegrationTest extends V2IntegrationTestBase {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getBasePluginConfig()).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig()).getBytes(StandardCharsets.UTF_8));
         ith.mkDirInProjectDir("src/main/java/com/example/plugin");
-        Files.write((/* language=java */ """
+        Files.write(ith.inProjectDir("src/main/java/com/example/plugin/SomeExtension.java").toPath(), (/* language=java */ """
                 package com.example.plugin;
                 @hudson.Extension
                 public class SomeExtension {
@@ -34,7 +34,7 @@ class DependencyResolutionIntegrationTest extends V2IntegrationTestBase {
                         System.out.println("Hello from SomeExtension");
                     }
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("src/main/java/com/example/plugin/SomeExtension.java"));
+                """).getBytes(StandardCharsets.UTF_8));
 
         GradleRunner gradleRunner = ith.gradleRunner();
 
@@ -45,7 +45,7 @@ class DependencyResolutionIntegrationTest extends V2IntegrationTestBase {
         var extensionsList = ith.inProjectDir("build/classes/java/main/META-INF/annotations/hudson.Extension.txt");
         assertThat(extensionsList).exists();
 
-        var lines = Files.readLines(extensionsList, StandardCharsets.UTF_8);
+        var lines = Files.readAllLines(extensionsList.toPath(), StandardCharsets.UTF_8);
         assertThat(lines.subList(1, lines.size())).containsExactlyInAnyOrder("com.example.plugin.SomeExtension");
     }
 
@@ -54,16 +54,16 @@ class DependencyResolutionIntegrationTest extends V2IntegrationTestBase {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getBasePluginConfig() +/* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig() +/* language=kotlin */ """
                 dependencies {
                     annotationProcessor("org.projectlombok:lombok:1.18.38")
                     compileOnly("org.projectlombok:lombok:1.18.38")
                     runtimeOnly("com.google.inject:guice:5.1.0") // This is an older version of Guice that should get upgraded
                 }
                 configurations.getByName("compileClasspath").shouldResolveConsistentlyWith(configurations.getByName("runtimeClasspath"))
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
         ith.mkDirInProjectDir("src/main/java/com/example/plugin");
-        Files.write(/* language=java */ """
+        Files.write(ith.inProjectDir("src/main/java/com/example/plugin/PluginAction.java").toPath(), /* language=java */ """
                 package com.example.plugin;
                 import lombok.*;
                 import hudson.Extension;
@@ -81,7 +81,7 @@ class DependencyResolutionIntegrationTest extends V2IntegrationTestBase {
                     public String getDisplayName() { return "Example plugin"; }
                     public String getIconFileName() { return null; }
                 }
-                """.getBytes(StandardCharsets.UTF_8), ith.inProjectDir("src/main/java/com/example/plugin/PluginAction.java"));
+                """.getBytes(StandardCharsets.UTF_8));
 
         // when
         var gradleRunner = ith.gradleRunner();
@@ -116,12 +116,12 @@ class DependencyResolutionIntegrationTest extends V2IntegrationTestBase {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getBasePluginConfig() + /* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig() + /* language=kotlin */ """
                 dependencies {
                     implementation("org.jenkins-ci.plugins:git:5.7.0")
                     implementation("com.github.rahulsom:nothing-java:0.2.0")
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
 
         var gradleRunner = ith.gradleRunner();
 
@@ -143,12 +143,12 @@ class DependencyResolutionIntegrationTest extends V2IntegrationTestBase {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getBasePluginConfig() + /* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig() + /* language=kotlin */ """
                 dependencies {
                     implementation("org.jenkins-ci.plugins:git:5.7.0")
                     implementation("com.github.rahulsom:nothing-java:0.2.0")
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
 
         var gradleRunner = ith.gradleRunner();
 
@@ -170,13 +170,13 @@ class DependencyResolutionIntegrationTest extends V2IntegrationTestBase {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getBasePluginConfig() + /* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig() + /* language=kotlin */ """
                 dependencies {
                     implementation("com.github.rahulsom:nothing-java:0.2.0") {
                         exclude(group = "org.apache.commons", module = "commons-lang3")
                     }
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
 
         var gradleRunner = ith.gradleRunner();
 

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/IncludedBuildDependencyIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/IncludedBuildDependencyIntegrationTest.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.gradle.plugins.jpi2;
 
-import com.google.common.io.Files;
+import java.nio.file.Files;
 import org.jenkinsci.gradle.plugins.jpi.IntegrationTestHelper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
@@ -36,47 +36,47 @@ class IncludedBuildDependencyIntegrationTest extends V2IntegrationTestBase {
     }
 
     private static void configureBuildWithIncludedBuildLibraryDependency(IntegrationTestHelper ith) throws IOException {
-        Files.write(/* language=kotlin */ """
+        Files.write(ith.inProjectDir("settings.gradle.kts").toPath(), /* language=kotlin */ """
                 rootProject.name = "test-plugin"
                 includeBuild("included-build")
-                """.getBytes(StandardCharsets.UTF_8), ith.inProjectDir("settings.gradle.kts"));
+                """.getBytes(StandardCharsets.UTF_8));
 
-        Files.write((getBasePluginConfig() + /* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig() + /* language=kotlin */ """
                 dependencies {
                     implementation("com.example:lib:1.0.0")
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
 
         ith.mkDirInProjectDir("included-build/lib/src/main/java/com/example/lib");
 
-        Files.write(/* language=kotlin */ """
+        Files.write(ith.inProjectDir("included-build/settings.gradle.kts").toPath(), /* language=kotlin */ """
                 rootProject.name = "included-build"
                 include("lib")
-                """.getBytes(StandardCharsets.UTF_8), ith.inProjectDir("included-build/settings.gradle.kts"));
+                """.getBytes(StandardCharsets.UTF_8));
 
-        Files.write(/* language=kotlin */ """
+        Files.write(ith.inProjectDir("included-build/build.gradle.kts").toPath(), /* language=kotlin */ """
                 allprojects {
                     group = "com.example"
                     version = "1.0.0"
                 }
-                """.getBytes(StandardCharsets.UTF_8), ith.inProjectDir("included-build/build.gradle.kts"));
+                """.getBytes(StandardCharsets.UTF_8));
 
-        Files.write(/* language=kotlin */ """
+        Files.write(ith.inProjectDir("included-build/lib/build.gradle.kts").toPath(), /* language=kotlin */ """
                 plugins {
                     id("java-library")
                 }
                 repositories {
                     mavenCentral()
                 }
-                """.getBytes(StandardCharsets.UTF_8), ith.inProjectDir("included-build/lib/build.gradle.kts"));
+                """.getBytes(StandardCharsets.UTF_8));
 
-        Files.write(/* language=java */ """
+        Files.write(ith.inProjectDir("included-build/lib/src/main/java/com/example/lib/IncludedBuildLibrary.java").toPath(), /* language=java */ """
                 package com.example.lib;
                 public class IncludedBuildLibrary {
                     public String hello() {
                         return "hello";
                     }
                 }
-                """.getBytes(StandardCharsets.UTF_8), ith.inProjectDir("included-build/lib/src/main/java/com/example/lib/IncludedBuildLibrary.java"));
+                """.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/LocalizationIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/LocalizationIntegrationTest.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.gradle.plugins.jpi2;
 
-import com.google.common.io.Files;
+import java.nio.file.Files;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.jenkinsci.gradle.plugins.jpi.IntegrationTestHelper;
@@ -21,10 +21,10 @@ class LocalizationIntegrationTest extends V2IntegrationTestBase {
     void classesTaskCompilesGeneratedLocalizationSources() throws IOException {
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write(getBasePluginConfig().getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), getBasePluginConfig().getBytes(StandardCharsets.UTF_8));
 
         ith.mkDirInProjectDir("src/main/java/org/example");
-        Files.write(/* language=java */ """
+        Files.write(ith.inProjectDir("src/main/java/org/example/UsesMessages.java").toPath(), /* language=java */ """
                 package org.example;
 
                 public class UsesMessages {
@@ -32,11 +32,11 @@ class LocalizationIntegrationTest extends V2IntegrationTestBase {
                         return Messages.displayName();
                     }
                 }
-                """.getBytes(StandardCharsets.UTF_8), ith.inProjectDir("src/main/java/org/example/UsesMessages.java"));
+                """.getBytes(StandardCharsets.UTF_8));
         ith.mkDirInProjectDir("src/main/resources/org/example");
-        Files.write(/* language=properties */ """
+        Files.write(ith.inProjectDir("src/main/resources/org/example/Messages.properties").toPath(), /* language=properties */ """
                 displayName=Display Name
-                """.getBytes(StandardCharsets.UTF_8), ith.inProjectDir("src/main/resources/org/example/Messages.properties"));
+                """.getBytes(StandardCharsets.UTF_8));
 
         BuildResult result = ith.gradleRunner().withArguments("classes").build();
 
@@ -53,17 +53,17 @@ class LocalizationIntegrationTest extends V2IntegrationTestBase {
     void localizeMessagesSupportsCustomOutputDirectory() throws IOException {
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getBasePluginConfig() + /* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig() + /* language=kotlin */ """
                 tasks.named<org.jenkinsci.gradle.plugins.jpi2.localization.LocalizationTask>("localizeMessages") {
                     outputDir.set(layout.buildDirectory.dir("custom-localizer"))
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
 
         ith.mkDirInProjectDir("src/main/resources/org/example");
-        Files.write(/* language=properties */ """
+        Files.write(ith.inProjectDir("src/main/resources/org/example/Messages.properties").toPath(), /* language=properties */ """
                 key1=Value 1
                 key2=Value 2
-                """.getBytes(StandardCharsets.UTF_8), ith.inProjectDir("src/main/resources/org/example/Messages.properties"));
+                """.getBytes(StandardCharsets.UTF_8));
 
         BuildResult result = ith.gradleRunner().withArguments("localizeMessages").build();
 
@@ -71,7 +71,7 @@ class LocalizationIntegrationTest extends V2IntegrationTestBase {
         assertThat(result.task(":localizeMessages").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
         var generated = ith.inProjectDir("build/custom-localizer/org/example/Messages.java");
         assertThat(generated).exists();
-        var generatedContent = java.nio.file.Files.readString(generated.toPath());
+        var generatedContent = Files.readString(generated.toPath());
         assertThat(generatedContent).contains("public static String key1()");
         assertThat(generatedContent).contains("public static String key2()");
     }
@@ -80,12 +80,12 @@ class LocalizationIntegrationTest extends V2IntegrationTestBase {
     void sourcesJarIncludesGeneratedLocalizationSources() throws IOException {
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write(getBasePluginConfig().getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), getBasePluginConfig().getBytes(StandardCharsets.UTF_8));
 
         ith.mkDirInProjectDir("src/main/resources/org/example");
-        Files.write(/* language=properties */ """
+        Files.write(ith.inProjectDir("src/main/resources/org/example/Messages.properties").toPath(), /* language=properties */ """
                 greeting=Hello
-                """.getBytes(StandardCharsets.UTF_8), ith.inProjectDir("src/main/resources/org/example/Messages.properties"));
+                """.getBytes(StandardCharsets.UTF_8));
 
         BuildResult result = ith.gradleRunner().withArguments("sourcesJar").build();
 
@@ -102,18 +102,18 @@ class LocalizationIntegrationTest extends V2IntegrationTestBase {
     @Test
     void localizeMessagesWorksInMultiModuleBuild() throws IOException {
         var ith = new IntegrationTestHelper(tempDir, "8.14");
-        Files.write(/* language=kotlin */ """
+        Files.write(ith.inProjectDir("settings.gradle.kts").toPath(), /* language=kotlin */ """
                 rootProject.name = "test-plugin"
                 include("plugin")
-                """.getBytes(StandardCharsets.UTF_8), ith.inProjectDir("settings.gradle.kts"));
-        Files.write(new byte[0], ith.inProjectDir("build.gradle.kts"));
+                """.getBytes(StandardCharsets.UTF_8));
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), new byte[0]);
         ith.mkDirInProjectDir("plugin");
-        Files.write(getBasePluginConfig().getBytes(StandardCharsets.UTF_8), ith.inProjectDir("plugin/build.gradle.kts"));
+        Files.write(ith.inProjectDir("plugin/build.gradle.kts").toPath(), getBasePluginConfig().getBytes(StandardCharsets.UTF_8));
         ith.mkDirInProjectDir("plugin/src/main/resources");
-        Files.write(/* language=properties */ """
+        Files.write(ith.inProjectDir("plugin/src/main/resources/Messages.properties").toPath(), /* language=properties */ """
                 key3=Value 3
                 key4=Value 4
-                """.getBytes(StandardCharsets.UTF_8), ith.inProjectDir("plugin/src/main/resources/Messages.properties"));
+                """.getBytes(StandardCharsets.UTF_8));
 
         BuildResult result = ith.gradleRunner().withArguments(":plugin:localizeMessages").build();
 
@@ -121,7 +121,7 @@ class LocalizationIntegrationTest extends V2IntegrationTestBase {
         assertThat(result.task(":plugin:localizeMessages").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
         var generated = ith.inProjectDir("plugin/build/generated-src/localizer/Messages.java");
         assertThat(generated).exists();
-        var generatedContent = java.nio.file.Files.readString(generated.toPath());
+        var generatedContent = Files.readString(generated.toPath());
         assertThat(generatedContent).contains("public static String key3()");
         assertThat(generatedContent).contains("public static String key4()");
     }
@@ -130,12 +130,12 @@ class LocalizationIntegrationTest extends V2IntegrationTestBase {
     void localizeMessagesSupportsConfigurationCache() throws IOException {
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write(getBasePluginConfig().getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), getBasePluginConfig().getBytes(StandardCharsets.UTF_8));
 
         ith.mkDirInProjectDir("src/main/resources/org/example");
-        Files.write(/* language=properties */ """
+        Files.write(ith.inProjectDir("src/main/resources/org/example/Messages.properties").toPath(), /* language=properties */ """
                 greeting=Hello
-                """.getBytes(StandardCharsets.UTF_8), ith.inProjectDir("src/main/resources/org/example/Messages.properties"));
+                """.getBytes(StandardCharsets.UTF_8));
 
         var gradleRunner = ith.gradleRunner();
         BuildResult firstRun = gradleRunner.withArguments("--configuration-cache", "localizeMessages", "-i").build();
@@ -154,14 +154,14 @@ class LocalizationIntegrationTest extends V2IntegrationTestBase {
     void extensionLocalizerVersionOverridesGradleProperty() throws IOException {
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getBasePluginConfig() + /* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig() + /* language=kotlin */ """
                 jenkinsPlugin {
                     localizerVersion.set("1.30")
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
-        Files.write(/* language=properties */ """
+                """).getBytes(StandardCharsets.UTF_8));
+        Files.write(ith.inProjectDir("gradle.properties").toPath(), /* language=properties */ """
                 jenkins.localizer.version=1.31
-                """.getBytes(StandardCharsets.UTF_8), ith.inProjectDir("gradle.properties"));
+                """.getBytes(StandardCharsets.UTF_8));
 
         BuildResult result = ith.gradleRunner()
                 .withArguments("dependencies", "--configuration=localizeMessagesRuntimeClasspath")

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/ManifestIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/ManifestIntegrationTest.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.gradle.plugins.jpi2;
 
-import com.google.common.io.Files;
+import java.nio.file.Files;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
@@ -28,7 +28,7 @@ class ManifestIntegrationTest extends V2IntegrationTestBase {
     void manifestContainsVersionWhenUsingForce() throws IOException {
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getBasePluginConfig() + /* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig() + /* language=kotlin */ """
                 configurations.configureEach {
                     resolutionStrategy {
                         force("org.jenkins-ci.plugins:git:5.7.0")
@@ -37,7 +37,7 @@ class ManifestIntegrationTest extends V2IntegrationTestBase {
                 dependencies {
                     implementation("org.jenkins-ci.plugins:git")
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
 
         GradleRunner gradleRunner = ith.gradleRunner();
 
@@ -54,7 +54,7 @@ class ManifestIntegrationTest extends V2IntegrationTestBase {
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
         ith.mkDirInProjectDir("src-repo/com/example/bom/bom/1.0.0");
-        Files.write(/* language=xml */ """
+        Files.write(ith.inProjectDir("src-repo/com/example/bom/bom/1.0.0/bom-1.0.0.pom").toPath(), /* language=xml */ """
                 <project xmlns="http://maven.apache.org/POM/4.0.0"
                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -73,8 +73,8 @@ class ManifestIntegrationTest extends V2IntegrationTestBase {
                         </dependencies>
                     </dependencyManagement>
                 </project>
-                """.getBytes(StandardCharsets.UTF_8), ith.inProjectDir("src-repo/com/example/bom/bom/1.0.0/bom-1.0.0.pom"));
-        Files.write((getBasePluginConfig() + /* language=kotlin */ """
+                """.getBytes(StandardCharsets.UTF_8));
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig() + /* language=kotlin */ """
                 repositories {
                     maven {
                         url = uri("${rootDir}/src-repo")
@@ -84,7 +84,7 @@ class ManifestIntegrationTest extends V2IntegrationTestBase {
                     implementation(platform("com.example.bom:bom:1.0.0"))
                     api("org.jenkins-ci.plugins:git")
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
 
         GradleRunner gradleRunner = ith.gradleRunner();
 
@@ -118,7 +118,7 @@ class ManifestIntegrationTest extends V2IntegrationTestBase {
     void supportDynamicLoadingDefaultsToTrueWhenNoExtensionsExist() throws IOException {
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write(getBasePluginConfig().getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), getBasePluginConfig().getBytes(StandardCharsets.UTF_8));
 
         ith.gradleRunner().withArguments("build").build();
 
@@ -129,7 +129,7 @@ class ManifestIntegrationTest extends V2IntegrationTestBase {
     void supportDynamicLoadingIsTrueWhenAllExtensionsAreYes() throws IOException {
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write(getBasePluginConfig().getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), getBasePluginConfig().getBytes(StandardCharsets.UTF_8));
         writeJavaSource(ith, "com/example/plugin/AlwaysReloadable.java", """
                 package com.example.plugin;
 
@@ -147,7 +147,7 @@ class ManifestIntegrationTest extends V2IntegrationTestBase {
     void supportDynamicLoadingIsOmittedWhenAnyExtensionIsMaybe() throws IOException {
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write(getBasePluginConfig().getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), getBasePluginConfig().getBytes(StandardCharsets.UTF_8));
         writeJavaSource(ith, "com/example/plugin/MaybeReloadable.java", """
                 package com.example.plugin;
 
@@ -172,7 +172,7 @@ class ManifestIntegrationTest extends V2IntegrationTestBase {
     void supportDynamicLoadingIsFalseWhenAnyExtensionIsNotDynamicLoadable() throws IOException {
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write(getBasePluginConfig().getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), getBasePluginConfig().getBytes(StandardCharsets.UTF_8));
         writeJavaSource(ith, "com/example/plugin/NeverReloadable.java", """
                 package com.example.plugin;
 
@@ -202,6 +202,6 @@ class ManifestIntegrationTest extends V2IntegrationTestBase {
     private static void writeJavaSource(IntegrationTestHelper ith, String relativePath, String source) throws IOException {
         var parent = relativePath.substring(0, relativePath.lastIndexOf('/'));
         ith.mkDirInProjectDir("src/main/java/" + parent);
-        Files.write(source.getBytes(StandardCharsets.UTF_8), ith.inProjectDir("src/main/java/" + relativePath));
+        Files.write(ith.inProjectDir("src/main/java/" + relativePath).toPath(), source.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/MetadataIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/MetadataIntegrationTest.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.gradle.plugins.jpi2;
 
-import com.google.common.io.Files;
+import java.nio.file.Files;
 import org.apache.maven.model.Developer;
 import org.apache.maven.model.License;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
@@ -52,8 +52,8 @@ class MetadataIntegrationTest extends V2IntegrationTestBase {
     void manifestContainsHomePageAndCompatibleSinceVersion() throws IOException {
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getBasePluginConfig() + FULL_METADATA_CONFIG)
-                .getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig() + FULL_METADATA_CONFIG)
+                .getBytes(StandardCharsets.UTF_8));
 
         ith.gradleRunner().withArguments("build").build();
 
@@ -72,8 +72,8 @@ class MetadataIntegrationTest extends V2IntegrationTestBase {
     void pomContainsDevelopersAndLicenses() throws IOException, XmlPullParserException {
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getBasePluginConfig() + FULL_METADATA_CONFIG)
-                .getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig() + FULL_METADATA_CONFIG)
+                .getBytes(StandardCharsets.UTF_8));
 
         ith.gradleRunner().withArguments("publish").build();
 
@@ -104,7 +104,7 @@ class MetadataIntegrationTest extends V2IntegrationTestBase {
     void defaultsApplyWhenMetadataNotConfigured() throws IOException {
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write(getBasePluginConfig().getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), getBasePluginConfig().getBytes(StandardCharsets.UTF_8));
 
         ith.gradleRunner().withArguments("build").build();
 

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/PublishingIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/PublishingIntegrationTest.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.gradle.plugins.jpi2;
 
-import com.google.common.io.Files;
+import java.nio.file.Files;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Repository;
@@ -27,12 +27,12 @@ class PublishingIntegrationTest extends V2IntegrationTestBase {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getBasePluginConfig() + /* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig() + /* language=kotlin */ """
                 dependencies {
                     api("org.jenkins-ci.plugins:jackson2-api:2.18.3-402.v74c4eb_f122b_2")
                     implementation("com.github.rahulsom:nothing-java:0.2.0")
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
 
         // when
         var gradleRunner = ith.gradleRunner();
@@ -96,7 +96,7 @@ class PublishingIntegrationTest extends V2IntegrationTestBase {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getBasePluginConfig() + /* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig() + /* language=kotlin */ """
                 publishing {
                     publications.withType<MavenPublication>().configureEach {
                         pom {
@@ -109,7 +109,7 @@ class PublishingIntegrationTest extends V2IntegrationTestBase {
                         }
                     }
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
 
         // when
         ith.gradleRunner().withArguments("publish").build();
@@ -131,7 +131,7 @@ class PublishingIntegrationTest extends V2IntegrationTestBase {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write(/* language=groovy */ """
+        Files.write(ith.inProjectDir("build.gradle").toPath(), /* language=groovy */ """
                 plugins {
                     id "org.jenkins-ci.jpi2"
                 }
@@ -149,7 +149,7 @@ class PublishingIntegrationTest extends V2IntegrationTestBase {
                         }
                     }
                 }
-                """.getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle"));
+                """.getBytes(StandardCharsets.UTF_8));
 
         // when
         var gradleRunner = ith.gradleRunner();
@@ -184,13 +184,13 @@ class PublishingIntegrationTest extends V2IntegrationTestBase {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        com.google.common.io.Files.write((PUBLISH_TO_JENKINS_IMPORT + getBasePluginConfig() + /* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (PUBLISH_TO_JENKINS_IMPORT + getBasePluginConfig() + /* language=kotlin */ """
                 publishing {
                     repositories {
                         publishToJenkins()
                     }
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
 
         // when
         var result = ith.gradleRunner().withArguments(
@@ -205,7 +205,7 @@ class PublishingIntegrationTest extends V2IntegrationTestBase {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        com.google.common.io.Files.write((PUBLISH_TO_JENKINS_IMPORT + String.format(/* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (PUBLISH_TO_JENKINS_IMPORT + String.format(/* language=kotlin */ """
                 plugins {
                     id("org.jenkins-ci.jpi2")
                 }
@@ -231,7 +231,7 @@ class PublishingIntegrationTest extends V2IntegrationTestBase {
                     }
                 }
                 """, RandomPortProvider.findFreePort(), RandomPortProvider.findFreePort()))
-                .getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                .getBytes(StandardCharsets.UTF_8));
 
         // when
         var result = ith.gradleRunner().withArguments(
@@ -247,7 +247,7 @@ class PublishingIntegrationTest extends V2IntegrationTestBase {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        com.google.common.io.Files.write((PUBLISH_TO_JENKINS_IMPORT + String.format(/* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (PUBLISH_TO_JENKINS_IMPORT + String.format(/* language=kotlin */ """
                 plugins {
                     id("org.jenkins-ci.jpi2")
                 }
@@ -273,7 +273,7 @@ class PublishingIntegrationTest extends V2IntegrationTestBase {
                     }
                 }
                 """, RandomPortProvider.findFreePort(), RandomPortProvider.findFreePort()))
-                .getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                .getBytes(StandardCharsets.UTF_8));
 
         // when
         var result = ith.gradleRunner().withArguments(
@@ -289,7 +289,7 @@ class PublishingIntegrationTest extends V2IntegrationTestBase {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        com.google.common.io.Files.write(/* language=groovy */ """
+        Files.write(ith.inProjectDir("build.gradle").toPath(), /* language=groovy */ """
                 plugins {
                     id "org.jenkins-ci.jpi2"
                 }
@@ -308,7 +308,7 @@ class PublishingIntegrationTest extends V2IntegrationTestBase {
                         }
                     }
                 }
-                """.getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle"));
+                """.getBytes(StandardCharsets.UTF_8));
 
         // when
         var result = ith.gradleRunner().withArguments(
@@ -323,14 +323,14 @@ class PublishingIntegrationTest extends V2IntegrationTestBase {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getBasePluginConfig() + /* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig() + /* language=kotlin */ """
                 dependencies {
                     implementation("org.jenkins-ci.plugins:jackson2-api:2.18.3-402.v74c4eb_f122b_2")
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
 
         ith.mkDirInProjectDir("src/main/java/com/example/plugin");
-        Files.write(/* language=java */ """
+        Files.write(ith.inProjectDir("src/main/java/com/example/plugin/Plugin.java").toPath(), /* language=java */ """
                 package com.example.plugin;
                 import com.fasterxml.jackson.databind.ObjectMapper;
                 public class Plugin {
@@ -338,7 +338,7 @@ class PublishingIntegrationTest extends V2IntegrationTestBase {
                         var o = new ObjectMapper();
                     }
                 }
-                """.getBytes(StandardCharsets.UTF_8), ith.inProjectDir("src/main/java/com/example/plugin/Plugin.java"));
+                """.getBytes(StandardCharsets.UTF_8));
 
         // when
         var gradleRunner = ith.gradleRunner();

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/TestHarnessIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/TestHarnessIntegrationTest.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.gradle.plugins.jpi2;
 
-import com.google.common.io.Files;
+import java.nio.file.Files;
 import org.gradle.testkit.runner.GradleRunner;
 import org.jenkinsci.gradle.plugins.jpi.IntegrationTestHelper;
 import org.junit.jupiter.api.Test;
@@ -21,9 +21,9 @@ class TestHarnessIntegrationTest extends V2IntegrationTestBase {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getBasePluginConfig()).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig()).getBytes(StandardCharsets.UTF_8));
         ith.mkDirInProjectDir("src/test/java/com/example/plugin");
-        Files.write((/* language=java */ """
+        Files.write(ith.inProjectDir("src/test/java/com/example/plugin/PluginTest.java").toPath(), (/* language=java */ """
                 package com.example.plugin;
                 import org.junit.jupiter.api.Test;
                 import org.jvnet.hudson.test.JenkinsRule;
@@ -39,7 +39,7 @@ class TestHarnessIntegrationTest extends V2IntegrationTestBase {
                         assertNotNull(injector);
                     }
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("src/test/java/com/example/plugin/PluginTest.java"));
+                """).getBytes(StandardCharsets.UTF_8));
 
         GradleRunner gradleRunner = ith.gradleRunner();
 
@@ -63,13 +63,13 @@ class TestHarnessIntegrationTest extends V2IntegrationTestBase {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getBasePluginConfig() + /* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig() + /* language=kotlin */ """
                 dependencies {
                     implementation("org.jenkins-ci.plugins:git:5.7.0")
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
         ith.mkDirInProjectDir("src/test/java/com/example/plugin");
-        Files.write((/* language=java */ """
+        Files.write(ith.inProjectDir("src/test/java/com/example/plugin/PluginTest.java").toPath(), (/* language=java */ """
                 package com.example.plugin;
                 import org.junit.jupiter.api.Test;
                 import static org.junit.jupiter.api.Assertions.*;
@@ -81,7 +81,7 @@ class TestHarnessIntegrationTest extends V2IntegrationTestBase {
                         assertNull(branch);
                     }
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("src/test/java/com/example/plugin/PluginTest.java"));
+                """).getBytes(StandardCharsets.UTF_8));
 
         GradleRunner gradleRunner = ith.gradleRunner();
 
@@ -105,13 +105,13 @@ class TestHarnessIntegrationTest extends V2IntegrationTestBase {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write(/* language=properties */ """
+        Files.write(ith.inProjectDir("gradle.properties").toPath(), /* language=properties */ """
                 jenkins.version=2.492.1
                 jenkins.testharness.version=2411.v1e79b_0dc94b_7
-                """.getBytes(StandardCharsets.UTF_8), ith.inProjectDir("gradle.properties"));
-        Files.write((getBasePluginConfig()).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """.getBytes(StandardCharsets.UTF_8));
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig()).getBytes(StandardCharsets.UTF_8));
         ith.mkDirInProjectDir("src/test/java/com/example/plugin");
-        Files.write((/* language=java */ """
+        Files.write(ith.inProjectDir("src/test/java/com/example/plugin/PluginTest.java").toPath(), (/* language=java */ """
                 package com.example.plugin;
                 import org.junit.jupiter.api.Test;
                 import org.jvnet.hudson.test.JenkinsRule;
@@ -127,7 +127,7 @@ class TestHarnessIntegrationTest extends V2IntegrationTestBase {
                         assertNotNull(injector);
                     }
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("src/test/java/com/example/plugin/PluginTest.java"));
+                """).getBytes(StandardCharsets.UTF_8));
 
         GradleRunner gradleRunner = ith.gradleRunner();
 
@@ -151,14 +151,14 @@ class TestHarnessIntegrationTest extends V2IntegrationTestBase {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getBasePluginConfig() + /* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig() + /* language=kotlin */ """
                 jenkinsPlugin {
                     jenkinsVersion.set("2.492.1")
                     testHarnessVersion.set("2411.v1e79b_0dc94b_7")
                     pluginId.set("custom-plugin-id")
                     displayName.set("Custom Plugin Name")
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
 
         GradleRunner gradleRunner = ith.gradleRunner();
 
@@ -191,14 +191,14 @@ class TestHarnessIntegrationTest extends V2IntegrationTestBase {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getBasePluginConfig() + /* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig() + /* language=kotlin */ """
                 jenkinsPlugin {
                     jenkinsVersion = "2.492.1"
                     testHarnessVersion = "2411.v1e79b_0dc94b_7"
                     pluginId = "custom-plugin-id"
                     displayName = "Custom Plugin Name"
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
 
         GradleRunner gradleRunner = ith.gradleRunner();
 
@@ -231,7 +231,7 @@ class TestHarnessIntegrationTest extends V2IntegrationTestBase {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((/* language=groovy */ """
+        Files.write(ith.inProjectDir("build.gradle").toPath(), (/* language=groovy */ """
                 plugins {
                     id("org.jenkins-ci.jpi2")
                 }
@@ -251,7 +251,7 @@ class TestHarnessIntegrationTest extends V2IntegrationTestBase {
                     pluginId = "custom-plugin-id"
                     displayName = "Custom Plugin Name"
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle"));
+                """).getBytes(StandardCharsets.UTF_8));
 
         GradleRunner gradleRunner = ith.gradleRunner();
 

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/VersionSourceIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/VersionSourceIntegrationTest.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.gradle.plugins.jpi2;
 
-import com.google.common.io.Files;
+import java.nio.file.Files;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
@@ -31,7 +31,7 @@ class VersionSourceIntegrationTest extends V2IntegrationTestBase {
     void projectVersionIsUsedByDefault() throws IOException {
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write(getConfig().getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), getConfig().getBytes(StandardCharsets.UTF_8));
 
         ith.gradleRunner().withArguments("build").build();
 
@@ -60,7 +60,7 @@ class VersionSourceIntegrationTest extends V2IntegrationTestBase {
     void projectVersionAppearsInPublishedPomAndJpi() throws IOException, XmlPullParserException {
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write(getConfig().getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), getConfig().getBytes(StandardCharsets.UTF_8));
 
         ith.gradleRunner().withArguments("publish").build();
 
@@ -72,12 +72,12 @@ class VersionSourceIntegrationTest extends V2IntegrationTestBase {
     void fixedVersionIsUsedWhenSet() throws IOException {
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getConfig() + /* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getConfig() + /* language=kotlin */ """
                 jenkinsPlugin {
                     versionSource.set(org.jenkinsci.gradle.plugins.jpi2.VersionSource.FIXED)
                     fixedVersion.set("2.0.0-beta")
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
 
         ith.gradleRunner().withArguments("build").build();
 
@@ -95,12 +95,12 @@ class VersionSourceIntegrationTest extends V2IntegrationTestBase {
     void fixedVersionFromProviderIsUsedWhenSet() throws IOException {
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getConfig() + /* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getConfig() + /* language=kotlin */ """
                 jenkinsPlugin {
                     versionSource.set(org.jenkinsci.gradle.plugins.jpi2.VersionSource.FIXED)
                     fixedVersion.set(providers.provider { "2.0.0-beta" })
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
 
         ith.gradleRunner().withArguments("build").build();
 
@@ -118,12 +118,12 @@ class VersionSourceIntegrationTest extends V2IntegrationTestBase {
     void fixedVersionAppearsInPublishedPomAndJpi() throws IOException, XmlPullParserException {
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getConfig() + /* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getConfig() + /* language=kotlin */ """
                 jenkinsPlugin {
                     versionSource.set(org.jenkinsci.gradle.plugins.jpi2.VersionSource.FIXED)
                     fixedVersion.set("2.0.0-beta")
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
 
         ith.gradleRunner().withArguments("publish").build();
 
@@ -134,20 +134,20 @@ class VersionSourceIntegrationTest extends V2IntegrationTestBase {
     void generateGitVersionTaskProducesVersionFile() throws IOException, InterruptedException {
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getConfig() + /* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getConfig() + /* language=kotlin */ """
                 jenkinsPlugin {
                     gitVersion {
                         allowDirty.set(true)
                     }
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
         initGitRepo(ith.inProjectDir("."));
 
         ith.gradleRunner().withArguments("generateGitVersion").build();
 
         var versionFile = ith.inProjectDir("build/generated/version/version.txt");
         assertThat(versionFile).exists();
-        var lines = Files.readLines(versionFile, StandardCharsets.UTF_8);
+        var lines = Files.readAllLines(versionFile.toPath(), StandardCharsets.UTF_8);
         assertThat(lines).hasSize(1);
         // depth.abbrevHash (e.g. 1.abc123def456)
         assertThat(lines.get(0)).matches("\\d+\\.[a-f0-9]{12}");
@@ -157,21 +157,21 @@ class VersionSourceIntegrationTest extends V2IntegrationTestBase {
     void gitVersionSourceUsesGeneratedVersionInBuild() throws IOException, InterruptedException {
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getConfig() + /* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getConfig() + /* language=kotlin */ """
                 jenkinsPlugin {
                     versionSource.set(org.jenkinsci.gradle.plugins.jpi2.VersionSource.GIT)
                     gitVersion {
                         allowDirty.set(true)
                     }
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
         initGitRepo(ith.inProjectDir("."));
 
         ith.gradleRunner().withArguments("generateGitVersion", "build").build();
 
         var versionFile = ith.inProjectDir("build/generated/version/version.txt");
         assertThat(versionFile).exists();
-        var expectedVersion = Files.readLines(versionFile, StandardCharsets.UTF_8).get(0).trim();
+        var expectedVersion = Files.readAllLines(versionFile.toPath(), StandardCharsets.UTF_8).get(0).trim();
 
         var manifest = ith.inProjectDir("build/jpi/META-INF/MANIFEST.MF");
         assertThat(manifest).exists();
@@ -188,20 +188,20 @@ class VersionSourceIntegrationTest extends V2IntegrationTestBase {
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
         initGitRepo(ith.inProjectDir("."));
-        Files.write((getConfig() + /* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getConfig() + /* language=kotlin */ """
                 jenkinsPlugin {
                     versionSource.set(org.jenkinsci.gradle.plugins.jpi2.VersionSource.GIT)
                     gitVersion {
                         allowDirty.set(true)
                     }
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
 
         ith.gradleRunner().withArguments("generateGitVersion", "publish").build();
 
         var versionFile = ith.inProjectDir("build/generated/version/version.txt");
         assertThat(versionFile).exists();
-        var expectedVersion = Files.readLines(versionFile, StandardCharsets.UTF_8).get(0).trim();
+        var expectedVersion = Files.readAllLines(versionFile.toPath(), StandardCharsets.UTF_8).get(0).trim();
         assertPomAndJpiContainVersion(ith, expectedVersion);
     }
 
@@ -209,9 +209,9 @@ class VersionSourceIntegrationTest extends V2IntegrationTestBase {
     void generateGitVersionFailsWhenDirtyAndAllowDirtyFalse() throws IOException, InterruptedException {
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write(getConfig().getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), getConfig().getBytes(StandardCharsets.UTF_8));
         initGitRepo(ith.inProjectDir("."));
-        Files.write("dirty".getBytes(StandardCharsets.UTF_8), ith.inProjectDir("uncommitted.txt"));
+        Files.write(ith.inProjectDir("uncommitted.txt").toPath(), "dirty".getBytes(StandardCharsets.UTF_8));
 
         BuildResult result = ith.gradleRunner().withArguments("generateGitVersion").buildAndFail();
 
@@ -222,15 +222,15 @@ class VersionSourceIntegrationTest extends V2IntegrationTestBase {
     void generateGitVersionSucceedsWhenAllowDirtyTrue() throws IOException, InterruptedException {
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getConfig() + /* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getConfig() + /* language=kotlin */ """
                 jenkinsPlugin {
                     gitVersion {
                         allowDirty.set(true)
                     }
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
         initGitRepo(ith.inProjectDir("."));
-        Files.write("dirty".getBytes(StandardCharsets.UTF_8), ith.inProjectDir("uncommitted.txt"));
+        Files.write(ith.inProjectDir("uncommitted.txt").toPath(), "dirty".getBytes(StandardCharsets.UTF_8));
 
         ith.gradleRunner().withArguments("generateGitVersion").build();
 
@@ -242,7 +242,7 @@ class VersionSourceIntegrationTest extends V2IntegrationTestBase {
     void generateGitVersionWithCustomFormat() throws IOException, InterruptedException {
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write((getConfig() + /* language=kotlin */ """
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getConfig() + /* language=kotlin */ """
                 jenkinsPlugin {
                     gitVersion {
                         versionFormat.set("rc-%d.%s")
@@ -250,14 +250,14 @@ class VersionSourceIntegrationTest extends V2IntegrationTestBase {
                         allowDirty.set(true)
                     }
                 }
-                """).getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+                """).getBytes(StandardCharsets.UTF_8));
         initGitRepo(ith.inProjectDir("."));
 
         ith.gradleRunner().withArguments("generateGitVersion").build();
 
         var versionFile = ith.inProjectDir("build/generated/version/version.txt");
         assertThat(versionFile).exists();
-        var firstLine = Files.readLines(versionFile, StandardCharsets.UTF_8).get(0);
+        var firstLine = Files.readAllLines(versionFile.toPath(), StandardCharsets.UTF_8).get(0);
         assertThat(firstLine).startsWith("rc-");
         assertThat(firstLine).matches("rc-\\d+\\.[a-f0-9]{10}");
     }
@@ -266,7 +266,7 @@ class VersionSourceIntegrationTest extends V2IntegrationTestBase {
     void generateGitVersionFailsWhenNotAGitRepository() throws IOException {
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         initBuild(ith);
-        Files.write(getConfig().getBytes(StandardCharsets.UTF_8), ith.inProjectDir("build.gradle.kts"));
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), getConfig().getBytes(StandardCharsets.UTF_8));
 
         BuildResult result = ith.gradleRunner().withArguments("generateGitVersion").buildAndFail();
 
@@ -291,10 +291,10 @@ class VersionSourceIntegrationTest extends V2IntegrationTestBase {
 
     private static void initGitRepo(File projectDir) throws IOException, InterruptedException {
         runGit(projectDir, "init");
-        Files.write(/* language=gitignore */ """
+        Files.write(new File(projectDir, ".gitignore").toPath(), /* language=gitignore */ """
                 .gradle
                 build
-                """.getBytes(StandardCharsets.UTF_8), new File(projectDir, ".gitignore"));
+                """.getBytes(StandardCharsets.UTF_8));
         runGit(projectDir, "add", ".");
         runGit(projectDir, "config", "user.email", "test@test");
         runGit(projectDir, "config", "user.name", "Test");


### PR DESCRIPTION
Drop guava from dependencies and rewrite all test usages:

- `Files.write(bytes, file)` → `Files.write(file.toPath(), bytes)`
- `Files.readLines(file, charset)` → `Files.readAllLines(file.toPath(), charset)`.
