### PR TITLE
Bump access-modifier-checker 1.33 -> 1.35 so checkAccessModifier readss Java 25

### DIFF
--- a/jpi/src/main/kotlin/org/jenkinsci/gradle/plugins/accmod/AccessModifierPlugin.kt
+++ b/jpi/src/main/kotlin/org/jenkinsci/gradle/plugins/accmod/AccessModifierPlugin.kt
@@ -15,7 +15,7 @@ open class AccessModifierPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             apply<JavaLibraryPlugin>()
-            val library = dependencies.create("org.kohsuke:access-modifier-checker:1.33")
+            val library = dependencies.create("org.kohsuke:access-modifier-checker:1.35")
             val mavenLog = dependencies.create("org.apache.maven:maven-plugin-api:2.0.1").apply {
                 because("Requires org.apache.maven.plugin.logging.Log but missing dependency")
             }

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
@@ -376,7 +376,7 @@ public class V2JpiPlugin implements Plugin<Project> {
     }
 
     private static void configureAccessModifier(@NotNull Project project) {
-        var library = project.getDependencies().create("org.kohsuke:access-modifier-checker:1.33");
+        var library = project.getDependencies().create("org.kohsuke:access-modifier-checker:1.35");
         var mavenLog = project.getDependencies().create("org.apache.maven:maven-plugin-api:2.0.1");
         var jenkinsAccessModifier = project.getConfigurations().create("jenkinsAccessModifier", c -> {
             c.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, project.getObjects().named(Usage.class, Usage.JAVA_RUNTIME));


### PR DESCRIPTION
checkAccessModifier reads compiled classes via org.kohsuke:access-modifier-checker, which brings ASM transitively. Both the v1 (AccessModifierPlugin.kt) and v2 (V2JpiPlugin.java) paths hardcoded 1.33 -> ASM 9.6, which cannot parse Java 25 bytecode (class file major version 69) and fails the task on JDK 25. Bump to 1.35 (ASM 9.8, reads Java 25), matching the value already declared in gradle/libs.versions.toml.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
