### PR TITLE
chore: Increase timeout to 5 minutes

### DIFF
--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/V2IntegrationTestBase.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/V2IntegrationTestBase.java
@@ -31,7 +31,7 @@ import java.util.jar.JarOutputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Timeout(value = 2, unit = TimeUnit.MINUTES)
+@Timeout(value = 5, unit = TimeUnit.MINUTES)
 @DisabledOnOs(value = OS.WINDOWS, disabledReason = "TempDir doesn't appear to work correctly on Windows")
 abstract class V2IntegrationTestBase {
 


### PR DESCRIPTION
Prior to this, it was 2 minutes.
But the `testServerStarts` method has this

```
        Awaitility.await()
                .atMost(3, TimeUnit.MINUTES)
```

That leads to some inconsistency and timeouts sooner than expected.
