### PR TITLE
chore(ci): tune heap sizing to fix GHA runner failures

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ buildscript {
 }
 plugins {
     alias(libs.plugins.distribution.sha)
+    alias(libs.plugins.test.logger) apply false
 }
 
 allprojects {
@@ -31,5 +32,6 @@ subprojects {
                 languageVersion.set(JavaLanguageVersion.of(17))
             }
         }
+        apply(plugin = "com.adarshr.test-logger")
     }
 }

--- a/core/src/testFixtures/groovy/org/jenkinsci/gradle/plugins/jpi/IntegrationTestHelper.java
+++ b/core/src/testFixtures/groovy/org/jenkinsci/gradle/plugins/jpi/IntegrationTestHelper.java
@@ -34,6 +34,10 @@ public class IntegrationTestHelper {
         if (!existsRelativeToProjectDir("gradle.properties")) {
             var props = new Properties();
             props.setProperty("org.gradle.warning.mode", warningMode.name().toLowerCase(Locale.US));
+            props.setProperty("org.gradle.jvmargs", "-Xmx512m -XX:MaxMetaspaceSize=256m");
+            // Nested-build daemons otherwise idle for hours, piling up alongside the outer
+            // daemon and the spawned Jenkins process; let them exit quickly once each test finishes.
+            props.setProperty("org.gradle.daemon.idletimeout", "10000");
             try (var outputStream = new FileOutputStream(gradleProperties)) {
                 props.store(outputStream, "IntegrationSpec default generated values");
             }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.jvmargs=-Xmx2g
+org.gradle.jvmargs=-Xmx768m -XX:MaxMetaspaceSize=384m

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,3 +54,4 @@ xmlunit = { module = "org.xmlunit:xmlunit-core", version.ref = "xmlunit" }
 [plugins]
 distribution-sha = { id = "com.github.sghill.distribution-sha", version = "0.4.0" }
 plugin-publish = { id = "com.gradle.plugin-publish", version = "2.1.1" }
+test-logger = { id = "com.adarshr.test-logger", version = "4.0.0" }

--- a/jpi/build.gradle.kts
+++ b/jpi/build.gradle.kts
@@ -1,7 +1,6 @@
 import okio.buffer
 import okio.sink
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
-import org.gradle.api.tasks.testing.logging.TestLogEvent
 import java.nio.file.StandardOpenOption
 
 buildscript {
@@ -135,13 +134,9 @@ tasks.addRule("Pattern: testGradle<ID>") {
     }
 }
 
-val isCi = providers.environmentVariable("CI")
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
     testLogging {
-        if (isCi.map { it.toBoolean() }.getOrElse(false)) {
-            events(TestLogEvent.FAILED, TestLogEvent.PASSED, TestLogEvent.SKIPPED)
-        }
         exceptionFormat = FULL
     }
 }

--- a/jpi2/build.gradle.kts
+++ b/jpi2/build.gradle.kts
@@ -34,6 +34,9 @@ tasks.withType<Test>().configureEach {
     testLogging {
         exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
     }
+    // This JVM mostly waits on nested Gradle/Jenkins processes rather than doing heap-heavy
+    // work itself; capping it leaves more headroom for those nested processes.
+    maxHeapSize = "512m"
 }
 
 publishing {

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/V2IntegrationTestBase.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/V2IntegrationTestBase.java
@@ -67,9 +67,11 @@ abstract class V2IntegrationTestBase {
                 }
                 tasks.named<JavaExec>("server") {
                     args("--httpPort=%d")
+                    maxHeapSize = "512m"
                 }
                 tasks.named<JavaExec>("hplRun") {
                     args("--httpPort=%d")
+                    maxHeapSize = "512m"
                 }
                 tasks.withType(Test::class) {
                     useJUnitPlatform()
@@ -92,9 +94,11 @@ abstract class V2IntegrationTestBase {
                 }
                 tasks.named<JavaExec>("server") {
                     args("--httpPort=%d")
+                    maxHeapSize = "512m"
                 }
                 tasks.named<JavaExec>("hplRun") {
                     args("--httpPort=%d")
+                    maxHeapSize = "512m"
                 }
                 tasks.withType(Test::class) {
                     useJUnitPlatform()


### PR DESCRIPTION
Reduce max heap sizing across the nested JVM chain used by jpi2 integration tests.

## Root cause

GHA jobs were failing with "The runner has received a shutdown signal" / "The operation was canceled", with orphaned java processes killed during cleanup. This looked like a test hang, but it's actually memory exhaustion.

Each `jpi2` integration test spawns a deep chain of nested JVMs:

```
Gradle Frontend (build)
  -> Gradle Daemon (build)
    -> JUnit
      -> Gradle Frontend (testServer)
        -> Gradle Daemon (testServer)
          -> Gradle Frontend (server)
            -> Gradle Daemon (server)
              -> Jenkins
```

With unconstrained/default heap sizing at every level, enough of these are alive concurrently to exhaust the GHA-hosted runner's memory. That triggers an infra-level kill of the whole job rather than a genuine test-level hang.

## Fix

Cap heap at each level of the chain, instead of relying on one global knob:

- outer build's Gradle daemon, down to `-Xmx768m -XX:MaxMetaspaceSize=384m` (root `gradle.properties`)
- first level of nested TestKit-driven Gradle daemons, capped at `-Xmx512m -XX:MaxMetaspaceSize=256m`, and shorten their idle timeout so they don't linger for hours alongside the outer daemon and the spawned Jenkins process (`IntegrationTestHelper`)
- the `:jpi2:test` JUnit JVM itself, capped at 512m (`jpi2/build.gradle.kts`)
- the `server`/`hplRun` `JavaExec` tasks generated by this repo's own test fixtures, capped at 512m (`V2IntegrationTestBase`)

The last point is deliberately scoped to our test fixtures only, **not** the plugin's public `server`/`hplRun` task defaults — lowering the shared default would silently change behavior for every downstream consumer of `org.jenkins-ci.jpi` / `org.jenkins-ci.jpi2` and force them to tune it themselves. Confirmed `jpi`'s `JenkinsServerTask` and `jpi2`'s `ServerAction` are separate implementations, and left both untouched.