### PR TITLE
fix: resolve implicit-dependency validation failures on testServer/testHplRun

### DIFF
--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
@@ -302,14 +302,18 @@ public class V2JpiPlugin implements Plugin<Project> {
         // to workDir/plugins, so snapshotting the destination would create an implicit dependency
         // between the two test tasks.
         testServerTask.configure(task -> {
-            task.getPluginFiles().from(prepareServer.map(Sync::getSource));
+            var pluginSourceFiles = prepareServer.map(Sync::getSource);
+            task.getPluginFiles().from(pluginSourceFiles);
+            task.mustRunAfter(pluginSourceFiles);
             task.getJenkinsClasspath().from(serverTaskClasspath);
         });
 
         var testHplRunTask = registerTestTask(project, portAllocationService, launchThrottle, maxParallelLaunches, gradleExecutable, startParameter, isRootProject, projectPath,
                 "testHplRun", "Launch Jenkins hplRun task and terminate after success or first error", ":hplRun");
         testHplRunTask.configure(task -> {
-            task.getPluginFiles().from(prepareRun.map(Sync::getSource));
+            var runSourceFiles = prepareRun.map(Sync::getSource);
+            task.getPluginFiles().from(runSourceFiles);
+            task.mustRunAfter(runSourceFiles);
             task.getJenkinsClasspath().from(serverTaskClasspath);
             // The .hpl manifest points at these directories on disk by absolute path; their
             // contents must be fingerprinted for caching to be correct, even though only the

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/MultiModuleIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/MultiModuleIntegrationTest.java
@@ -97,6 +97,18 @@ class MultiModuleIntegrationTest extends V2IntegrationTestBase {
 
     @Test
     @Timeout(value = 15, unit = TimeUnit.MINUTES)
+    void testServerAcrossPluginDependencyHasNoImplicitDependencyWarning() throws IOException {
+        var ith = new IntegrationTestHelper(tempDir, "8.14");
+        configureTwoPluginsForVerification(ith);
+
+        var result = ith.gradleRunner().withArguments(":downstream:testServer", "--build-cache").build();
+
+        assertThat(result.task(":downstream:testServer").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(result.getOutput()).doesNotContainIgnoringCase("implicit dependency");
+    }
+
+    @Test
+    @Timeout(value = 15, unit = TimeUnit.MINUTES)
     void testHplRunInvalidatesOnUpstreamModuleSourceChange() throws IOException {
         var ith = new IntegrationTestHelper(tempDir, "8.14");
         configureTwoPluginsForVerification(ith);
@@ -107,6 +119,7 @@ class MultiModuleIntegrationTest extends V2IntegrationTestBase {
         var first = runner.withArguments(":downstream:testHplRun", "--build-cache").build();
         assertThat(first.task(taskPath).getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
         assertThat(first.getOutput()).contains("Jenkins is fully up and running");
+        assertThat(first.getOutput()).doesNotContainIgnoringCase("implicit dependency");
 
         var noChange = runner.withArguments(":downstream:testHplRun", "--build-cache").build();
         assertThat(noChange.task(taskPath).getOutcome())


### PR DESCRIPTION
## Summary
- `testServer`/`testHplRun` fingerprint `prepareServer`/`prepareRun`'s source via `Provider#map()`, which only carries the build dependency of the mapped task itself, not producer tasks of files nested inside the mapped value (e.g. another project's `jpi` output). Added `mustRunAfter` on those source providers to make the dependency explicit.
- `buildConfigFiles`'s fileTree is rooted at the whole multi-project directory to catch shared build-logic changes. That meant any sibling project's task output nested under that root was flagged as an implicit dependency by Gradle's task validation, even though none of the included patterns ever match files written there. Excluding `build`/`.gradle` removes the false positives.

`mustRunAfter` is load-bearing, not redundant with the existing `@InputFiles` registration on `getPluginFiles()`. For a single-level cross-project dependency, `getPluginFiles().from(...)` alone is enough for Gradle to infer the dependency and no warning appears without `mustRunAfter`. But with a deeper chain of cross-project plugin dependencies (plugin C depends on plugin B, which depends on plugin A), Gradle still flags "implicit dependency" without it — confirmed by re-running the verification below with `mustRunAfter` removed and seeing the warning reappear.

Reproduced and verified against a real multi-project consumer build (26+ Jenkins plugin projects, several with cross-project dependencies) where `./gradlew testServer` previously failed with dozens of "implicit dependency" validation errors across nearly every project; it now completes with `BUILD SUCCESSFUL` and launches/terminates a real Jenkins server for every project.

Added `MultiModuleIntegrationTest#testServerAcrossPluginDependencyHasNoImplicitDependencyWarning` and an assertion in `testHplRunInvalidatesOnUpstreamModuleSourceChange` covering the single-level case as a regression guard. The deeper chain that actually requires `mustRunAfter` isn't covered by an in-repo test — only by the external multi-project consumer build above.

## Verification
- [x] `./gradlew :jpi2:compileJava`
- [x] `./gradlew :jpi2:test --tests "org.jenkinsci.gradle.plugins.jpi2.MultiModuleIntegrationTest" --tests "org.jenkinsci.gradle.plugins.jpi2.SimpleBuildIntegrationTest"`
- [x] Ran `./gradlew testServer --max-workers=3` in a large external multi-project consumer repo (via `--include-build`) — confirmed zero implicit-dependency validation warnings and a full successful build with every `testServer` task launching and terminating a real Jenkins instance. Re-ran with `mustRunAfter` removed to confirm the warnings reappear on the deeper cross-project dependency chains, ruling out that it's dead code.
