### PR TITLE
feat: throttle concurrent Jenkins test-server launches

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,13 @@ jenkinsPlugin {
 Those temporary directories are deleted after the task finishes.
 Set `jpi2.preserveTestWorkDir=true` if you want to keep them for debugging.
 
+Each launch is a nested Gradle build plus a full Jenkins JVM, so running many at once (for example a multi-module build where every module has a `testServer` task) can saturate the machine and make Jenkins miss its startup timeout.
+To avoid this, the plugin caps how many launches run concurrently across the whole build with a shared build service, independent of `--max-workers`, so the rest of the build keeps full parallelism.
+The default cap scales with available processors (roughly one launch per three cores).
+Override it with `-DtestServer.maxParallelLaunches`, which accepts either an absolute count (for example `3`) or a processor-relative value: `C` for all available processors, or `C/D` for one launch per `D` processors (for example `C/2` for a more aggressive cap, `C/4` for a more conservative one).
+Prefer the `C/D` form when the setting is checked in or shared, so it keeps making sense on a machine with a different core count.
+A launch that still times out is retried (`-DtestServer.maxAttempts=N`, default `2`), and the per-launch startup timeout is `-DtestServer.timeoutSeconds=N` (default `120`).
+
 ## Migration And Legacy Docs
 
 Use [docs/migrating-to-jpi2.md](docs/migrating-to-jpi2.md) when moving an existing plugin from `org.jenkins-ci.jpi` to `org.jenkins-ci.jpi2`.

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/JenkinsLaunchThrottle.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/JenkinsLaunchThrottle.java
@@ -1,0 +1,80 @@
+package org.jenkinsci.gradle.plugins.jpi2;
+
+import org.gradle.api.services.BuildService;
+import org.gradle.api.services.BuildServiceParameters;
+
+import java.util.Locale;
+
+/**
+ * A shared Gradle build service used purely as a concurrency gate for launching Jenkins.
+ *
+ * <p>Each {@link TestServerTask} spawns a nested Gradle build that boots a full Jenkins JVM, so every
+ * {@code testServer} / {@code testHplRun} task is two heavyweight JVMs. When many such tasks run at
+ * once — a monorepo can have dozens, one per plugin module — the machine saturates and Jenkins fails
+ * to finish booting within the startup timeout, then gets terminated (exit code 143).
+ *
+ * <p>Registering this service with a bounded {@code maxParallelUsages} and having every launch task
+ * declare {@code usesService(...)} caps the number of <em>concurrent Jenkins launches</em> without
+ * throttling the rest of the build (compilation, unit tests, etc. keep full {@code --max-workers}
+ * parallelism). This replaces the blunt {@code --max-workers=N} workaround.
+ *
+ * <p>The service holds no state; it exists only so Gradle can enforce the parallelism limit.
+ */
+public abstract class JenkinsLaunchThrottle implements BuildService<BuildServiceParameters.None> {
+
+    /**
+     * System property that sets the concurrent-launch cap. Accepts an absolute integer (e.g.
+     * {@code 3}), or a processor-relative value {@code C} (all available processors) or {@code C/D}
+     * (processors divided by {@code D}). The processor-relative form lets a single setting scale
+     * across machines, so a user does not have to re-tune an absolute number per machine.
+     */
+    public static final String MAX_PARALLEL_LAUNCHES_PROPERTY = "testServer.maxParallelLaunches";
+
+    /**
+     * Default cap when the property is unset: one launch per this many processors. A Jenkins boot is
+     * a bursty, largely CPU-bound workload (plugin init, Jelly/Groovy compilation, classloading), so
+     * the cap scales with cores rather than memory. This divisor is the tuning knob — override the
+     * whole value with {@code C/D} to change it without editing the plugin.
+     */
+    static final int DEFAULT_PROCESSOR_DIVISOR = 3;
+
+    /**
+     * Resolves the configured concurrent-launch cap from the raw property value.
+     *
+     * @param spec                 the raw property value, or {@code null}/blank to use the default {@code C/3}
+     * @param availableProcessors  processor count to scale {@code C}-relative specs against
+     * @return the cap, always at least {@code 1}
+     * @throws IllegalArgumentException if {@code spec} is neither a non-negative integer nor {@code C}/{@code C/D}
+     */
+    static int resolveMaxParallelLaunches(String spec, int availableProcessors) {
+        var trimmed = spec == null ? "" : spec.trim();
+        if (trimmed.isEmpty()) {
+            return atLeastOne(availableProcessors / DEFAULT_PROCESSOR_DIVISOR);
+        }
+        if (trimmed.matches("\\d+")) {
+            return atLeastOne(Integer.parseInt(trimmed));
+        }
+        var relative = trimmed.toUpperCase(Locale.ROOT).replaceAll("\\s+", "");
+        if (relative.equals("C")) {
+            return atLeastOne(availableProcessors);
+        }
+        if (relative.matches("C/\\d+")) {
+            var divisor = Integer.parseInt(relative.substring(2));
+            if (divisor <= 0) {
+                throw new IllegalArgumentException(invalidValueMessage(spec));
+            }
+            return atLeastOne(availableProcessors / divisor);
+        }
+        throw new IllegalArgumentException(invalidValueMessage(spec));
+    }
+
+    private static int atLeastOne(int value) {
+        return Math.max(1, value);
+    }
+
+    private static String invalidValueMessage(String spec) {
+        return "Invalid " + MAX_PARALLEL_LAUNCHES_PROPERTY + " value '" + spec
+                + "'. Expected a non-negative integer (e.g. 3), or a processor-relative value "
+                + "'C' or 'C/D' (e.g. C/3).";
+    }
+}

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/TestServerTask.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/TestServerTask.java
@@ -188,51 +188,122 @@ public abstract class TestServerTask extends DefaultTask {
     public abstract Property<PortAllocationService> getPortAllocationService();
 
     /**
-     * Launches a nested Gradle build, streams its output, and fails the task
-     * if Jenkins does not report a successful start within the configured timeout.
+     * @return the configured cap on concurrent Jenkins launches, used only to make the timeout
+     * diagnostic actionable. Not an input: it does not affect the produced marker, and folding it
+     * into the cache key would needlessly invalidate cached runs when only the parallelism changes.
+     */
+    @Internal
+    public abstract Property<Integer> getMaxParallelLaunches();
+
+    /** Outcome of a single Jenkins launch attempt. */
+    private enum Status {
+        /** Jenkins reported "fully up and running". */
+        SUCCESS,
+        /** Jenkins printed a deterministic startup failure (e.g. a plugin failed to load). */
+        CRASH,
+        /** The startup timeout fired and we terminated the process (exit code 143). */
+        TIMEOUT,
+        /** The nested build exited on its own without reporting success. */
+        EXITED
+    }
+
+    private record LaunchResult(Status status, int exitCode, String detail) {
+        static LaunchResult success() {
+            return new LaunchResult(Status.SUCCESS, 0, null);
+        }
+    }
+
+    /**
+     * Launches a nested Gradle build, streams its output, and fails the task if Jenkins does not
+     * report a successful start within the configured timeout.
+     *
+     * <p>A timeout is treated as transient (the machine was likely saturated) and retried up to
+     * {@code testServer.maxAttempts} times; a deterministic startup crash fails immediately.
      */
     @TaskAction
     public void runTestServer() {
-        var timeoutSystemProperty = System.getProperty("testServer.timeoutSeconds", "120");
-        var timeout = Integer.parseInt(timeoutSystemProperty);
+        var timeout = Integer.parseInt(System.getProperty("testServer.timeoutSeconds", "120"));
+        var maxAttempts = Math.max(1, Integer.parseInt(System.getProperty("testServer.maxAttempts", "2")));
 
         clearSuccessMarker();
 
-        Path workDir = null;
-        try {
-            workDir = createWorkDirectory();
-            var commandLine = getCommandLine(workDir);
-            var process = launchProcess(commandLine);
-
-            var timerThread = new Thread(() -> {
-                try {
-                    Thread.sleep(timeout * 1000L);
-                } catch (InterruptedException e) {
-                    return;
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            Path workDir = null;
+            try {
+                workDir = createWorkDirectory();
+                var result = attemptLaunch(workDir, timeout);
+                switch (result.status()) {
+                    case SUCCESS -> {
+                        writeSuccessMarker();
+                        return;
+                    }
+                    // A real startup failure is deterministic; retrying only repeats it, so fail fast.
+                    case CRASH -> throw new GradleException("Jenkins failed to start: " + result.detail());
+                    case EXITED -> throw new GradleException(
+                            "Jenkins failed to report a successful start (exit code " + result.exitCode() + ")");
+                    case TIMEOUT -> {
+                        getLogger().warn("testServer: Jenkins did not start within " + timeout
+                                + "s (attempt " + attempt + " of " + maxAttempts + ")"
+                                + (attempt < maxAttempts ? "; retrying" : ""));
+                        if (attempt == maxAttempts) {
+                            throw new GradleException(timeoutMessage(timeout, maxAttempts));
+                        }
+                    }
                 }
+            } catch (IOException e) {
+                throw new GradleException("IO Exception", e);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new GradleException("Process interrupted", e);
+            } finally {
+                cleanupWorkDirectory(workDir);
+            }
+        }
+    }
+
+    /**
+     * Launches the nested build once and waits for a verdict, terminating Jenkins after either a
+     * successful start or the timeout. A fresh work directory and port are used per attempt.
+     */
+    private LaunchResult attemptLaunch(Path workDir, int timeout) throws IOException, InterruptedException {
+        var process = launchProcess(getCommandLine(workDir));
+        var timedOut = new java.util.concurrent.atomic.AtomicBoolean(false);
+
+        var timerThread = new Thread(() -> {
+            try {
+                Thread.sleep(timeout * 1000L);
+                timedOut.set(true);
                 getLogger().warn("Timeout reached, terminating Jenkins server");
                 destroyTree(process);
-            });
-
-            timerThread.start();
-
-            BufferedReader stdoutReader = new BufferedReader(new InputStreamReader(process.getInputStream()));
-            boolean foundSuccess = isProcessSuccessful(stdoutReader, process);
-
-            process.waitFor();
-
-            if (!foundSuccess) {
-                throw new GradleException("Jenkins failed to report a successful start (exit code " + process.exitValue() + ")");
+            } catch (InterruptedException e) {
+                // The launch reached a verdict before the timeout; nothing to terminate.
             }
+        });
+        timerThread.setDaemon(true);
+        timerThread.start();
 
-            writeSuccessMarker();
-        } catch (IOException e) {
-            throw new GradleException("IO Exception", e);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new GradleException("Process interrupted", e);
+        try {
+            var reader = new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8));
+            LaunchResult verdict;
+            try {
+                verdict = readUntilVerdict(reader, process);
+            } catch (IOException e) {
+                if (!timedOut.get()) {
+                    throw e;
+                }
+                verdict = new LaunchResult(Status.EXITED, -1, null);
+            }
+            process.waitFor();
+            return switch (verdict.status()) {
+                case SUCCESS, CRASH -> verdict;
+                // EOF without a reported verdict: either our timer killed it, or it exited on its own.
+                default -> timedOut.get()
+                        ? new LaunchResult(Status.TIMEOUT, process.exitValue(), null)
+                        : new LaunchResult(Status.EXITED, process.exitValue(), null);
+            };
         } finally {
-            cleanupWorkDirectory(workDir);
+            // Stop the timer promptly so a fast start doesn't leave a thread sleeping for the full timeout.
+            timerThread.interrupt();
         }
     }
 
@@ -270,22 +341,43 @@ public abstract class TestServerTask extends DefaultTask {
         process.destroy();
     }
 
-    private boolean isProcessSuccessful(BufferedReader stdoutReader, Process process) throws IOException, InterruptedException {
+    /**
+     * Streams the nested build's output until Jenkins reports success, prints a known failure, or
+     * the stream closes. Terminates the process on success or crash; the caller decides whether an
+     * unresolved stream close was a timeout or an independent exit.
+     */
+    private LaunchResult readUntilVerdict(BufferedReader stdoutReader, Process process) throws IOException {
         String stdout;
 
         while ((stdout = stdoutReader.readLine()) != null) {
             getLogger().lifecycle("    {}", stdout);
             if (stdout.contains("Jenkins is fully up and running")) {
                 destroyTree(process);
-                return true;
+                return LaunchResult.success();
             }
             if (FAILURE_MESSAGES.stream().anyMatch(stdout::contains)) {
                 destroyTree(process);
-                process.waitFor();
-                throw new GradleException("Jenkins failed to start: " + stdout);
+                return new LaunchResult(Status.CRASH, -1, stdout);
             }
         }
-        return false;
+        return new LaunchResult(Status.EXITED, -1, null);
+    }
+
+    private String timeoutMessage(int timeout, int maxAttempts) {
+        var message = new StringBuilder("Jenkins did not start within ").append(timeout)
+                .append("s and was terminated (exit code 143)");
+        if (maxAttempts > 1) {
+            message.append(" after ").append(maxAttempts).append(" attempts");
+        }
+        message.append(".\nThis usually means too many Jenkins servers were launching at once. ");
+        var cap = getMaxParallelLaunches().getOrElse(0);
+        if (cap > 0) {
+            message.append("The plugin limits concurrent launches to ").append(cap)
+                    .append(" (override with -DtestServer.maxParallelLaunches=N or =C/D). ");
+        }
+        message.append("You can also raise the startup timeout with -DtestServer.timeoutSeconds=N ")
+                .append("or the attempt count with -DtestServer.maxAttempts=N.");
+        return message.toString();
     }
 
     @NotNull

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
@@ -272,6 +272,20 @@ public class V2JpiPlugin implements Plugin<Project> {
         var portAllocationService = buildServices.registerIfAbsent("portAllocation", PortAllocationService.class, spec -> {
         });
 
+        // Cap how many Jenkins servers boot at once. Each launch is a nested Gradle build plus a
+        // Jenkins JVM, so unbounded parallelism saturates the machine and Jenkins misses its startup
+        // timeout (killed → exit 143). The cap governs only the launch tasks, so the rest of the
+        // build keeps full parallelism. Default scales with CPUs (~1 launch per 3 cores); override
+        // with -DtestServer.maxParallelLaunches, which accepts an absolute count or a processor-
+        // relative C/D so one setting survives moving to a machine with a different core count.
+        var availableProcessors = Runtime.getRuntime().availableProcessors();
+        Provider<Integer> maxParallelLaunches = project.getProviders()
+                .systemProperty(JenkinsLaunchThrottle.MAX_PARALLEL_LAUNCHES_PROPERTY)
+                .map(spec -> JenkinsLaunchThrottle.resolveMaxParallelLaunches(spec, availableProcessors))
+                .orElse(JenkinsLaunchThrottle.resolveMaxParallelLaunches(null, availableProcessors));
+        var launchThrottle = buildServices.registerIfAbsent("jenkinsLaunchThrottle", JenkinsLaunchThrottle.class,
+                spec -> spec.getMaxParallelUsages().set(maxParallelLaunches));
+
         var gradle = project.getGradle();
         var startParameter = gradle.getStartParameter();
         var gradleHome = gradle.getGradleHomeDir();
@@ -281,7 +295,7 @@ public class V2JpiPlugin implements Plugin<Project> {
         var isRootProject = project == project.getRootProject();
         var projectPath = project.getPath();
 
-        var testServerTask = registerTestTask(project, portAllocationService, gradleExecutable, startParameter, isRootProject, projectPath,
+        var testServerTask = registerTestTask(project, portAllocationService, launchThrottle, maxParallelLaunches, gradleExecutable, startParameter, isRootProject, projectPath,
                 "testServer", "Launch Jenkins server and terminate after success or first error", ":server");
         // Fingerprint the source files that prepareServer would sync (jpi, plugin dependencies,
         // project-dependency jpis), not its destination — prepareServer and prepareRun both write
@@ -292,7 +306,7 @@ public class V2JpiPlugin implements Plugin<Project> {
             task.getJenkinsClasspath().from(serverTaskClasspath);
         });
 
-        var testHplRunTask = registerTestTask(project, portAllocationService, gradleExecutable, startParameter, isRootProject, projectPath,
+        var testHplRunTask = registerTestTask(project, portAllocationService, launchThrottle, maxParallelLaunches, gradleExecutable, startParameter, isRootProject, projectPath,
                 "testHplRun", "Launch Jenkins hplRun task and terminate after success or first error", ":hplRun");
         testHplRunTask.configure(task -> {
             task.getPluginFiles().from(prepareRun.map(Sync::getSource));
@@ -312,6 +326,7 @@ public class V2JpiPlugin implements Plugin<Project> {
     @NotNull
     private static TaskProvider<TestServerTask> registerTestTask(
             @NotNull Project project, @NotNull Provider<PortAllocationService> portAllocationService,
+            @NotNull Provider<JenkinsLaunchThrottle> launchThrottle, @NotNull Provider<Integer> maxParallelLaunches,
             @NotNull String gradleExecutable, @NotNull StartParameter startParameter,
             boolean isRootProject, @NotNull String projectPath, @NotNull String taskName,
             @NotNull String description, @NotNull String taskSuffix) {
@@ -354,6 +369,9 @@ public class V2JpiPlugin implements Plugin<Project> {
                 task.getSuccessMarker().set(project.getLayout().getBuildDirectory().file("test-server/" + taskName + ".success"));
                 task.getPortAllocationService().set(portAllocationService);
                 task.usesService(portAllocationService);
+                // Bounds concurrent Jenkins launches across the whole build (see JenkinsLaunchThrottle).
+                task.usesService(launchThrottle);
+                task.getMaxParallelLaunches().set(maxParallelLaunches);
             }
         });
     }

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/JenkinsLaunchThrottleTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/JenkinsLaunchThrottleTest.java
@@ -1,0 +1,61 @@
+package org.jenkinsci.gradle.plugins.jpi2;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.jenkinsci.gradle.plugins.jpi2.JenkinsLaunchThrottle.resolveMaxParallelLaunches;
+
+class JenkinsLaunchThrottleTest {
+
+    @Test
+    void unsetValueDefaultsToProcessorsDividedByThree() {
+        assertThat(resolveMaxParallelLaunches(null, 10)).isEqualTo(3);
+        assertThat(resolveMaxParallelLaunches("", 10)).isEqualTo(3);
+        assertThat(resolveMaxParallelLaunches("   ", 12)).isEqualTo(4);
+    }
+
+    @Test
+    void absoluteValueIsUsedAsIs() {
+        assertThat(resolveMaxParallelLaunches("1", 10)).isEqualTo(1);
+        assertThat(resolveMaxParallelLaunches("4", 10)).isEqualTo(4);
+        // An absolute cap is independent of the core count.
+        assertThat(resolveMaxParallelLaunches("3", 64)).isEqualTo(3);
+    }
+
+    @Test
+    void processorRelativeValueScalesWithCoreCount() {
+        assertThat(resolveMaxParallelLaunches("C", 10)).isEqualTo(10);
+        assertThat(resolveMaxParallelLaunches("C/2", 10)).isEqualTo(5);
+        assertThat(resolveMaxParallelLaunches("C/3", 10)).isEqualTo(3);
+        assertThat(resolveMaxParallelLaunches("C/4", 10)).isEqualTo(2);
+        // The same C/3 setting yields a different, machine-appropriate cap elsewhere.
+        assertThat(resolveMaxParallelLaunches("C/3", 24)).isEqualTo(8);
+    }
+
+    @Test
+    void processorRelativeValueIsCaseAndWhitespaceInsensitive() {
+        assertThat(resolveMaxParallelLaunches("c/2", 10)).isEqualTo(5);
+        assertThat(resolveMaxParallelLaunches(" C / 2 ", 10)).isEqualTo(5);
+    }
+
+    @Test
+    void resultIsAlwaysAtLeastOne() {
+        // Integer division would give 0 on a small machine; the cap must stay runnable.
+        assertThat(resolveMaxParallelLaunches("C/4", 2)).isEqualTo(1);
+        assertThat(resolveMaxParallelLaunches(null, 2)).isEqualTo(1);
+        assertThat(resolveMaxParallelLaunches("0", 10)).isEqualTo(1);
+    }
+
+    @Test
+    void invalidValuesAreRejectedWithAnActionableMessage() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> resolveMaxParallelLaunches("C/0", 10))
+                .withMessageContaining("testServer.maxParallelLaunches")
+                .withMessageContaining("C/D");
+        assertThatIllegalArgumentException().isThrownBy(() -> resolveMaxParallelLaunches("-2", 10));
+        assertThatIllegalArgumentException().isThrownBy(() -> resolveMaxParallelLaunches("half", 10));
+        assertThatIllegalArgumentException().isThrownBy(() -> resolveMaxParallelLaunches("C/", 10));
+        assertThatIllegalArgumentException().isThrownBy(() -> resolveMaxParallelLaunches("3.5", 10));
+    }
+}

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/SimpleBuildIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/SimpleBuildIntegrationTest.java
@@ -142,6 +142,30 @@ class SimpleBuildIntegrationTest extends V2IntegrationTestBase {
 
     @Test
     @Timeout(value = 15, unit = TimeUnit.MINUTES)
+    void testServerRetriesThenReportsAnActionableTimeout() throws IOException {
+        // given
+        var ith = new IntegrationTestHelper(tempDir, "8.14");
+        configureSimpleBuildForVerification(ith);
+
+        // when — force a timeout far shorter than any real Jenkins boot so the timeout path is deterministic
+        var result = ith.gradleRunner()
+                .withArguments("testServer", "-DtestServer.timeoutSeconds=5", "-DtestServer.maxAttempts=2")
+                .buildAndFail();
+
+        // then — the transient timeout is retried before the task gives up...
+        assertThat(result.getOutput())
+                .contains("Jenkins did not start within 5s (attempt 1 of 2); retrying");
+        // ...and the final failure is actionable rather than a bare "exit code 143"
+        assertThat(result.getOutput())
+                .contains("Jenkins did not start within 5s and was terminated (exit code 143) after 2 attempts")
+                .contains("concurrent launches")
+                .contains("-DtestServer.maxParallelLaunches=N")
+                .contains("-DtestServer.timeoutSeconds=N")
+                .contains("-DtestServer.maxAttempts=N");
+    }
+
+    @Test
+    @Timeout(value = 15, unit = TimeUnit.MINUTES)
     void testServerIsCacheableAndInvalidatesOnSourceChange() throws IOException {
         assertVerificationTaskCachingBehavior("testServer");
     }


### PR DESCRIPTION
## Problem

`testServer` / `testHplRun` each spawn a nested Gradle build **plus** a full Jenkins JVM. In a multi-module build with a `testServer` per module, the default parallelism launches many at once, saturating the machine so Jenkins misses its startup timeout and is killed — surfacing as the cryptic `Jenkins failed to report a successful start (exit code 143)` (143 = SIGTERM from our own timeout kill). The only workaround was throttling the whole build with `--max-workers=N`.

## Change

- **Concurrency cap.** A shared `JenkinsLaunchThrottle` build service with `maxParallelUsages` caps how many launches run at once across the whole build, independent of `--max-workers`, so compilation/tests keep full parallelism.
- **Tunable, machine-independent default.** Defaults to one launch per three processors. Override with `-DtestServer.maxParallelLaunches`, which accepts an absolute count (`3`) or a processor-relative value (`C`, `C/2`, `C/4`) so one setting scales across machines.
- **Retry.** A launch that still times out is retried (`-DtestServer.maxAttempts`, default `2`); a deterministic startup crash still fails fast.
- **Actionable diagnostic.** The timeout failure now explains the cap and the tuning knobs instead of a bare exit code.

## Verification

- `JenkinsLaunchThrottleTest` unit-tests the `C`/`C/D`/absolute parsing, clamping, and invalid-input rejection.
- New integration test `testServerRetriesThenReportsAnActionableTimeout` forces a short timeout and asserts the retry log + actionable message end-to-end; existing success-path server test still passes.
- Config-only `--dry-run` across a 28-module consumer verified the service registration and `usesService` wiring configure cleanly at real scale.
- A concurrency sweep on that 28-module consumer (10-core host) measured the timeout onset: **0 timeouts at K≤6 concurrent boots, 100% timeouts at K≥8** — a sharp CPU-saturation cliff that confirms the `C/3` default (3 here) sits safely below it while `C/2` (5) would approach it.
