### PR TITLE
feat: make `testServer` and `testHplRun` cacheable

### DIFF
--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/TestServerTask.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/TestServerTask.java
@@ -2,12 +2,19 @@ package org.jenkinsci.gradle.plugins.jpi2;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
-import org.gradle.work.DisableCachingByDefault;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 import org.jetbrains.annotations.NotNull;
 
@@ -15,6 +22,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
@@ -23,8 +31,31 @@ import java.util.List;
 
 /**
  * Task that launches a Jenkins server and terminates after success or first error.
+ *
+ * <p>It does so by spawning a nested Gradle build that runs the real {@code :server} / {@code :hplRun}
+ * task, so the verification exercises exactly the launch path users rely on.
+ *
+ * <p>Cacheable: a successful run produces a marker file. If the declared inputs are unchanged, Gradle
+ * can restore the marker from cache and skip launching Jenkins. The modeled inputs are:
+ * <ul>
+ *   <li>the plugin files synced for the server and the Jenkins runtime classpath;</li>
+ *   <li>files referenced from the plugin's HPL ({@code testHplRun} only);</li>
+ *   <li>the forwarded init scripts — content via {@link #getInitScriptFiles()} and order/identity
+ *       via {@link #getInitScriptPaths()};</li>
+ *   <li>the project's build logic that can change the nested build: build &amp; settings scripts,
+ *       {@code gradle.properties}, version catalogs, and {@code buildSrc} sources (see
+ *       {@link #getBuildConfigFiles()});</li>
+ *   <li>the forwarded Gradle flags and system/project properties.</li>
+ * </ul>
+ *
+ * <p><strong>Cacheability boundary.</strong> Because the nested build re-evaluates the whole project,
+ * its inputs cannot be captured exhaustively from here. Changes to build logic <em>outside</em> the
+ * modeled set are <em>not</em> guaranteed to invalidate the cache, notably: included builds located
+ * outside the project tree, environment variables, {@code ~/.gradle/gradle.properties}, the Gradle or
+ * wrapper version, and dynamic dependency versions resolved from the network. When in doubt, run with
+ * {@code --rerun-tasks} to force a fresh launch.
  */
