### PR TITLE
fix(jpi2): wire classpath for testGradle<ID> rule and pin reproducible archives

### DIFF
--- a/jpi2/build.gradle.kts
+++ b/jpi2/build.gradle.kts
@@ -103,21 +103,37 @@ gradlePlugin {
 
 fun Project.stringProp(named: String): String? = findProperty(named) as String?
 
-tasks.addRule("Pattern: testGradle<ID>") {
+val javaVersions = listOf(17)
+val umbrellaPattern = Regex("^testGradle([0-9]+(?:\\.[0-9]+)*)$")
+val perJavaPattern = Regex("^testGradle([0-9]+(?:\\.[0-9]+)*)onJava([0-9]+)$")
+
+fun Project.registerJavaSpecificTestGradleTask(gradleVersion: String, javaVersion: Int) =
+    tasks.register<Test>("testGradle${gradleVersion}onJava${javaVersion}") {
+        val testSourceSet = sourceSets.test.get()
+        testClassesDirs = testSourceSet.output.classesDirs
+        classpath = testSourceSet.runtimeClasspath
+        systemProperty("gradle.under.test", gradleVersion)
+        setTestNameIncludePatterns(listOf("*IntegrationTest"))
+        javaLauncher.set(javaToolchains.launcherFor {
+            languageVersion.set(JavaLanguageVersion.of(javaVersion))
+        })
+    }
+
+tasks.addRule("Pattern: testGradle<ID>[onJava<Version>]") {
     val taskName = this
-    if (!taskName.startsWith("testGradle")) return@addRule
-    val task = tasks.register(taskName)
-    for (javaVersion in listOf(17)) {
-        val javaSpecificTask = tasks.register<Test>("${taskName}onJava${javaVersion}") {
-            val gradleVersion = taskName.substringAfter("testGradle")
-            systemProperty("gradle.under.test", gradleVersion)
-            setTestNameIncludePatterns(listOf("*IntegrationTest"))
-            javaLauncher.set(javaToolchains.launcherFor {
-                languageVersion.set(JavaLanguageVersion.of(javaVersion))
-            })
-        }
-        task.configure {
-            dependsOn(javaSpecificTask)
+    perJavaPattern.matchEntire(taskName)?.let { match ->
+        val (gradleVersion, javaVersion) = match.destructured
+        registerJavaSpecificTestGradleTask(gradleVersion, javaVersion.toInt())
+        return@addRule
+    }
+    umbrellaPattern.matchEntire(taskName)?.let { match ->
+        val gradleVersion = match.groupValues[1]
+        val task = tasks.register(taskName)
+        for (javaVersion in javaVersions) {
+            val javaSpecificTask = registerJavaSpecificTestGradleTask(gradleVersion, javaVersion)
+            task.configure {
+                dependsOn(javaSpecificTask)
+            }
         }
     }
 }

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
@@ -158,6 +158,11 @@ public class V2JpiPlugin implements Plugin<Project> {
                 war.getManifest().from(optionalManifestFile);
                 war.getWebInf().from(licenseTask.flatMap(GenerateLicenseInfoTask::getOutputDirectory));
                 war.getArchiveVersion().set(extension.getEffectiveVersion());
+                // Gradle's own default for these flipped between the 8.x and 9.x lines; pin them so the
+                // archive's bytes (and therefore testServer's build-cache key, which fingerprints this
+                // file) don't depend on which Gradle version is running.
+                war.setPreserveFileTimestamps(false);
+                war.setReproducibleFileOrder(true);
             }
         });
         project.getTasks().named("jar", Jar.class).configure(new Action<>() {
@@ -166,6 +171,8 @@ public class V2JpiPlugin implements Plugin<Project> {
                 jarTask.manifest(new ManifestAction(project, defaultRuntime, extension));
                 jarTask.getInputs().file(optionalManifestFile);
                 jarTask.getManifest().from(optionalManifestFile);
+                jarTask.setPreserveFileTimestamps(false);
+                jarTask.setReproducibleFileOrder(true);
             }
         });
         Provider<Directory> jpiDirectory = project.getLayout().getBuildDirectory().dir("jpi");


### PR DESCRIPTION
## Summary
- The custom `Test` tasks created by the `testGradle<ID>` task rule in `jpi2/build.gradle.kts` never had `testClassesDirs`/`classpath` set, so every `testGradle<ID>onJava<N>` task ran as `NO-SOURCE` and silently executed zero integration tests.
- Wired those tasks to use the `test` source set's `output.classesDirs`/`runtimeClasspath`, matching how the default `test` task is configured.
- Anchored the rule's name matching (separate regexes for the umbrella `testGradle<ID>` name vs the generated `testGradle<ID>onJava<N>` name) so invoking the generated task directly doesn't re-trigger the rule and shadow it with an untyped `DefaultTask`. That shadowing previously made `--tests` filtering unusable on these tasks.
- With `--tests` filtering working, root-caused and fixed `testServerIsCacheableAndInvalidatesOnSourceChange` failing only under Gradle 8.14.3 (it passed on 9.2.1). Gradle's `AbstractArchiveTask` defaults for `preserveFileTimestamps`/`reproducibleFileOrder` flipped between the 8.x and 9.x lines, so a clean rebuild under 8.14.3 produces a byte-different `.jpi`/`jar` archive even with unchanged sources. `testServer`'s cache key fingerprints that archive's bytes directly (via `prepareServer`'s `sync.from(jpi)`), so the non-reproducible timestamps busted the cache. `testHplRun` was unaffected because its `prepareRun` source only includes the generated `.hpl` manifest, with class files/resources fingerprinted separately by content hash. Pinned `preserveFileTimestamps(false)` and `reproducibleFileOrder(true)` on both `jar` and `jpi` (`War`) so archive bytes are stable regardless of which Gradle version builds them.

Verified locally: `./gradlew :jpi2:testGradle9.2.1 --rerun` now actually executes all 85 integration tests (previously NO-SOURCE) and they pass. Also verified `SimpleBuildIntegrationTest` passes in full under both `testGradle8.14.3onJava17` and `testGradle9.2.1onJava17`, including `testServerIsCacheableAndInvalidatesOnSourceChange`.

Note: `jpi/build.gradle.kts` has the identical `testGradle<ID>` rule with the same classpath gap, not addressed here.