### PR TITLE
refactor: replace System.err.println with Gradle logger calls

### DIFF
--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/PomBuilder.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/PomBuilder.java
@@ -8,6 +8,7 @@ import org.gradle.api.Project;
 import org.gradle.api.XmlProvider;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
+import org.gradle.api.logging.Logger;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -22,11 +23,13 @@ class PomBuilder implements Action<XmlProvider> {
     private final Configuration runtimeClasspath;
     private final Project project;
     private final JenkinsPluginExtension extension;
+    private final Logger logger;
 
-    public PomBuilder(Configuration runtimeClasspath, Project project, JenkinsPluginExtension extension) {
+    public PomBuilder(Configuration runtimeClasspath, Project project, JenkinsPluginExtension extension, Logger logger) {
         this.runtimeClasspath = runtimeClasspath;
         this.project = project;
         this.extension = extension;
+        this.logger = logger;
     }
 
     private static Optional<String> getNodeElement(Node dependencyNode, String elementName) {
@@ -85,7 +88,7 @@ class PomBuilder implements Action<XmlProvider> {
                 }
                 dependencyNode.appendNode(new QName(POM_NS, "version"), resolvedDependency.get().getModuleVersion());
             } else {
-                System.err.println("Dependency not found: " + groupId + ":" + artifactId);
+                logger.warn("Dependency not found: {}:{}", groupId, artifactId);
             }
         });
     }

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/TestServerTask.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/TestServerTask.java
@@ -210,7 +210,7 @@ public abstract class TestServerTask extends DefaultTask {
                 } catch (InterruptedException e) {
                     // Ignore
                 }
-                System.err.println("Timeout reached, terminating Jenkins server");
+                getLogger().warn("Timeout reached, terminating Jenkins server");
                 process.destroy();
             });
 
@@ -259,11 +259,11 @@ public abstract class TestServerTask extends DefaultTask {
         return new ProcessBuilder(commandLine).directory(new File(getRootDir().get())).redirectErrorStream(true).start();
     }
 
-    private static boolean isProcessSuccessful(BufferedReader stdoutReader, Process process) throws IOException, InterruptedException {
+    private boolean isProcessSuccessful(BufferedReader stdoutReader, Process process) throws IOException, InterruptedException {
         String stdout;
 
         while ((stdout = stdoutReader.readLine()) != null) {
-            System.err.println("    " + stdout);
+            getLogger().lifecycle("    {}", stdout);
             if (stdout.contains("Jenkins is fully up and running")) {
                 process.destroy();
                 return true;
@@ -336,7 +336,7 @@ public abstract class TestServerTask extends DefaultTask {
         commandLine.add(getServerTaskPath().get());
         commandLine.add("-Dserver.port=" + getPortAllocationService().get().findAndReserveFreePort());
         commandLine.add("-P" + WorkDirectorySettings.PROPERTY + "=" + workDir.toAbsolutePath());
-        System.err.println("Command: " + commandLine);
+        getLogger().info("Command: {}", commandLine);
         return commandLine;
     }
 }

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
@@ -413,7 +413,7 @@ public class V2JpiPlugin implements Plugin<Project> {
         publication.getPom().getName().set(extension.getDisplayName());
         publication.getPom().getUrl().set(extension.getHomePage().map(URI::toASCIIString));
         publication.getPom().getDescription().set(project.provider(project::getDescription));
-        publication.getPom().withXml(new PomBuilder(runtimeClasspath, project, extension));
+        publication.getPom().withXml(new PomBuilder(runtimeClasspath, project, extension, project.getLogger()));
     }
 
     @NotNull


### PR DESCRIPTION
`System.err` bypasses Gradle's logging infrastructure — output appears unconditionally regardless of log level and is not routed through Gradle's quiet/lifecycle/info/debug hierarchy.

## Changes

- **`PomBuilder`** — `System.err.println` → `project.getLogger().warn(...)` with SLF4J placeholder syntax
- **`TestServerTask`** — three call sites replaced:
  - Timeout message → `warn` (abnormal condition)
  - Jenkins stdout passthrough → `lifecycle` (visible at normal verbosity, which is what users want when watching a server start)
  - Command-line diagnostic → `info` (available with `--info`, not shown by default)
  - `isProcessSuccessful` de-staticized so `getLogger()` is accessible