### PR TITLE
test(windows): re-enable integration tests on Windows

### DIFF
--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/ServerAction.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/ServerAction.java
@@ -39,13 +39,14 @@ class ServerAction implements Action<JavaExec> {
         spec.getMainClass().set("executable.Main");
         spec.doFirst(task -> {
             var resolvedWorkDir = workDir.get();
+            var serverPort = task.getProject().findProperty("server.port");
             var args = new ArrayList<String>();
             args.addAll(List.of(
                     "--webroot=" + projectRoot + "/build/jenkins/war",
                     "--pluginroot=" + projectRoot + "/build/jenkins/plugins",
                     "--extractedFilesFolder=" + projectRoot + "/build/jenkins/extracted",
                     "--commonLibFolder=" + resolvedWorkDir + "/lib",
-                    "--httpPort=" + System.getProperty("server.port", "8080")
+                    "--httpPort=" + (serverPort != null ? serverPort : "8080")
             ));
             args.addAll(spec.getArgs());
             spec.setArgs(args);

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/TestServerTask.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/TestServerTask.java
@@ -195,10 +195,10 @@ public abstract class TestServerTask extends DefaultTask {
     public void runTestServer() {
         var timeoutSystemProperty = System.getProperty("testServer.timeoutSeconds", "120");
         var timeout = Integer.parseInt(timeoutSystemProperty);
-        Path workDir = null;
 
         clearSuccessMarker();
 
+        Path workDir = null;
         try {
             workDir = createWorkDirectory();
             var commandLine = getCommandLine(workDir);
@@ -211,7 +211,7 @@ public abstract class TestServerTask extends DefaultTask {
                     return;
                 }
                 getLogger().warn("Timeout reached, terminating Jenkins server");
-                process.destroy();
+                destroyTree(process);
             });
 
             timerThread.start();
@@ -260,17 +260,27 @@ public abstract class TestServerTask extends DefaultTask {
         return new ProcessBuilder(commandLine).directory(new File(getRootDir().get())).redirectErrorStream(true).start();
     }
 
+    /**
+     * {@link Process#destroy()} only terminates the launched process itself, not the forked
+     * JavaExec JVM it starts, so that JVM (and the Jenkins server port/files it holds) would
+     * otherwise keep running for the rest of the build.
+     */
+    private static void destroyTree(Process process) {
+        process.descendants().forEach(ProcessHandle::destroyForcibly);
+        process.destroy();
+    }
+
     private boolean isProcessSuccessful(BufferedReader stdoutReader, Process process) throws IOException, InterruptedException {
         String stdout;
 
         while ((stdout = stdoutReader.readLine()) != null) {
             getLogger().lifecycle("    {}", stdout);
             if (stdout.contains("Jenkins is fully up and running")) {
-                process.destroy();
+                destroyTree(process);
                 return true;
             }
             if (FAILURE_MESSAGES.stream().anyMatch(stdout::contains)) {
-                process.destroy();
+                destroyTree(process);
                 process.waitFor();
                 throw new GradleException("Jenkins failed to start: " + stdout);
             }
@@ -301,19 +311,20 @@ public abstract class TestServerTask extends DefaultTask {
     @NotNull
     private List<String> getCommandLine(@NotNull Path workDir) {
         List<String> commandLine = new ArrayList<>();
-        commandLine.add(getGradleExecutable().get());
-        commandLine.add("-Dorg.gradle.java.home=" + getJavaHome().get());
+        commandLine.add(slashify(getGradleExecutable().get()));
+        commandLine.add("-Dorg.gradle.java.home=" + slashify(getJavaHome().get()));
 
         for (var initScriptPath : getInitScriptPaths().get()) {
             commandLine.add("--init-script");
-            commandLine.add(initScriptPath);
+            commandLine.add(slashify(initScriptPath));
         }
 
         for (var includedBuild : getIncludedBuilds().get()) {
             commandLine.add("--include-build");
-            commandLine.add(includedBuild);
+            commandLine.add(slashify(includedBuild));
         }
 
+        commandLine.add("--no-daemon");
         if (getOffline().get()) commandLine.add("--offline");
         if (getBuildCacheEnabled().get()) commandLine.add("--build-cache");
         if (getRefreshDependencies().get()) commandLine.add("--refresh-dependencies");
@@ -325,19 +336,31 @@ public abstract class TestServerTask extends DefaultTask {
 
         getSystemProperties().get().forEach((k, v) -> {
             if (!k.equals(WorkDirectorySettings.PROPERTY)) {
-                commandLine.add("-D" + k + "=" + v);
+                commandLine.add("-D" + k + "=" + slashify(v));
             }
         });
         getProjectProperties().get().forEach((k, v) -> {
             if (!k.equals(WorkDirectorySettings.PROPERTY)) {
-                commandLine.add("-P" + k + "=" + v);
+                commandLine.add("-P" + k + "=" + slashify(v));
             }
         });
 
         commandLine.add(getServerTaskPath().get());
-        commandLine.add("-Dserver.port=" + getPortAllocationService().get().findAndReserveFreePort());
-        commandLine.add("-P" + WorkDirectorySettings.PROPERTY + "=" + workDir.toAbsolutePath());
+        commandLine.add("-Pserver.port=" + getPortAllocationService().get().findAndReserveFreePort());
+        commandLine.add("-P" + WorkDirectorySettings.PROPERTY + "=" + slashify(workDir.toAbsolutePath().toString()));
         getLogger().info("Command: {}", commandLine);
         return commandLine;
+    }
+
+    /**
+     * Backslashes in Windows paths get silently dropped somewhere between here and the spawned
+     * Gradle process reading its own arguments (observed even on values, like
+     * {@link #getGradleExecutable()}, that never pass through our own {@code -D}/{@code -P}
+     * parsing). Forward slashes are accepted in paths on Windows, so use those everywhere a
+     * path is placed on the spawned process's command line.
+     */
+    @NotNull
+    private static String slashify(@NotNull String value) {
+        return value.replace('\\', '/');
     }
 }

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
@@ -43,6 +43,7 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -267,7 +268,9 @@ public class V2JpiPlugin implements Plugin<Project> {
         var gradle = project.getGradle();
         var startParameter = gradle.getStartParameter();
         var gradleHome = gradle.getGradleHomeDir();
-        var gradleExecutable = gradleHome != null ? new File(gradleHome, "bin/gradle").getAbsolutePath() : "gradle";
+        var isWindows = System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("windows");
+        var gradleScriptName = isWindows ? "bin/gradle.bat" : "bin/gradle";
+        var gradleExecutable = gradleHome != null ? new File(gradleHome, gradleScriptName).getAbsolutePath() : "gradle";
         var isRootProject = project == project.getRootProject();
         var projectPath = project.getPath();
 

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/AccessModifierIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/AccessModifierIntegrationTest.java
@@ -3,15 +3,12 @@ package org.jenkinsci.gradle.plugins.jpi2;
 import java.nio.file.Files;
 import org.jenkinsci.gradle.plugins.jpi.IntegrationTestHelper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "TempDir doesn't appear to work correctly on Windows")
 class AccessModifierIntegrationTest extends V2IntegrationTestBase {
 
     @Test

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/ArchiveExtensionIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/ArchiveExtensionIntegrationTest.java
@@ -6,8 +6,6 @@ import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.jenkinsci.gradle.plugins.jpi.IntegrationTestHelper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import java.io.FileReader;
 import java.io.IOException;
@@ -15,7 +13,6 @@ import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "TempDir doesn't appear to work correctly on Windows")
 class ArchiveExtensionIntegrationTest extends V2IntegrationTestBase {
 
     @Test

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/CheckOverlappingSourcesIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/CheckOverlappingSourcesIntegrationTest.java
@@ -4,15 +4,12 @@ import java.nio.file.Files;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.jenkinsci.gradle.plugins.jpi.IntegrationTestHelper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "TempDir doesn't appear to work correctly on Windows")
 class CheckOverlappingSourcesIntegrationTest extends V2IntegrationTestBase {
 
     @Test

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/DependencyFilteringIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/DependencyFilteringIntegrationTest.java
@@ -3,8 +3,6 @@ package org.jenkinsci.gradle.plugins.jpi2;
 import java.nio.file.Files;
 import org.jenkinsci.gradle.plugins.jpi.IntegrationTestHelper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import java.io.File;
 import java.io.IOException;
@@ -12,7 +10,6 @@ import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "TempDir doesn't appear to work correctly on Windows")
 class DependencyFilteringIntegrationTest extends V2IntegrationTestBase {
 
     @Test

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/DependencyResolutionIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/DependencyResolutionIntegrationTest.java
@@ -6,8 +6,6 @@ import org.gradle.testkit.runner.GradleRunner;
 import org.jenkinsci.gradle.plugins.jpi.IntegrationTestHelper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -16,7 +14,6 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "TempDir doesn't appear to work correctly on Windows")
 class DependencyResolutionIntegrationTest extends V2IntegrationTestBase {
 
     @Test

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/IncludedBuildDependencyIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/IncludedBuildDependencyIntegrationTest.java
@@ -3,15 +3,12 @@ package org.jenkinsci.gradle.plugins.jpi2;
 import java.nio.file.Files;
 import org.jenkinsci.gradle.plugins.jpi.IntegrationTestHelper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "TempDir doesn't appear to work correctly on Windows")
 class IncludedBuildDependencyIntegrationTest extends V2IntegrationTestBase {
 
     @Test

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/LicenseInfoIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/LicenseInfoIntegrationTest.java
@@ -2,15 +2,12 @@ package org.jenkinsci.gradle.plugins.jpi2;
 
 import org.jenkinsci.gradle.plugins.jpi.IntegrationTestHelper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import java.io.IOException;
 import java.nio.file.Files;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "TempDir doesn't appear to work correctly on Windows")
 class LicenseInfoIntegrationTest extends V2IntegrationTestBase {
 
     @Test

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/LocalizationIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/LocalizationIntegrationTest.java
@@ -5,8 +5,6 @@ import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.jenkinsci.gradle.plugins.jpi.IntegrationTestHelper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -14,7 +12,6 @@ import java.util.jar.JarFile;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "TempDir doesn't appear to work correctly on Windows")
 class LocalizationIntegrationTest extends V2IntegrationTestBase {
 
     @Test

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/ManifestIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/ManifestIntegrationTest.java
@@ -9,8 +9,6 @@ import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.gradle.testkit.runner.GradleRunner;
 import org.jenkinsci.gradle.plugins.jpi.IntegrationTestHelper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import java.io.File;
 import java.io.FileReader;
@@ -21,7 +19,6 @@ import java.util.jar.Manifest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "TempDir doesn't appear to work correctly on Windows")
 class ManifestIntegrationTest extends V2IntegrationTestBase {
 
     @Test

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/MetadataIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/MetadataIntegrationTest.java
@@ -7,8 +7,6 @@ import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.jenkinsci.gradle.plugins.jpi.IntegrationTestHelper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import java.io.FileReader;
 import java.io.IOException;
@@ -17,7 +15,6 @@ import java.util.jar.Manifest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "TempDir doesn't appear to work correctly on Windows")
 class MetadataIntegrationTest extends V2IntegrationTestBase {
 
     private static final String FULL_METADATA_CONFIG = /* language=kotlin */ """

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/MultiModuleIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/MultiModuleIntegrationTest.java
@@ -10,8 +10,6 @@ import org.gradle.testkit.runner.TaskOutcome;
 import org.jenkinsci.gradle.plugins.jpi.IntegrationTestHelper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import java.io.File;
 import java.io.FileReader;
@@ -23,7 +21,6 @@ import java.util.jar.Manifest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "TempDir doesn't appear to work correctly on Windows")
 class MultiModuleIntegrationTest extends V2IntegrationTestBase {
 
     @Test

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/OssLibraryDependencyIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/OssLibraryDependencyIntegrationTest.java
@@ -3,8 +3,6 @@ package org.jenkinsci.gradle.plugins.jpi2;
 import org.gradle.testkit.runner.GradleRunner;
 import org.jenkinsci.gradle.plugins.jpi.IntegrationTestHelper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import java.io.File;
 import java.io.IOException;
@@ -12,7 +10,6 @@ import java.util.jar.Manifest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "TempDir doesn't appear to work correctly on Windows")
 class OssLibraryDependencyIntegrationTest extends V2IntegrationTestBase {
 
     @Test

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/OssPluginDependencyIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/OssPluginDependencyIntegrationTest.java
@@ -3,8 +3,6 @@ package org.jenkinsci.gradle.plugins.jpi2;
 import org.gradle.testkit.runner.GradleRunner;
 import org.jenkinsci.gradle.plugins.jpi.IntegrationTestHelper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import java.io.File;
 import java.io.IOException;
@@ -14,7 +12,6 @@ import java.util.jar.Manifest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "TempDir doesn't appear to work correctly on Windows")
 class OssPluginDependencyIntegrationTest extends V2IntegrationTestBase {
 
     @Test

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/PublishingIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/PublishingIntegrationTest.java
@@ -9,8 +9,6 @@ import org.assertj.core.groups.Tuple;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.jenkinsci.gradle.plugins.jpi.IntegrationTestHelper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import java.io.File;
 import java.io.FileReader;
@@ -19,7 +17,6 @@ import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "TempDir doesn't appear to work correctly on Windows")
 class PublishingIntegrationTest extends V2IntegrationTestBase {
 
     @Test

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/SimpleBuildIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/SimpleBuildIntegrationTest.java
@@ -5,8 +5,6 @@ import org.gradle.testkit.runner.TaskOutcome;
 import org.jenkinsci.gradle.plugins.jpi.IntegrationTestHelper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import java.io.File;
 import java.io.IOException;
@@ -18,7 +16,6 @@ import java.util.jar.Manifest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "TempDir doesn't appear to work correctly on Windows")
 class SimpleBuildIntegrationTest extends V2IntegrationTestBase {
 
     @Test

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/TestHarnessIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/TestHarnessIntegrationTest.java
@@ -4,8 +4,6 @@ import java.nio.file.Files;
 import org.gradle.testkit.runner.GradleRunner;
 import org.jenkinsci.gradle.plugins.jpi.IntegrationTestHelper;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -13,7 +11,6 @@ import java.util.jar.Manifest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "TempDir doesn't appear to work correctly on Windows")
 class TestHarnessIntegrationTest extends V2IntegrationTestBase {
 
     @Test

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/V2IntegrationTestBase.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/V2IntegrationTestBase.java
@@ -7,8 +7,6 @@ import org.gradle.testkit.runner.GradleRunner;
 import org.jenkinsci.gradle.plugins.jpi.IntegrationTestHelper;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.CleanupMode;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -33,7 +31,6 @@ import java.util.jar.JarOutputStream;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Timeout(value = 5, unit = TimeUnit.MINUTES)
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "TempDir doesn't appear to work correctly on Windows")
 abstract class V2IntegrationTestBase {
 
     @TempDir(cleanup = CleanupMode.NEVER)

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/VersionSourceIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/VersionSourceIntegrationTest.java
@@ -8,8 +8,6 @@ import org.gradle.testkit.runner.BuildResult;
 import org.jenkinsci.gradle.plugins.jpi.IntegrationTestHelper;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import java.io.File;
 import java.io.FileReader;
@@ -22,7 +20,6 @@ import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisabledOnOs(value = OS.WINDOWS, disabledReason = "TempDir doesn't appear to work correctly on Windows")
 class VersionSourceIntegrationTest extends V2IntegrationTestBase {
 
     private static final Pattern GIT_HASH = Pattern.compile("[a-f0-9]{40}");


### PR DESCRIPTION
## Summary
- Removes the wholesale `@DisabledOnOs(WINDOWS)` guards added in 37566d9 across all `jpi2` integration test classes.
- Those were added out of caution when the suite was split into per-scenario classes, citing "TempDir doesn't appear to work correctly on Windows," but they were just skipped, not failing, on `windows-latest`.
- Re-enabling surfaced three real Windows bugs, fixed here:
  - Backslashes silently dropped from Windows paths on the way into the nested testServer/testHplRun build's argument parsing — normalized to forward slashes.
  - The nested build's gradle executable was hardcoded to the POSIX `bin/gradle` script instead of `bin/gradle.bat` on Windows.
  - The nested build's Gradle Daemon (and the Jenkins/Winstone JVM it forks) outlived `Process.destroy()`, piling up live Jenkins servers across a test run and causing real port-bind races for later tests. Fixed by running the nested build with `--no-daemon` and destroying the full process descendant tree.