### PR TITLE
fix: handle InterruptedException correctly in TestServerTask

### DIFF
--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/TestServerTask.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/TestServerTask.java
@@ -208,7 +208,7 @@ public abstract class TestServerTask extends DefaultTask {
                 try {
                     Thread.sleep(timeout * 1000L);
                 } catch (InterruptedException e) {
-                    // Ignore
+                    return;
                 }
                 System.err.println("Timeout reached, terminating Jenkins server");
                 process.destroy();
@@ -229,6 +229,7 @@ public abstract class TestServerTask extends DefaultTask {
         } catch (IOException e) {
             throw new GradleException("IO Exception", e);
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new GradleException("Process interrupted", e);
         } finally {
             cleanupWorkDirectory(workDir);


### PR DESCRIPTION
## Summary

- The timer thread in `TestServerTask` was ignoring `InterruptedException` and falling through to `process.destroy()`, killing the Jenkins process even when the timer was intentionally cancelled. Fixed by returning early on interrupt.
- The `runTestServer()` catch block was wrapping `InterruptedException` in a `GradleException` without restoring the interrupted flag, silently consuming the interrupt signal. Fixed by calling `Thread.currentThread().interrupt()` before re-throwing.