### PR TITLE
fix(gradle9): Allow tasks to report FROM_CACHE

### DIFF
--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/LocalizationIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/LocalizationIntegrationTest.java
@@ -41,9 +41,9 @@ class LocalizationIntegrationTest extends V2IntegrationTestBase {
         BuildResult result = ith.gradleRunner().withArguments("classes").build();
 
         assertThat(result.task(":localizeMessages")).isNotNull();
-        assertThat(result.task(":localizeMessages").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(result.task(":localizeMessages").getOutcome()).isIn(TaskOutcome.SUCCESS, TaskOutcome.FROM_CACHE);
         assertThat(result.task(":classes")).isNotNull();
-        assertThat(result.task(":classes").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(result.task(":classes").getOutcome()).isIn(TaskOutcome.SUCCESS, TaskOutcome.FROM_CACHE);
         assertThat(ith.inProjectDir("build/generated-src/localizer/org/example/Messages.java")).exists();
         assertThat(ith.inProjectDir("build/classes/java/main/org/example/Messages.class")).exists();
         assertThat(ith.inProjectDir("build/classes/java/main/org/example/UsesMessages.class")).exists();
@@ -68,7 +68,7 @@ class LocalizationIntegrationTest extends V2IntegrationTestBase {
         BuildResult result = ith.gradleRunner().withArguments("localizeMessages").build();
 
         assertThat(result.task(":localizeMessages")).isNotNull();
-        assertThat(result.task(":localizeMessages").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(result.task(":localizeMessages").getOutcome()).isIn(TaskOutcome.SUCCESS, TaskOutcome.FROM_CACHE);
         var generated = ith.inProjectDir("build/custom-localizer/org/example/Messages.java");
         assertThat(generated).exists();
         var generatedContent = Files.readString(generated.toPath());
@@ -90,7 +90,7 @@ class LocalizationIntegrationTest extends V2IntegrationTestBase {
         BuildResult result = ith.gradleRunner().withArguments("sourcesJar").build();
 
         assertThat(result.task(":localizeMessages")).isNotNull();
-        assertThat(result.task(":localizeMessages").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(result.task(":localizeMessages").getOutcome()).isIn(TaskOutcome.SUCCESS, TaskOutcome.FROM_CACHE);
         var sourcesJar = ith.inProjectDir("build/libs/test-plugin-1.0.0-sources.jar");
         assertThat(sourcesJar).exists();
 
@@ -118,7 +118,7 @@ class LocalizationIntegrationTest extends V2IntegrationTestBase {
         BuildResult result = ith.gradleRunner().withArguments(":plugin:localizeMessages").build();
 
         assertThat(result.task(":plugin:localizeMessages")).isNotNull();
-        assertThat(result.task(":plugin:localizeMessages").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(result.task(":plugin:localizeMessages").getOutcome()).isIn(TaskOutcome.SUCCESS, TaskOutcome.FROM_CACHE);
         var generated = ith.inProjectDir("plugin/build/generated-src/localizer/Messages.java");
         assertThat(generated).exists();
         var generatedContent = Files.readString(generated.toPath());
@@ -142,7 +142,7 @@ class LocalizationIntegrationTest extends V2IntegrationTestBase {
         BuildResult secondRun = gradleRunner.withArguments("--configuration-cache", "localizeMessages", "-i").build();
 
         assertThat(firstRun.task(":localizeMessages")).isNotNull();
-        assertThat(firstRun.task(":localizeMessages").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(firstRun.task(":localizeMessages").getOutcome()).isIn(TaskOutcome.SUCCESS, TaskOutcome.FROM_CACHE);
         assertThat(firstRun.getOutput()).contains("Configuration cache entry stored");
 
         assertThat(secondRun.task(":localizeMessages")).isNotNull();


### PR DESCRIPTION
Without this preemptive fix, the tests break on Gradle 9.5.0.
