### PR TITLE
fix: Handle cleanup of workdir better

### DIFF
--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/TestServerTask.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/TestServerTask.java
@@ -179,13 +179,8 @@ public abstract class TestServerTask extends DefaultTask {
 
         try (var paths = Files.walk(workDir)) {
             paths.sorted(Comparator.reverseOrder())
-                    .forEach(path -> {
-                        try {
-                            Files.deleteIfExists(path);
-                        } catch (IOException e) {
-                            throw new GradleException("Failed to delete temporary Jenkins work directory " + workDir, e);
-                        }
-                    });
+                    .map(Path::toFile)
+                    .forEach(File::delete);
         } catch (IOException e) {
             throw new GradleException("Failed to clean temporary Jenkins work directory " + workDir, e);
         }


### PR DESCRIPTION
Sometimes, we see random errors during the clean.

```
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':myplugin:testServer' (registered by plugin 'org.jenkins-ci.jpi2')
  Caused by: org.gradle.api.GradleException: Failed to delete file from temporary Jenkins work directory /path/myplugin/build/tmp/testServer/jenkins-work-9064908567013095199/monitoring/_MacBook-5FCGQ
  Caused by: java.nio.file.DirectoryNotEmptyException: /path/myplugin/build/tmp/testServer/jenkins-work-9064908567013095199/monitoring/_MacBook-5FCGQ
```

This changes how we do the deletes to avoid this failure.
