### PR TITLE
chore: Enable build scans

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,22 @@
+plugins {
+    id("com.gradle.develocity").version("4.4.1")
+}
+
+val isDevelocityConfigEnabled =
+    providers
+        .gradleProperty("develocity.config.enabled")
+        .map { it.toBoolean() }
+        .orElse(true)
+
+if (isDevelocityConfigEnabled.get()) {
+    develocity {
+        buildScan {
+            termsOfUseUrl.set("https://gradle.com/terms-of-service")
+            termsOfUseAgree.set("yes")
+        }
+    }
+}
+
 rootProject.name = "gradle-jpi-plugin"
 
 val jpiMode = providers.gradleProperty("gradleJpiPlugin.mode")


### PR DESCRIPTION
This will detect rely on the `develocity.config.enabled` gradle property or default to true.
That makes debugging CI problems easier.

If being composited with a custom distribution, it will automatically fall back to the custom distribution's build scan.