-@DisableCachingByDefault(because = "starts an external Jenkins process and produces no cacheable outputs")
+@CacheableTask
 public abstract class TestServerTask extends DefaultTask {
 
     private static final List<String> FAILURE_MESSAGES = List.of(
@@ -45,9 +76,37 @@ public abstract class TestServerTask extends DefaultTask {
     @Input
     public abstract Property<String> getJavaHome();
 
-    /** @return init scripts forwarded to the spawned Gradle via {@code --init-script} */
+    /**
+     * @return ordered absolute paths of the init scripts forwarded via {@code --init-script}, in the
+     * exact order they are passed. Gradle applies init scripts in command-line order, so the order
+     * (and the set of paths) is part of the cache key — reordering two scripts, or swapping one for a
+     * same-content script at a different path, changes the nested build and must invalidate the cache.
+     * Content is fingerprinted separately by {@link #getInitScriptFiles()}.
+     */
     @Input
-    public abstract ListProperty<String> getInitScripts();
+    public abstract ListProperty<String> getInitScriptPaths();
+
+    /**
+     * @return the init script files, fingerprinted for content so that editing a script invalidates
+     * the cache even when its path is unchanged. Path and ordering are captured by
+     * {@link #getInitScriptPaths()}, so this collection only needs to track content
+     * ({@link PathSensitivity#NONE}).
+     */
+    @InputFiles
+    @PathSensitive(PathSensitivity.NONE)
+    public abstract ConfigurableFileCollection getInitScriptFiles();
+
+    /**
+     * @return build-logic files for the nested build's project tree: build &amp; settings scripts
+     * ({@code *.gradle}, {@code *.gradle.kts}), {@code gradle.properties}, version catalogs
+     * ({@code *.versions.toml}), and {@code buildSrc} sources. Changes to these affect the nested
+     * build's behavior (e.g. {@code JavaExec} task args or resolved plugin versions) but are not
+     * captured by plugin-file or classpath inputs. This is best-effort, not exhaustive — see the
+     * cacheability boundary on the class javadoc.
+     */
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public abstract ConfigurableFileCollection getBuildConfigFiles();
 
     /** @return composite-build inclusions forwarded via {@code --include-build} */
     @Input
@@ -97,6 +156,33 @@ public abstract class TestServerTask extends DefaultTask {
     @Input
     public abstract Property<String> getServerTaskPath();
 
+    /**
+     * @return files that {@code prepareServer} / {@code prepareRun} would copy into the Jenkins
+     * work directory (the project's own JPI/HPL and resolved plugin dependencies). Fingerprinting
+     * these is what makes the task safely cacheable when nothing relevant has changed.
+     */
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public abstract ConfigurableFileCollection getPluginFiles();
+
+    /** @return classpath used to launch the embedded Jenkins server (jenkins-war). */
+    @Classpath
+    public abstract ConfigurableFileCollection getJenkinsClasspath();
+
+    /**
+     * @return files referenced by the plugin's HPL but not bundled into {@link #getPluginFiles()}:
+     * the plugin's own classes, resource directories, and bundled libraries. Required for
+     * {@code testHplRun}, where the HPL points at these paths directly; ignored (empty) for
+     * {@code testServer}, since the JPI archive already captures the same content.
+     */
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    public abstract ConfigurableFileCollection getReferencedFiles();
+
+    /** @return marker file written only on a successful Jenkins start so the task is cacheable. */
+    @OutputFile
+    public abstract RegularFileProperty getSuccessMarker();
+
     /** @return build service that allocates a free TCP port for the Jenkins test server */
     @Internal
     public abstract Property<PortAllocationService> getPortAllocationService();
@@ -110,6 +196,8 @@ public abstract class TestServerTask extends DefaultTask {
         var timeoutSystemProperty = System.getProperty("testServer.timeoutSeconds", "120");
         var timeout = Integer.parseInt(timeoutSystemProperty);
         Path workDir = null;
+
+        clearSuccessMarker();
 
         try {
             workDir = createWorkDirectory();
@@ -131,17 +219,38 @@ public abstract class TestServerTask extends DefaultTask {
             BufferedReader stdoutReader = new BufferedReader(new InputStreamReader(process.getInputStream()));
             boolean foundSuccess = isProcessSuccessful(stdoutReader, process);
 
-            if (process.waitFor() != 0) {
-                if (!foundSuccess) {
-                    throw new GradleException("Jenkins failed to start with exit code " + process.exitValue());
-                }
+            process.waitFor();
+
+            if (!foundSuccess) {
+                throw new GradleException("Jenkins failed to report a successful start (exit code " + process.exitValue() + ")");
             }
+
+            writeSuccessMarker();
         } catch (IOException e) {
             throw new GradleException("IO Exception", e);
         } catch (InterruptedException e) {
             throw new GradleException("Process interrupted", e);
         } finally {
             cleanupWorkDirectory(workDir);
+        }
+    }
+
+    private void clearSuccessMarker() {
+        var marker = getSuccessMarker().get().getAsFile();
+        try {
+            Files.deleteIfExists(marker.toPath());
+        } catch (IOException e) {
+            throw new GradleException("Failed to clear success marker " + marker, e);
+        }
+    }
+
+    private void writeSuccessMarker() {
+        var marker = getSuccessMarker().get().getAsFile();
+        try {
+            Files.createDirectories(marker.toPath().getParent());
+            Files.writeString(marker.toPath(), "Jenkins reported successful start\n", StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new GradleException("Failed to write success marker " + marker, e);
         }
     }
 
@@ -194,9 +303,9 @@ public abstract class TestServerTask extends DefaultTask {
         commandLine.add(getGradleExecutable().get());
         commandLine.add("-Dorg.gradle.java.home=" + getJavaHome().get());
 
-        for (var initScript : getInitScripts().get()) {
+        for (var initScriptPath : getInitScriptPaths().get()) {
             commandLine.add("--init-script");
-            commandLine.add(initScript);
+            commandLine.add(initScriptPath);
         }
 
         for (var includedBuild : getIncludedBuilds().get()) {

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
@@ -212,6 +212,7 @@ public class V2JpiPlugin implements Plugin<Project> {
             var projectDependencies = getProjectDependencies(runtimeClasspath, projectByPath);
             configureProjectDependencyJpis(prepareServer, getProjectDependencyJpis(projectDependencies, extension.getArchiveExtension().get()));
             configureProjectDependencyTasks(prepareRun, getProjectDependencyTasks(projectDependencies, GenerateHplTask.TASK_NAME));
+            wireUpstreamJpiReferencedFiles(project, projectDependencies);
         });
 
         project.getTasks().register("server", JavaExec.class, new ServerAction(serverTaskClasspath, projectRoot, workDir, prepareServer));
@@ -270,17 +271,41 @@ public class V2JpiPlugin implements Plugin<Project> {
         var isRootProject = project == project.getRootProject();
         var projectPath = project.getPath();
 
-        registerTestTask(project, portAllocationService, gradleExecutable, startParameter, isRootProject, projectPath,
+        var testServerTask = registerTestTask(project, portAllocationService, gradleExecutable, startParameter, isRootProject, projectPath,
                 "testServer", "Launch Jenkins server and terminate after success or first error", ":server");
-        registerTestTask(project, portAllocationService, gradleExecutable, startParameter, isRootProject, projectPath,
+        // Fingerprint the source files that prepareServer would sync (jpi, plugin dependencies,
+        // project-dependency jpis), not its destination — prepareServer and prepareRun both write
+        // to workDir/plugins, so snapshotting the destination would create an implicit dependency
+        // between the two test tasks.
+        testServerTask.configure(task -> {
+            task.getPluginFiles().from(prepareServer.map(Sync::getSource));
+            task.getJenkinsClasspath().from(serverTaskClasspath);
+        });
+
+        var testHplRunTask = registerTestTask(project, portAllocationService, gradleExecutable, startParameter, isRootProject, projectPath,
                 "testHplRun", "Launch Jenkins hplRun task and terminate after success or first error", ":hplRun");
+        testHplRunTask.configure(task -> {
+            task.getPluginFiles().from(prepareRun.map(Sync::getSource));
+            task.getJenkinsClasspath().from(serverTaskClasspath);
+            // The .hpl manifest points at these directories on disk by absolute path; their
+            // contents must be fingerprinted for caching to be correct, even though only the
+            // generated .hpl file (whose text doesn't change when sources change) is an input
+            // to prepareRun.
+            task.getReferencedFiles().from(main.getResources().getSrcDirs());
+            task.getReferencedFiles().from(main.getOutput().getClassesDirs());
+            task.getReferencedFiles().from(project.provider(main.getOutput()::getResourcesDir));
+            task.getReferencedFiles().from(runtimeClasspathArtifacts.getBundledLibraries());
+            task.dependsOn(project.getTasks().named("classes"));
+        });
     }
 
-    private static void registerTestTask(@NotNull Project project, @NotNull Provider<PortAllocationService> portAllocationService,
-                                         @NotNull String gradleExecutable, @NotNull StartParameter startParameter,
-                                         boolean isRootProject, @NotNull String projectPath, @NotNull String taskName,
-                                         @NotNull String description, @NotNull String taskSuffix) {
-        project.getTasks().register(taskName, TestServerTask.class, new Action<>() {
+    @NotNull
+    private static TaskProvider<TestServerTask> registerTestTask(
+            @NotNull Project project, @NotNull Provider<PortAllocationService> portAllocationService,
+            @NotNull String gradleExecutable, @NotNull StartParameter startParameter,
+            boolean isRootProject, @NotNull String projectPath, @NotNull String taskName,
+            @NotNull String description, @NotNull String taskSuffix) {
+        return project.getTasks().register(taskName, TestServerTask.class, new Action<>() {
             @Override
             public void execute(@NotNull TestServerTask task) {
                 task.setGroup("verification");
@@ -288,8 +313,21 @@ public class V2JpiPlugin implements Plugin<Project> {
                 task.getRootDir().set(project.getRootDir().getAbsolutePath());
                 task.getGradleExecutable().set(gradleExecutable);
                 task.getJavaHome().set(System.getProperty("java.home"));
-                task.getInitScripts().set(startParameter.getAllInitScripts().stream()
-                        .map(File::getAbsolutePath).toList());
+                var initScripts = startParameter.getAllInitScripts();
+                task.getInitScriptFiles().from(initScripts);
+                task.getInitScriptPaths().set(initScripts.stream().map(File::getAbsolutePath).toList());
+                task.getBuildConfigFiles().from(project.fileTree(project.getRootDir(), tree -> {
+                    // Build logic that can change how the nested :server / :hplRun build behaves.
+                    // This cannot be exhaustive — the nested build re-evaluates everything — so see
+                    // the cacheability note on TestServerTask for what is and isn't guaranteed.
+                    tree.include(
+                            "**/*.gradle", "**/*.gradle.kts",   // build & settings scripts (incl. buildSrc, included builds)
+                            "**/gradle.properties",
+                            "**/*.versions.toml",               // version catalogs, e.g. gradle/libs.versions.toml
+                            "buildSrc/src/**"                   // precompiled script plugins / buildSrc logic
+                    );
+                    tree.exclude("**/build/**", "**/.gradle/**");
+                }));
                 task.getIncludedBuilds().set(startParameter.getIncludedBuilds().stream()
                         .map(File::getPath).toList());
                 task.getOffline().set(startParameter.isOffline());
@@ -303,6 +341,7 @@ public class V2JpiPlugin implements Plugin<Project> {
                 task.getSystemProperties().set(startParameter.getSystemPropertiesArgs());
                 task.getProjectProperties().set(startParameter.getProjectProperties());
                 task.getServerTaskPath().set(isRootProject ? taskSuffix : projectPath + taskSuffix);
+                task.getSuccessMarker().set(project.getLayout().getBuildDirectory().file("test-server/" + taskName + ".success"));
                 task.getPortAllocationService().set(portAllocationService);
                 task.usesService(portAllocationService);
             }
@@ -402,6 +441,36 @@ public class V2JpiPlugin implements Plugin<Project> {
 
     private static void configureProjectDependencyTasks(TaskProvider<Sync> prepareTask, List<TaskProvider<?>> projectDependencyTasks) {
         prepareTask.configure(sync -> projectDependencyTasks.forEach(sync::from));
+    }
+
+    /**
+     * Wire each upstream JPI project dependency's {@code main} source set classes / resources
+     * into this project's {@code testHplRun} {@code referencedFiles}. Upstream {@code .hpl}
+     * manifests only reference paths to those directories, so without this the consumer's
+     * {@code testHplRun} cache would not invalidate when an upstream class's content changes.
+     */
+    private static void wireUpstreamJpiReferencedFiles(@NotNull Project project, @NotNull List<Project> projectDependencies) {
+        var hplProjectDeps = projectDependencies.stream()
+                .filter(dep -> dep.getTasks().getNames().contains(GenerateHplTask.TASK_NAME))
+                .toList();
+        if (hplProjectDeps.isEmpty()) {
+            return;
+        }
+        project.getTasks().named("testHplRun", TestServerTask.class, task -> {
+            for (var dep : hplProjectDeps) {
+                var depJava = dep.getExtensions().getByType(JavaPluginExtension.class);
+                var depMain = depJava.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
+                task.getReferencedFiles().from(depMain.getResources().getSrcDirs());
+                task.getReferencedFiles().from(depMain.getOutput().getClassesDirs());
+                task.getReferencedFiles().from(dep.provider(() -> depMain.getOutput().getResourcesDir()));
+                // The upstream .hpl also references the dep's bundled library JARs by path, so
+                // adding or removing a library in the upstream module must bust the cache here.
+                var depDefaultRuntime = dep.getConfigurations().getByName("defaultRuntime");
+                var depJenkinsCore = dep.getConfigurations().getByName("jenkinsCore");
+                task.getReferencedFiles().from(new RuntimeClasspathArtifacts(dep, depDefaultRuntime, depJenkinsCore).getBundledLibraries());
+                task.dependsOn(dep.getTasks().named("classes"));
+            }
+        });
     }
 
     private static void configureProjectDependencyJpis(TaskProvider<Sync> prepareTask, List<TaskWithRename> projectDependencyJpis) {

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/MultiModuleIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/MultiModuleIntegrationTest.java
@@ -6,14 +6,19 @@ import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.assertj.core.groups.Tuple;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
 import org.jenkinsci.gradle.plugins.jpi.IntegrationTestHelper;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.concurrent.TimeUnit;
 import java.util.jar.Manifest;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -91,6 +96,46 @@ class MultiModuleIntegrationTest extends V2IntegrationTestBase {
         // then
         var pluginThreeJpi = ith.inProjectDir("plugin-four/work/plugins/plugin-three.jpi");
         assertThat(pluginThreeJpi).exists();
+    }
+
+    @Test
+    @Timeout(value = 15, unit = TimeUnit.MINUTES)
+    void testHplRunInvalidatesOnUpstreamModuleSourceChange() throws IOException {
+        var ith = new IntegrationTestHelper(tempDir, "8.14");
+        configureTwoPluginsForVerification(ith);
+
+        GradleRunner runner = ith.gradleRunner();
+        var taskPath = ":downstream:testHplRun";
+
+        var first = runner.withArguments(":downstream:testHplRun", "--build-cache").build();
+        assertThat(first.task(taskPath).getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(first.getOutput()).contains("Jenkins is fully up and running");
+
+        var noChange = runner.withArguments(":downstream:testHplRun", "--build-cache").build();
+        assertThat(noChange.task(taskPath).getOutcome())
+                .as("unchanged inputs should hit the cache and skip launching Jenkins")
+                .isEqualTo(TaskOutcome.UP_TO_DATE);
+
+        deleteDirectory(ith.inProjectDir("downstream/build"));
+        var fromCache = runner.withArguments(":downstream:testHplRun", "--build-cache").build();
+        assertThat(fromCache.task(taskPath).getOutcome())
+                .as("after build dir is deleted, the task must be restored FROM_CACHE rather than re-executing")
+                .isEqualTo(TaskOutcome.FROM_CACHE);
+
+        // Edit a source file in the *upstream* module — Jenkins on the next hplRun would
+        // load the new class via upstream's HPL (which only references paths, not content).
+        // The downstream testHplRun must therefore re-execute, not silently reuse the
+        // cached pass that no longer reflects current behavior.
+        var upstreamSrc = ith.inProjectDir("upstream/src/main/java/com/example/upstream/Example.java").toPath();
+        Files.writeString(upstreamSrc, /* language=java */ """
+                package com.example.upstream;
+                public class Example { public String hello() { return "v2"; } }
+                """, StandardCharsets.UTF_8);
+        var afterUpstreamEdit = runner.withArguments(":downstream:testHplRun", "--build-cache").build();
+        assertThat(afterUpstreamEdit.task(taskPath).getOutcome())
+                .as("editing an upstream module's source must invalidate the downstream testHplRun cache")
+                .isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(afterUpstreamEdit.getOutput()).contains("Jenkins is fully up and running");
     }
 
     @Test

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/SimpleBuildIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/SimpleBuildIntegrationTest.java
@@ -1,15 +1,19 @@
 package org.jenkinsci.gradle.plugins.jpi2;
 
 import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
 import org.jenkinsci.gradle.plugins.jpi.IntegrationTestHelper;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
+import java.util.concurrent.TimeUnit;
 import java.util.jar.Manifest;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -137,6 +141,147 @@ class SimpleBuildIntegrationTest extends V2IntegrationTestBase {
 
         // when
         testServerVerificationTask(gradleRunner, "testHplRun");
+    }
+
+    @Test
+    @Timeout(value = 15, unit = TimeUnit.MINUTES)
+    void testServerIsCacheableAndInvalidatesOnSourceChange() throws IOException {
+        assertVerificationTaskCachingBehavior("testServer");
+    }
+
+    @Test
+    @Timeout(value = 15, unit = TimeUnit.MINUTES)
+    void testHplRunIsCacheableAndInvalidatesOnSourceChange() throws IOException {
+        assertVerificationTaskCachingBehavior("testHplRun");
+    }
+
+    @Test
+    @Timeout(value = 15, unit = TimeUnit.MINUTES)
+    void testServerInvalidatesOnBuildScriptChange() throws IOException {
+        assertVerificationTaskInvalidatesOnBuildScriptChange("testServer");
+    }
+
+    @Test
+    @Timeout(value = 15, unit = TimeUnit.MINUTES)
+    void testHplRunInvalidatesOnBuildScriptChange() throws IOException {
+        assertVerificationTaskInvalidatesOnBuildScriptChange("testHplRun");
+    }
+
+    @Test
+    @Timeout(value = 15, unit = TimeUnit.MINUTES)
+    void testServerInvalidatesOnInitScriptContentAndOrderChange() throws IOException {
+        var ith = new IntegrationTestHelper(tempDir, "8.14");
+        configureSimpleBuildForVerification(ith);
+
+        // Init scripts forwarded to the nested build affect its behavior. Keep them outside the
+        // project tree so only the init-script inputs (not the build-config fileTree) can invalidate
+        // the cache, isolating that getInitScriptFiles (content) and getInitScriptPaths (order) work.
+        var initDir = Files.createTempDirectory("jpi2-init-scripts");
+        var scriptA = Files.writeString(initDir.resolve("a.gradle"), "// init script a v1\n").toAbsolutePath().toString();
+        var scriptB = Files.writeString(initDir.resolve("b.gradle"), "// init script b\n").toAbsolutePath().toString();
+
+        GradleRunner runner = ith.gradleRunner();
+
+        var first = runner.withArguments("testServer", "--init-script", scriptA, "--init-script", scriptB, "--build-cache").build();
+        assertThat(first.task(":testServer").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+
+        var unchanged = runner.withArguments("testServer", "--init-script", scriptA, "--init-script", scriptB, "--build-cache").build();
+        assertThat(unchanged.task(":testServer").getOutcome())
+                .as("unchanged init scripts should hit the cache")
+                .isEqualTo(TaskOutcome.UP_TO_DATE);
+
+        // Edit an init script's content without changing its path: the content fingerprint
+        // (getInitScriptFiles, PathSensitivity.NONE) must invalidate the cache.
+        Files.writeString(initDir.resolve("a.gradle"), "// init script a v2\n");
+        var afterContentEdit = runner.withArguments("testServer", "--init-script", scriptA, "--init-script", scriptB, "--build-cache").build();
+        assertThat(afterContentEdit.task(":testServer").getOutcome())
+                .as("editing an init script's content must invalidate the cache")
+                .isEqualTo(TaskOutcome.SUCCESS);
+
+        // Swap the order of two unchanged scripts: Gradle applies init scripts in command-line order,
+        // so the ordered path input (getInitScriptPaths) must invalidate the cache.
+        var afterReorder = runner.withArguments("testServer", "--init-script", scriptB, "--init-script", scriptA, "--build-cache").build();
+        assertThat(afterReorder.task(":testServer").getOutcome())
+                .as("reordering init scripts must invalidate the cache")
+                .isEqualTo(TaskOutcome.SUCCESS);
+    }
+
+    private void assertVerificationTaskInvalidatesOnBuildScriptChange(String task) throws IOException {
+        var ith = new IntegrationTestHelper(tempDir, "8.14");
+        configureSimpleBuildForVerification(ith);
+
+        GradleRunner runner = ith.gradleRunner();
+        var taskPath = ":" + task;
+
+        var first = runner.withArguments(task).build();
+        assertThat(first.task(taskPath).getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+
+        var secondNoChange = runner.withArguments(task).build();
+        assertThat(secondNoChange.task(taskPath).getOutcome())
+                .as("unchanged inputs should hit the cache")
+                .isEqualTo(TaskOutcome.UP_TO_DATE);
+
+        // Append a comment to build.gradle.kts — changes file content without affecting behavior.
+        Files.writeString(ith.inProjectDir("build.gradle.kts").toPath(),
+                "\n// cache-invalidation marker\n",
+                StandardCharsets.UTF_8, StandardOpenOption.APPEND);
+        var afterBuildScriptEdit = runner.withArguments(task).build();
+        assertThat(afterBuildScriptEdit.task(taskPath).getOutcome())
+                .as("editing build.gradle.kts must invalidate the cache")
+                .isEqualTo(TaskOutcome.SUCCESS);
+    }
+
+    private void assertVerificationTaskCachingBehavior(String task) throws IOException {
+        var ith = new IntegrationTestHelper(tempDir, "8.14");
+        configureSimpleBuildForVerification(ith);
+
+        // A non-empty source set ensures the testHplRun cache must track classes/resources
+        // via referencedFiles — without that wiring, removing this file would not invalidate
+        // the cache (the .hpl text only references paths, not content).
+        ith.mkDirInProjectDir("src/main/java/com/example");
+        var source = ith.inProjectDir("src/main/java/com/example/Example.java").toPath();
+        Files.writeString(source,
+                "package com.example; public class Example { public String hello() { return \"v1\"; } }\n",
+                StandardCharsets.UTF_8);
+
+        GradleRunner runner = ith.gradleRunner();
+        var taskPath = ":" + task;
+
+        var first = runner.withArguments(task, "--build-cache").build();
+        assertThat(first.task(taskPath).getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(first.getOutput()).contains("Jenkins is fully up and running");
+
+        var secondNoChange = runner.withArguments(task, "--build-cache").build();
+        assertThat(secondNoChange.task(taskPath).getOutcome())
+                .as("unchanged inputs should hit the cache and skip launching Jenkins")
+                .isEqualTo(TaskOutcome.UP_TO_DATE);
+        assertThat(secondNoChange.getOutput()).doesNotContain("Jenkins is fully up and running");
+
+        // Delete build outputs to force a cache lookup instead of an UP_TO_DATE check.
+        deleteDirectory(ith.inProjectDir("build"));
+        var fromCache = runner.withArguments(task, "--build-cache").build();
+        assertThat(fromCache.task(taskPath).getOutcome())
+                .as("after build dir is deleted, the task must be restored FROM_CACHE rather than re-executing")
+                .isEqualTo(TaskOutcome.FROM_CACHE);
+        assertThat(fromCache.getOutput()).doesNotContain("Jenkins is fully up and running");
+
+        // Edit-in-place: the .class file's content changes but its path does not. For
+        // testHplRun, the .hpl manifest's Libraries attribute lists paths (filtered by
+        // File.exists), so editing alone does NOT change the .hpl bytes.
+        Files.writeString(source,
+                "package com.example; public class Example { public String hello() { return \"v2\"; } }\n",
+                StandardCharsets.UTF_8);
+        var afterEdit = runner.withArguments(task).build();
+        assertThat(afterEdit.task(taskPath).getOutcome())
+                .as("editing main source must invalidate the cache (catches missing referencedFiles wiring on testHplRun)")
+                .isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(afterEdit.getOutput()).contains("Jenkins is fully up and running");
+
+        var rerunTasks = runner.withArguments(task, "--rerun-tasks").build();
+        assertThat(rerunTasks.task(taskPath).getOutcome())
+                .as("--rerun-tasks must force the task to run regardless of cache state")
+                .isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(rerunTasks.getOutput()).contains("Jenkins is fully up and running");
     }
 
     @Test

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/V2IntegrationTestBase.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/V2IntegrationTestBase.java
@@ -20,6 +20,7 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -211,6 +212,42 @@ abstract class V2IntegrationTestBase {
         var pluginJar = materializePluginJar(ith.inProjectDir("plugin-under-test/jpi2-under-test.jar"));
         Files.write(ith.inProjectDir("build.gradle.kts").toPath(),
                 getBasePluginConfigWithBuildscriptClasspath(pluginJar.getAbsolutePath()).getBytes(StandardCharsets.UTF_8));
+    }
+
+    static void configureTwoPluginsForVerification(IntegrationTestHelper ith) throws IOException {
+        var pluginJar = materializePluginJar(ith.inProjectDir("plugin-under-test/jpi2-under-test.jar"));
+        Files.writeString(ith.inProjectDir("settings.gradle.kts").toPath(), /* language=kotlin */ """
+                rootProject.name = "test-plugin"
+                include("upstream", "downstream")
+                """, StandardCharsets.UTF_8);
+        Files.writeString(ith.inProjectDir("gradle.properties").toPath(), /* language=properties */ """
+                jenkins.version=2.492.3
+                org.gradle.warning.mode=all
+                """, StandardCharsets.UTF_8);
+        Files.writeString(ith.inProjectDir("build.gradle.kts").toPath(), "", StandardCharsets.UTF_8);
+
+        ith.mkDirInProjectDir("upstream/src/main/java/com/example/upstream");
+        Files.writeString(ith.inProjectDir("upstream/build.gradle.kts").toPath(),
+                getBasePluginConfigWithBuildscriptClasspath(pluginJar.getAbsolutePath()),
+                StandardCharsets.UTF_8);
+        Files.writeString(ith.inProjectDir("upstream/src/main/java/com/example/upstream/Example.java").toPath(),
+                /* language=java */ """
+                        package com.example.upstream;
+                        public class Example { public String hello() { return "v1"; } }
+                        """, StandardCharsets.UTF_8);
+
+        ith.mkDirInProjectDir("downstream/src/main/java/com/example/downstream");
+        Files.writeString(ith.inProjectDir("downstream/build.gradle.kts").toPath(),
+                getBasePluginConfigWithBuildscriptClasspath(pluginJar.getAbsolutePath()) + /* language=kotlin */ """
+                        dependencies {
+                            "implementation"(project(":upstream"))
+                        }
+                        """, StandardCharsets.UTF_8);
+        Files.writeString(ith.inProjectDir("downstream/src/main/java/com/example/downstream/Example.java").toPath(),
+                /* language=java */ """
+                        package com.example.downstream;
+                        public class Example { public String hello() { return "v1"; } }
+                        """, StandardCharsets.UTF_8);
     }
 
     static void configureBuildWithOssPluginDependency(IntegrationTestHelper ith) throws IOException {
@@ -434,6 +471,13 @@ abstract class V2IntegrationTestBase {
                 Files.copy(path, jarOutputStream);
                 jarOutputStream.closeEntry();
             }
+        }
+    }
+
+    static void deleteDirectory(File dir) throws IOException {
+        if (!dir.exists()) return;
+        try (var paths = Files.walk(dir.toPath())) {
+            paths.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
         }
     }
 }


### PR DESCRIPTION
Replace `TestServerTask`'s `@DisableCachingByDefault` with `@CacheableTask` and wire real inputs/outputs so the task is only re-executed when something that affects the outcome actually changes:

- `@InputFiles pluginFiles`: the `prepareServer` / `prepareRun` source files (snapshotted via `Sync::getSource` so the two test tasks do not collide on the shared `workDir/plugins` destination)
- `@Classpath jenkinsClasspath`: the `serverTaskClasspath` (`jenkins-war`)
- `@InputFiles referencedFiles`: classes, resources, and bundled libraries pointed at by the `.hpl` `Libraries` attribute -- required because the `.hpl` text only stores paths, not the content at those paths. Includes the upstream JPI project dependencies' `main` source set as well, so a consumer's `testHplRun` cache invalidates when an upstream module's class content changes (the upstream `.hpl` bytes do not).
- `@OutputFile successMarker`: written only when Jenkins reports a successful start; the task now fails fast if no success line is seen

Add `SimpleBuildIntegrationTest.testServerIsCacheableAndInvalidatesOn` `SourceChange` and the `testHplRun` counterpart. They assert: first run `SUCCESS`, no-change re-run `UP_TO_DATE`, edit-in-place `SUCCESS`, and `--rerun-tasks` `SUCCESS`.

Add `MultiModuleIntegrationTest.testHplRunInvalidatesOnUpstreamModule`, `SourceChange` covering the cross-module case: editing an upstream module's source must invalidate the downstream `testHplRun` cache.

### Testing done

I've added integration tests to verify this works as intended.

This is the manual testing I did: On my M1 MacBook Pro, for a fairly large project with several submodules, this was the improvement in developer experience for running `./gradlew --include-build <PLUGIN_PATH> --max-workers=3 check`

* Clean
* Before (07c2829c8845cf33c3f9a53ce16ab487420c76bf)
  * First Run: 9m 36s
  * Second Run: 7m 30s (An improvement from other cached tasks, but `testServer` on each submodule is significant)
* Clean
* After (62ea9e4c3bb04314de2cd2c0a2fbbfc7fea3cb10)
  * First Run: 8m 41s
  * Second Run: 1m 12s (That project has other areas for improvement, but this is a huge improvement)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
