### PR TITLE
fix(gradle9): Configure explicit task caching

### DIFF
--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/CheckOverlappingSourcesTask.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/CheckOverlappingSourcesTask.java
@@ -4,6 +4,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.PathSensitive;
@@ -29,6 +30,7 @@ import static java.util.stream.Collectors.joining;
  * or duplicate {@code hudson.Plugin} service entries — both of which break Jenkins plugin loading.
  * The fix is always joint compilation so that a single compiler run owns all annotation processing.
  */
+@CacheableTask
 public abstract class CheckOverlappingSourcesTask extends DefaultTask {
     /** Standard name under which this task is registered. */
     public static final String NAME = "checkOverlappingSources";

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/GenerateHplTask.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/GenerateHplTask.java
@@ -4,10 +4,13 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 
 import java.io.File;
@@ -22,6 +25,7 @@ import java.util.jar.Manifest;
 /**
  * Generates an HPL (Hudson Plugin Link) file for running Jenkins against local classes and resources.
  */
+@CacheableTask
 public abstract class GenerateHplTask extends DefaultTask {
     /** Standard name under which this task is registered. */
     public static final String TASK_NAME = "generateJenkinsServerHpl";
@@ -40,6 +44,7 @@ public abstract class GenerateHplTask extends DefaultTask {
 
     /** @return upstream {@code MANIFEST.MF} whose attributes are copied into the HPL before augmentation */
     @InputFile
+    @PathSensitive(PathSensitivity.NONE)
     public abstract RegularFileProperty getUpstreamManifest();
 
     @TaskAction

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/GenerateLicenseInfoTask.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/GenerateLicenseInfoTask.java
@@ -4,6 +4,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
@@ -37,6 +38,7 @@ import java.util.Set;
 /**
  * Generates {@code licenses.xml} for libraries bundled into the plugin package.
  */
+@CacheableTask
 public abstract class GenerateLicenseInfoTask extends DefaultTask {
     /** Standard name under which this task is registered. */
     public static final String NAME = "generateLicenseInfo";

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/GenerateOptionalJenkinsManifestTask.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/GenerateOptionalJenkinsManifestTask.java
@@ -4,6 +4,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.PathSensitive;
@@ -23,6 +24,7 @@ import java.util.stream.Stream;
  * Generates the optional Jenkins manifest fragment that declares whether a plugin supports
  * dynamic loading, derived from the {@code dynamicLoadable} attribute of Sezpoz extension entries.
  */
+@CacheableTask
 public abstract class GenerateOptionalJenkinsManifestTask extends DefaultTask {
     /** Standard name under which this task is registered. */
     public static final String NAME = "generateOptionalJenkinsManifest";

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/TestServerTask.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/TestServerTask.java
@@ -5,6 +5,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.work.DisableCachingByDefault;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.TaskAction;
@@ -23,6 +24,7 @@ import java.util.List;
 /**
  * Task that launches a Jenkins server and terminates after success or first error.
  */
+@DisableCachingByDefault(because = "starts an external Jenkins process and produces no cacheable outputs")
 public abstract class TestServerTask extends DefaultTask {
 
     private static final List<String> FAILURE_MESSAGES = List.of(

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/accmod/CheckAccessModifierTask.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/accmod/CheckAccessModifierTask.java
@@ -5,6 +5,7 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.CompileClasspath;
 import org.gradle.api.tasks.Input;
@@ -19,6 +20,7 @@ import javax.inject.Inject;
  * Submits parallel {@link CheckAccess} work items — one per compilation output directory —
  * to enforce {@code @Restricted} API access rules from {@code kohsuke.accmod}.
  */
+@CacheableTask
 public abstract class CheckAccessModifierTask extends DefaultTask {
     /** Standard name under which this task is registered. */
     public static final String NAME = "checkAccessModifier";
@@ -71,6 +73,7 @@ public abstract class CheckAccessModifierTask extends DefaultTask {
 
     /** @return directories of compiled {@code .class} files to scan for {@code @Restricted} violations */
     @InputFiles
+    @Classpath
     public ConfigurableFileCollection getCompilationDirs() {
         return compilationDirs;
     }


### PR DESCRIPTION
Gradle 9 expects tasks to explicity say whether they are Cacheable. Without it, `validatePlugins` fails.

See: https://github.com/jenkinsci/gradle-jpi-plugin/pull/374

After this is merged, we'll need to check the "Retry" box on that PR.