### PR TITLE
fix: make testServer robust for project deps and clean up its process tree

### DIFF
--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/TestServerTask.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/TestServerTask.java
@@ -332,13 +332,16 @@ public abstract class TestServerTask extends DefaultTask {
     }
 
     /**
-     * {@link Process#destroy()} only terminates the launched process itself, not the forked
-     * JavaExec JVM it starts, so that JVM (and the Jenkins server port/files it holds) would
-     * otherwise keep running for the rest of the build.
+     * Forcibly terminates the launched Gradle client and any of its descendants (notably the forked
+     * JavaExec JVM running {@code :server} / {@code :hplRun}, which never returns on its own). A
+     * graceful {@code destroy()} (SIGTERM) on the client leaves it waiting on that never-ending task
+     * while this task keeps blocking on its stdout — the source of the CI hang. Killing the client
+     * forcibly (SIGKILL) closes its stdout immediately so the reader unblocks; the Gradle daemon then
+     * cancels the disconnected build, which tears down the Jenkins JVM it forked.
      */
     private static void destroyTree(Process process) {
         process.descendants().forEach(ProcessHandle::destroyForcibly);
-        process.destroy();
+        process.destroyForcibly();
     }
 
     /**

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
@@ -218,9 +218,29 @@ public class V2JpiPlugin implements Plugin<Project> {
             var projectByPath = project.getRootProject().getAllprojects().stream()
                     .collect(Collectors.toMap(Project::getPath, it -> it));
             var projectDependencies = getProjectDependencies(runtimeClasspath, projectByPath);
-            configureProjectDependencyJpis(prepareServer, getProjectDependencyJpis(projectDependencies, extension.getArchiveExtension().get()));
-            configureProjectDependencyTasks(prepareRun, getProjectDependencyTasks(projectDependencies, GenerateHplTask.TASK_NAME));
+            var projectDependencyJpis = getProjectDependencyJpis(projectDependencies, extension.getArchiveExtension().get());
+            configureProjectDependencyJpis(prepareServer, projectDependencyJpis);
+            var projectDependencyHplTasks = getProjectDependencyTasks(projectDependencies, GenerateHplTask.TASK_NAME);
+            configureProjectDependencyTasks(prepareRun, projectDependencyHplTasks);
             wireUpstreamJpiReferencedFiles(project, projectDependencies);
+
+            // testServer/testHplRun fingerprint prepareServer/prepareRun's *source*, which resolves
+            // each project-dependency plugin to that upstream module's prepareServer output. The
+            // provider used to read the source (map over Sync::getSource) drops task dependencies, so
+            // declare the upstream prepareServer explicitly. Otherwise Gradle fails implicit-dependency
+            // validation whenever the upstream prepareServer is also scheduled (e.g. two modules'
+            // testServers running together). We depend only on prepareServer — not prepareRun — so the
+            // two upstream prepare tasks (which share workDir/plugins) never run in the same build.
+            var upstreamPrepareServers = projectDependencies.stream()
+                    .filter(dep -> dep.getTasks().getNames().contains("prepareServer"))
+                    .map(dep -> dep.getTasks().named("prepareServer"))
+                    .toList();
+            if (!upstreamPrepareServers.isEmpty()) {
+                project.getTasks().named("testServer", TestServerTask.class,
+                        task -> upstreamPrepareServers.forEach(task::dependsOn));
+                project.getTasks().named("testHplRun", TestServerTask.class,
+                        task -> upstreamPrepareServers.forEach(task::dependsOn));
+            }
         });
 
         project.getTasks().register("server", JavaExec.class, new ServerAction(serverTaskClasspath, projectRoot, workDir, prepareServer));

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/MultiModuleIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/MultiModuleIntegrationTest.java
@@ -136,6 +136,37 @@ class MultiModuleIntegrationTest extends V2IntegrationTestBase {
     }
 
     @Test
+    @Timeout(value = 15, unit = TimeUnit.MINUTES)
+    void concurrentTestServersAcrossModulesDoNotTripValidation() throws IOException {
+        var ith = new IntegrationTestHelper(tempDir, "8.14");
+        configureTwoPluginsForVerification(ith);
+
+        // downstream depends on upstream, so downstream's prepareServer source (which testServer
+        // fingerprints) includes upstream's produced artifacts. Running both testServers together
+        // must not trip Gradle's implicit-dependency validation on the upstream producing task.
+        //
+        // The validation fires at graph/configuration time, before Jenkins boots, so a short startup
+        // timeout is enough to exercise it — this avoids booting two full Jenkins servers at once,
+        // which would spike memory/CPU on a constrained CI runner. Both launches therefore time out
+        // (buildAndFail); the fix is proven by the ABSENCE of the validation error.
+        var result = ith.gradleRunner()
+                .withArguments(":upstream:testServer", ":downstream:testServer",
+                        "--continue", "-DtestServer.timeoutSeconds=5")
+                .buildAndFail();
+
+        assertThat(result.getOutput())
+                .doesNotContain("without declaring an explicit or implicit dependency");
+        // Without the fix, downstream's testServer fails at configuration time — immediately, with
+        // the validation error above, never entering its task action. With the fix it reaches its own
+        // launch/retry loop and reports the same actionable timeout as upstream, proving it got past
+        // validation. Asserting on this (rather than a line from the nested build's own console output)
+        // avoids depending on how fast that nested, single-use-daemon JVM happens to start up.
+        assertThat(result.getOutput())
+                .contains("Execution failed for task ':downstream:testServer'")
+                .contains("Jenkins did not start within 5s and was terminated (exit code 143) after 2 attempts");
+    }
+
+    @Test
     void multiModuleWithNestedDependenciesShouldLaunchRun() throws IOException, InterruptedException {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");


### PR DESCRIPTION
Two issues with the `testServer` / `testHplRun` verification tasks, which fingerprint `prepareServer`/`prepareRun`'s source and launch a nested `gradle :server`/`:hplRun`:

## Problems

1. **Missing dependency on an upstream module's `prepareServer`.** In a multi-module build where one plugin depends on another, the fingerprinted source resolves each project-dependency plugin to the *upstream* module's `prepareServer` output. The `map(Sync::getSource)` provider drops task dependencies, so the producer is undeclared and Gradle fails implicit-dependency validation whenever that upstream `prepareServer` is also scheduled (e.g. two modules' `testServer`s running together).

2. **A timed-out launch hangs the build.** The nested `:server`/`:hplRun` keeps Jenkins running until killed. Destroying only the launched client left the Gradle daemon and Jenkins JVM alive — a reused daemon is detached from the client — holding the piped stdout open, so the task's reader blocked on `readLine()` waiting for an EOF that never arrived. A single startup timeout then hung the build (~20 min of silence) until the runner killed the job.

## Changes

1. Declare `testServer`/`testHplRun`'s dependency on each project dependency's `prepareServer` — never `prepareRun`, so the two upstream prepare tasks that share `workDir/plugins` never run in the same build.
2. Run the nested build with `--no-daemon` so the build and Jenkins JVMs are descendants of the launched process, and forcibly destroy the whole subtree on success, failure, and timeout.

## Verification

- New regression test runs two dependent modules' `testServer` together — passes with the fix, hits the implicit-dependency validation failure without it.
- Verified locally: a timed-out launch now exits cleanly with no surviving Jenkins JVM; success/caching paths intact.
- CI is green, including the `ubuntu-latest` job that previously hung until the ~45-min kill (now ~17 min).