### PR TITLE
fix(jpi2): disambiguate artifact type attribute for third-party consumers

### DIFF
--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/ArtifactTypeDisambiguationRule.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/ArtifactTypeDisambiguationRule.java
@@ -1,0 +1,32 @@
+package org.jenkinsci.gradle.plugins.jpi2;
+
+import org.gradle.api.attributes.AttributeDisambiguationRule;
+import org.gradle.api.attributes.MultipleCandidatesDetails;
+import org.jetbrains.annotations.NotNull;
+
+import javax.inject.Inject;
+
+/**
+ * Third-party plugins (e.g. {@code pmd}) resolve their own configurations over hpi/jpi-packaged
+ * dependencies without requesting {@link ArtifactType#ARTIFACT_TYPE_ATTRIBUTE}, which otherwise
+ * leaves {@link HpiMetadataRule}'s "runtime" and "defaultRuntime" variants ambiguous. When no
+ * value is requested, prefer the plain jar variant, matching what jenkinsPlugin-owned
+ * configurations already request explicitly.
+ */
+abstract class ArtifactTypeDisambiguationRule implements AttributeDisambiguationRule<ArtifactType> {
+
+    @Inject
+    public ArtifactTypeDisambiguationRule() {
+    }
+
+    @Override
+    public void execute(@NotNull MultipleCandidatesDetails<ArtifactType> details) {
+        if (details.getConsumerValue() != null) {
+            return;
+        }
+        details.getCandidateValues().stream()
+                .filter(candidate -> ArtifactType.PLUGIN_JAR.equals(candidate.getName()))
+                .findFirst()
+                .ifPresent(details::closestMatch);
+    }
+}

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
@@ -245,6 +245,7 @@ public class V2JpiPlugin implements Plugin<Project> {
         dependencies.add(jenkinsCore.getName(), jenkinsCoreCoordinate);
 
         dependencies.getComponents().all(HpiMetadataRule.class);
+        dependencies.getAttributesSchema().attribute(ARTIFACT_TYPE_ATTRIBUTE).getDisambiguationRules().add(ArtifactTypeDisambiguationRule.class);
         var publicationName = configurePublishing(project, jpiTask, defaultRuntime, extension);
 
         var publishing = project.getExtensions().getByType(PublishingExtension.class);

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/PmdInteroperabilityIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/PmdInteroperabilityIntegrationTest.java
@@ -1,0 +1,68 @@
+package org.jenkinsci.gradle.plugins.jpi2;
+
+import org.jenkinsci.gradle.plugins.jpi.IntegrationTestHelper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "TempDir doesn't appear to work correctly on Windows")
+class PmdInteroperabilityIntegrationTest extends V2IntegrationTestBase {
+
+    /**
+     * HpiMetadataRule adds a "defaultRuntime" variant (attributed {@code ArtifactType.DEFAULT})
+     * alongside the existing "runtime" variant (attributed {@code ArtifactType.PLUGIN_JAR}) to
+     * every hpi/jpi-packaged dependency. Configurations the plugin controls (runtimeClasspath,
+     * testRuntimeClasspath) request {@code ArtifactType.PLUGIN_JAR} explicitly to disambiguate,
+     * but the `pmd` plugin resolves its own aux classpath configuration, which never requests
+     * that attribute. ArtifactTypeDisambiguationRule resolves the ambiguity for such consumers
+     * by defaulting to the plain jar variant when nothing is requested.
+     */
+    @Test
+    void pmdTestResolvesAuxClasspathForJpiPluginDependency() throws IOException {
+        // given
+        var ith = new IntegrationTestHelper(tempDir, "8.14");
+        initBuild(ith);
+        Files.writeString(ith.inProjectDir("build.gradle.kts").toPath(), """
+                plugins {
+                    id("org.jenkins-ci.jpi2")
+                    pmd
+                }
+                repositories {
+                    mavenCentral()
+                    jenkinsPublic()
+                }
+                tasks.withType(Test::class) {
+                    useJUnitPlatform()
+                }
+                group = "com.example"
+                version = "1.0.0"
+                dependencies {
+                    testImplementation("org.jenkins-ci.plugins:git:5.7.0")
+                    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+                    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+                }
+                """, StandardCharsets.UTF_8);
+        ith.mkDirInProjectDir("src/test/java/com/example");
+        Files.writeString(ith.inProjectDir("src/test/java/com/example/ExampleTest.java").toPath(), """
+                package com.example;
+                import org.junit.jupiter.api.Test;
+                class ExampleTest {
+                    @Test
+                    void example() {
+                    }
+                }
+                """, StandardCharsets.UTF_8);
+
+        // when
+        var result = ith.gradleRunner().withArguments("pmdTest").build();
+
+        // then
+        assertThat(result.getOutput()).contains("BUILD SUCCESSFUL");
+    }
+}


### PR DESCRIPTION
## Summary
- `HpiMetadataRule` adds a "defaultRuntime" variant to every hpi/jpi-packaged dependency, distinguished from the existing "runtime" variant only by the plugin's own `org.jenkinsci.gradle.plugins.jpi2.artifact.type` attribute.
- Configurations the jpi2 plugin owns (`runtimeClasspath`, `testRuntimeClasspath`, `defaultRuntime`) request that attribute explicitly, but third-party plugins (e.g. `pmd`) resolve their own configurations (`testPmdAuxClasspath`, etc.) without requesting it, so Gradle can't pick a variant and resolution fails with an ambiguity error.
- Registers an `AttributeDisambiguationRule` on the attribute that defaults to the plain jar variant when no value is requested, so unrelated consumers resolve cleanly.
- Adds `PmdInteroperabilityIntegrationTest`, which applies `pmd` alongside `jpi2`, adds a jpi-packaged dependency, and asserts `pmdTest` now resolves and runs successfully.
- Verified against the real-world reproduction at https://github.com/mtughan/jpi-plugin-tests/tree/pmd via `./gradlew --include-build <this repo> clean check`, which now passes.

Fixes: #418