### PR TITLE
fix: remove no-op Configuration.setVisible() calls

### DIFF
--- a/jpi/src/main/java/org/jenkinsci/gradle/plugins/jpi/UnsupportedGradleConfigurationVerifier.java
+++ b/jpi/src/main/java/org/jenkinsci/gradle/plugins/jpi/UnsupportedGradleConfigurationVerifier.java
@@ -44,7 +44,6 @@ public class UnsupportedGradleConfigurationVerifier {
         project.getConfigurations().create(confName, new Action<Configuration>() {
             @Override
             public void execute(Configuration conf) {
-                conf.setVisible(false);
                 conf.getIncoming().beforeResolve(new Action<ResolvableDependencies>() {
                     @Override
                     public void execute(ResolvableDependencies resolvable) {

--- a/jpi/src/main/java/org/jenkinsci/gradle/plugins/jpi/localization/LocalizationPlugin.java
+++ b/jpi/src/main/java/org/jenkinsci/gradle/plugins/jpi/localization/LocalizationPlugin.java
@@ -38,7 +38,6 @@ public class LocalizationPlugin implements Plugin<Project> {
         Dependency localizer = target.getDependencies().create("org.jvnet.localizer:localizer-maven-plugin:1.31");
         Configuration localizeMessagesRuntimeClasspath = target.getConfigurations().create(CONFIGURATION_NAME, c -> {
             c.attributes(container -> container.attribute(USAGE_ATTRIBUTE, objects.named(Usage.class, JAVA_RUNTIME)));
-            c.setVisible(false);
             c.setCanBeConsumed(false);
             c.setCanBeResolved(true);
             c.withDependencies(dependencies -> dependencies.add(localizer));

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
@@ -234,7 +234,6 @@ public class V2JpiPlugin implements Plugin<Project> {
          * If other annotation processors contribute methods/controllers that sezpoz expects, this will ensure it happens.
          */
         var lastAnnotationProcessor = project.getConfigurations().create("lastAnnotationProcessor");
-        lastAnnotationProcessor.setVisible(false);
         project.getDependencies().add("lastAnnotationProcessor", "net.java.sezpoz:sezpoz:1.13");
         project.getDependencies().add("lastAnnotationProcessor", jenkinsCoreCoordinate);
         project.getConfigurations().getByName("annotationProcessor").extendsFrom(lastAnnotationProcessor);
@@ -381,7 +380,6 @@ public class V2JpiPlugin implements Plugin<Project> {
         var mavenLog = project.getDependencies().create("org.apache.maven:maven-plugin-api:2.0.1");
         var jenkinsAccessModifier = project.getConfigurations().create("jenkinsAccessModifier", c -> {
             c.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, project.getObjects().named(Usage.class, Usage.JAVA_RUNTIME));
-            c.setVisible(false);
             c.setCanBeConsumed(false);
             c.setCanBeResolved(true);
             c.withDependencies(dependencies -> {

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/localization/LocalizationPlugin.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/localization/LocalizationPlugin.java
@@ -91,7 +91,6 @@ public class LocalizationPlugin implements Plugin<Project> {
         } catch (NoSuchMethodException ignored) {
             return target.getConfigurations().create(CONFIGURATION_NAME, c -> {
                 configure.execute(c);
-                c.setVisible(false);
                 c.setCanBeConsumed(false);
                 c.setCanBeResolved(true);
             });


### PR DESCRIPTION
## Summary
- Since Gradle 9.0.0, `Configuration.setVisible()` has no meaningful effect, is deprecated as of Gradle 9.8.0, and will be removed in Gradle 10.0.0
- Removed the calls from `UnsupportedGradleConfigurationVerifier`, `LocalizationPlugin` (jpi and jpi2), and `V2JpiPlugin`

Fixes: #415