### PR TITLE
fix: defer Plugin-Dependencies manifest resolution to task execution

### DIFF
--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/ConfigureJpiAction.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/ConfigureJpiAction.java
@@ -2,6 +2,7 @@ package org.jenkinsci.gradle.plugins.jpi2;
 
 import org.gradle.api.Action;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.tasks.bundling.War;
@@ -29,7 +30,23 @@ class ConfigureJpiAction implements Action<War> {
     @Override
     public void execute(@NotNull War jpi) {
         jpi.getArchiveExtension().set(extension.getArchiveExtension());
-        jpi.manifest(new ManifestAction(project, configuration, extension));
+        jpi.manifest(new ManifestAction(project, extension));
+
+        // Resolving `configuration` must wait until the jpi task actually executes: some publishing
+        // plugins (e.g. com.jfrog.artifactory) realize this task from a gradle.projectsEvaluated
+        // listener, before projects are configured and before Gradle's exclusive project-execution
+        // lock is available, and an eager resolution there is rejected as unsafe.
+        var pluginDependencies = project.provider(() -> V2JpiPlugin.resolvePluginDependencies(configuration));
+        jpi.getInputs().property("pluginDependencies", pluginDependencies).optional(true);
+        jpi.doFirst(new Action<>() {
+            @Override
+            public void execute(@NotNull Task task) {
+                var value = pluginDependencies.getOrNull();
+                if (value != null) {
+                    jpi.getManifest().getAttributes().put("Plugin-Dependencies", value);
+                }
+            }
+        });
         jpi.from(project.getTasks().named("jar"), new Action<>() {
             @Override
             public void execute(@NotNull CopySpec copySpec) {

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/ManifestAction.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/ManifestAction.java
@@ -2,28 +2,25 @@ package org.jenkinsci.gradle.plugins.jpi2;
 
 import org.gradle.api.Action;
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.internal.artifacts.result.DefaultResolvedDependencyResult;
 import org.gradle.api.java.archives.Manifest;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
- * Action to update the JAR manifest with plugin dependencies and other attributes required in a Jenkins Plugin.
+ * Action to update the JAR manifest with attributes required in a Jenkins Plugin, except for
+ * {@code Plugin-Dependencies}, which requires resolving a configuration and is set separately at task
+ * execution time (see {@link V2JpiPlugin}).
  */
 class ManifestAction implements Action<Manifest> {
     public static final int DEFAULT_MINIMUM_JAVA_VERSION = 17;
     private final Project project;
-    private final Configuration configuration;
     private final JenkinsPluginExtension extension;
 
-    public ManifestAction(Project project, Configuration configuration, JenkinsPluginExtension extension) {
+    public ManifestAction(Project project, JenkinsPluginExtension extension) {
         this.project = project;
-        this.configuration = configuration;
         this.extension = extension;
     }
 
@@ -33,23 +30,6 @@ class ManifestAction implements Action<Manifest> {
         var version = extension.getEffectiveVersion().get();
         attributes.put("Implementation-Title", project.getGroup() + "#" + project.getName() + ";" + version);
         attributes.put("Implementation-Version", version);
-
-        var rootDependencies = configuration.getIncoming().getResolutionResult().getRoot().getDependencies();
-
-        var pluginDependencies = rootDependencies
-                .stream()
-                .filter(it -> !it.isConstraint())
-                .filter(it -> it instanceof DefaultResolvedDependencyResult)
-                .map(it -> ((DefaultResolvedDependencyResult) it))
-                .filter(it -> it.getResolvedVariant().getDisplayName().equals(HpiMetadataRule.DEFAULT_RUNTIME_VARIANT))
-                .map(it -> it.getSelected().getModuleVersion())
-                .filter(Objects::nonNull)
-                .map(it -> it.getName() + ":" + it.getVersion())
-                .toList();
-
-        if (!pluginDependencies.isEmpty()) {
-            attributes.put("Plugin-Dependencies", String.join(",", pluginDependencies));
-        }
         attributes.put("Plugin-Version", version);
         attributes.put("Short-Name", extension.getPluginId().get());
         attributes.put("Extension-Name", extension.getPluginId().get());

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
@@ -11,6 +11,7 @@ import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.Directory;
+import org.gradle.api.internal.artifacts.result.DefaultResolvedDependencyResult;
 import org.gradle.api.plugins.BasePlugin;
 import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.plugins.GroovyBasePlugin;
@@ -34,6 +35,7 @@ import org.jenkinsci.gradle.plugins.jpi2.localization.LocalizationPlugin;
 import org.jenkinsci.gradle.plugins.jpi2.accmod.CheckAccessModifierTask;
 import org.jenkinsci.gradle.plugins.jpi2.accmod.PrefixedPropertiesProvider;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,6 +47,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -169,11 +172,27 @@ public class V2JpiPlugin implements Plugin<Project> {
         project.getTasks().named("jar", Jar.class).configure(new Action<>() {
             @Override
             public void execute(@NotNull Jar jarTask) {
-                jarTask.manifest(new ManifestAction(project, defaultRuntime, extension));
+                jarTask.manifest(new ManifestAction(project, extension));
                 jarTask.getInputs().file(optionalManifestFile);
                 jarTask.getManifest().from(optionalManifestFile);
                 jarTask.setPreserveFileTimestamps(false);
                 jarTask.setReproducibleFileOrder(true);
+
+                // Resolving defaultRuntime must wait until the jar task actually executes: some publishing
+                // plugins (e.g. com.jfrog.artifactory) realize this task from a gradle.projectsEvaluated
+                // listener, before projects are configured and before Gradle's exclusive project-execution
+                // lock is available, and an eager resolution there is rejected as unsafe.
+                var pluginDependencies = project.provider(() -> resolvePluginDependencies(defaultRuntime));
+                jarTask.getInputs().property("pluginDependencies", pluginDependencies).optional(true);
+                jarTask.doFirst(new Action<>() {
+                    @Override
+                    public void execute(@NotNull Task task) {
+                        var value = pluginDependencies.getOrNull();
+                        if (value != null) {
+                            jarTask.getManifest().getAttributes().put("Plugin-Dependencies", value);
+                        }
+                    }
+                });
             }
         });
         Provider<Directory> jpiDirectory = project.getLayout().getBuildDirectory().dir("jpi");
@@ -622,6 +641,24 @@ public class V2JpiPlugin implements Plugin<Project> {
     private static String getVersionFromProperties(@NotNull Project project, String propertyName, String defaultVersion) {
         Provider<String> myProperty = project.getProviders().gradleProperty(propertyName);
         return myProperty.getOrElse(defaultVersion);
+    }
+
+    @Nullable
+    static String resolvePluginDependencies(@NotNull Configuration defaultRuntime) {
+        var rootDependencies = defaultRuntime.getIncoming().getResolutionResult().getRoot().getDependencies();
+
+        var pluginDependencies = rootDependencies
+                .stream()
+                .filter(it -> !it.isConstraint())
+                .filter(it -> it instanceof DefaultResolvedDependencyResult)
+                .map(it -> ((DefaultResolvedDependencyResult) it))
+                .filter(it -> it.getResolvedVariant().getDisplayName().equals(HpiMetadataRule.DEFAULT_RUNTIME_VARIANT))
+                .map(it -> it.getSelected().getModuleVersion())
+                .filter(Objects::nonNull)
+                .map(it -> it.getName() + ":" + it.getVersion())
+                .toList();
+
+        return pluginDependencies.isEmpty() ? null : String.join(",", pluginDependencies);
     }
 
 }

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/ManifestIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/ManifestIntegrationTest.java
@@ -18,6 +18,7 @@ import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 class ManifestIntegrationTest extends V2IntegrationTestBase {
 
@@ -188,6 +189,22 @@ class ManifestIntegrationTest extends V2IntegrationTestBase {
         ith.gradleRunner().withArguments("build").build();
 
         assertThat(manifestAttributes(ith).getValue("Support-Dynamic-Loading")).isEqualTo("false");
+    }
+
+    @Test
+    void manifestCanBeComputedWhenPublicationArtifactsAreAccessedFromProjectsEvaluated() throws IOException {
+        // Publishing plugins such as com.jfrog.artifactory inspect every maven publication's
+        // artifacts from a gradle.projectsEvaluated listener, which realizes the jar task (and its
+        // manifest) outside of the per-project configuration lock that plain afterEvaluate holds.
+        var ith = new IntegrationTestHelper(tempDir, "8.14");
+        initBuild(ith);
+        Files.write(ith.inProjectDir("build.gradle.kts").toPath(), (getBasePluginConfig() + /* language=kotlin */ """
+                gradle.projectsEvaluated {
+                    (publishing.publications["mavenJpi"] as MavenPublication).artifacts.forEach { }
+                }
+                """).getBytes(StandardCharsets.UTF_8));
+
+        assertThatCode(() -> ith.gradleRunner().withArguments("help").build()).doesNotThrowAnyException();
     }
 
     private static Attributes manifestAttributes(IntegrationTestHelper ith) throws IOException {


### PR DESCRIPTION
## Summary

- Fix a build failure (`Resolution of the configuration ':defaultRuntime' was attempted without an exclusive lock`) that occurs when Gradle 9.x is used with the Artifactory Gradle plugin (`com.jfrog.artifactory`).
- `ManifestAction` used to resolve the `defaultRuntime` configuration eagerly while computing the `Plugin-Dependencies` manifest attribute. That action runs immediately when `Jar.manifest(Action)`/`War.manifest(Action)` is invoked, i.e. whenever the `jar`/`jpi` task is realized. Publishing plugins like Artifactory realize these tasks from a `gradle.projectsEvaluated` listener while inspecting Maven publication artifacts — a point in Gradle's lifecycle before the exclusive project-execution lock is available — so the eager resolution is rejected as unsafe.
- The `Plugin-Dependencies` computation is now deferred to a `doFirst` on the `jar`/`jpi` tasks, guarded by a lazy `Provider` that is also registered as a task input (so build-cache/up-to-date checks still see it). This defers the actual configuration resolution to real task execution time, when Gradle's exclusive lock is safely held.

## Verification

- Added `ManifestIntegrationTest.manifestCanBeComputedWhenPublicationArtifactsAreAccessedFromProjectsEvaluated`, which registers a `gradle.projectsEvaluated` listener that accesses the `mavenJpi` publication's artifacts, reproducing the exact failure reported in #417 (it fails without this fix and passes with it).
- Ran the full `jpi2` test suite (86 tests) — all passing, including the tests that assert `Plugin-Dependencies` content in built/published artifacts.
- Verified against a minimal reproduction project using `org.jenkins-ci.jpi2` + `com.jfrog.artifactory` and `./gradlew check`: fails on `main`, succeeds with this fix applied (via `mavenLocal()`).

Fixes: #417
