### PR TITLE
chore: Remove double testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         cache: "gradle"
     - uses: gradle/actions/setup-gradle@v6
     - name: Build
-      run: ./gradlew clean build testGradle8.4
+      run: ./gradlew clean build
     - name: Archive Codenarc Report on Failure
       uses: actions/upload-artifact@v7
       if: ${{ failure() }}


### PR DESCRIPTION
We were running this on CI

```
./gradlew clean build testGradle8.4
```

For a long time, the taskRule was not doing what it was supposed to do so the only tests running were from the `test` task.

Once I fixed the taskRule, we started running tests twice, which makes CI take a very long time.

We already test with gradle 8.14 in `regression.yml`. So this is redundant.
