### PR TITLE
fix(jpi2): stop fingerprinting the whole root directory for testServer

### DIFF
--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/TestServerTask.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/TestServerTask.java
@@ -50,7 +50,8 @@ import java.util.List;
  *
  * <p><strong>Cacheability boundary.</strong> Because the nested build re-evaluates the whole project,
  * its inputs cannot be captured exhaustively from here. Changes to build logic <em>outside</em> the
- * modeled set are <em>not</em> guaranteed to invalidate the cache, notably: included builds located
+ * modeled set are <em>not</em> guaranteed to invalidate the cache, notably: scripts applied from
+ * outside {@code gradle/}, included builds located
  * outside the project tree, environment variables, {@code ~/.gradle/gradle.properties}, the Gradle or
  * wrapper version, and dynamic dependency versions resolved from the network. When in doubt, run with
  * {@code --rerun-tasks} to force a fresh launch.
@@ -97,9 +98,9 @@ public abstract class TestServerTask extends DefaultTask {
     public abstract ConfigurableFileCollection getInitScriptFiles();
 
     /**
-     * @return build-logic files for the nested build's project tree: build &amp; settings scripts
-     * ({@code *.gradle}, {@code *.gradle.kts}), {@code gradle.properties}, version catalogs
-     * ({@code *.versions.toml}), and {@code buildSrc} sources. Changes to these affect the nested
+     * @return build-logic files for the nested build's project tree: each project's build script and
+     * {@code gradle.properties}, the root settings script, the scripts and version catalogs
+     * ({@code *.versions.toml}) under {@code gradle/}, and {@code buildSrc} sources. Changes to these affect the nested
      * build's behavior (e.g. {@code JavaExec} task args or resolved plugin versions) but are not
      * captured by plugin-file or classpath inputs. This is best-effort, not exhaustive — see the
      * cacheability boundary on the class javadoc.

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
@@ -341,18 +341,7 @@ public class V2JpiPlugin implements Plugin<Project> {
                 var initScripts = startParameter.getAllInitScripts();
                 task.getInitScriptFiles().from(initScripts);
                 task.getInitScriptPaths().set(initScripts.stream().map(File::getAbsolutePath).toList());
-                task.getBuildConfigFiles().from(project.fileTree(project.getRootDir(), tree -> {
-                    // Build logic that can change how the nested :server / :hplRun build behaves.
-                    // This cannot be exhaustive — the nested build re-evaluates everything — so see
-                    // the cacheability note on TestServerTask for what is and isn't guaranteed.
-                    tree.include(
-                            "**/*.gradle", "**/*.gradle.kts",   // build & settings scripts (incl. buildSrc, included builds)
-                            "**/gradle.properties",
-                            "**/*.versions.toml",               // version catalogs, e.g. gradle/libs.versions.toml
-                            "buildSrc/src/**"                   // precompiled script plugins / buildSrc logic
-                    );
-                    tree.exclude("**/build/**", "**/.gradle/**");
-                }));
+                addBuildConfigFiles(project, task);
                 task.getIncludedBuilds().set(startParameter.getIncludedBuilds().stream()
                         .map(File::getPath).toList());
                 task.getOffline().set(startParameter.isOffline());
@@ -374,6 +363,42 @@ public class V2JpiPlugin implements Plugin<Project> {
                 task.getMaxParallelLaunches().set(maxParallelLaunches);
             }
         });
+    }
+
+    /**
+     * Registers the build logic that can change how the nested {@code :server} / {@code :hplRun}
+     * build behaves: build &amp; settings scripts, {@code gradle.properties}, version catalogs and
+     * {@code buildSrc} sources.
+     *
+     * <p>The files are enumerated per project instead of scanned from the root directory. A file
+     * tree rooted at the root directory is an ancestor of every other task's output in the build
+     * (a sibling module's Jenkins work directory, an npm install directory, …), and Gradle reports
+     * such an input as an undeclared dependency on those producing tasks and, since Gradle 9, fails
+     * the build for it. Naming the files keeps the fingerprint without claiming to read the whole
+     * tree.
+     *
+     * <p>This cannot be exhaustive — the nested build re-evaluates everything — so see the
+     * cacheability note on {@link TestServerTask} for what is and isn't guaranteed.
+     */
+    private static void addBuildConfigFiles(@NotNull Project project, @NotNull TestServerTask task) {
+        var rootDir = project.getRootDir();
+        var files = new LinkedHashSet<File>();
+        files.add(new File(rootDir, "settings.gradle"));
+        files.add(new File(rootDir, "settings.gradle.kts"));
+        // buildSrc is a separate build, so it is not part of getAllprojects().
+        for (var name : List.of("build.gradle", "build.gradle.kts", "settings.gradle", "settings.gradle.kts", "gradle.properties")) {
+            files.add(new File(rootDir, "buildSrc/" + name));
+        }
+        for (var candidate : project.getRootProject().getAllprojects()) {
+            files.add(candidate.getBuildFile());
+            files.add(new File(candidate.getProjectDir(), "gradle.properties"));
+        }
+        task.getBuildConfigFiles().from(files);
+        // The `gradle` and `buildSrc/src` directories hold no task outputs, so they are safe to
+        // walk as trees: version catalogs, script plugins and precompiled build logic.
+        task.getBuildConfigFiles().from(project.fileTree(new File(rootDir, "gradle"), tree ->
+                tree.include("**/*.versions.toml", "**/*.gradle", "**/*.gradle.kts")));
+        task.getBuildConfigFiles().from(project.fileTree(new File(rootDir, "buildSrc/src")));
     }
 
     private static void configureAccessModifier(@NotNull Project project) {

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/MultiModuleIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/MultiModuleIntegrationTest.java
@@ -136,6 +136,25 @@ class MultiModuleIntegrationTest extends V2IntegrationTestBase {
     }
 
     @Test
+    @Timeout(value = 15, unit = TimeUnit.MINUTES)
+    void testServerDoesNotClaimSiblingModuleOutputsAsItsOwnInputs() throws IOException {
+        var ith = new IntegrationTestHelper(tempDir, "8.14");
+        configureTwoPluginsForVerification(ith);
+
+        // A sibling module's prepareServer writes into upstream/work, i.e. inside the root
+        // directory. If testServer fingerprinted its build logic by scanning the root directory,
+        // that input would cover the sibling's output and Gradle would flag the missing dependency.
+        // Gradle only reports the overlap for output produced earlier in the same build, hence the
+        // single worker and the sibling task listed first.
+        var result = ith.gradleRunner()
+                .withArguments(":upstream:prepareServer", ":downstream:testServer", "--max-workers=1")
+                .build();
+
+        assertThat(result.task(":downstream:testServer").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(result.getOutput()).doesNotContain("implicit dependency");
+    }
+
+    @Test
     void multiModuleWithNestedDependenciesShouldLaunchRun() throws IOException, InterruptedException {
         // given
         var ith = new IntegrationTestHelper(tempDir, "8.14");


### PR DESCRIPTION
## Problem

`testServer` / `testHplRun` tracked the build logic that can change the nested `:server` / `:hplRun` build through a file tree rooted at the root directory:

```java
task.getBuildConfigFiles().from(project.fileTree(project.getRootDir(), tree -> {
    tree.include("**/*.gradle", "**/*.gradle.kts", "**/gradle.properties", ...);
    tree.exclude("**/build/**", "**/.gradle/**");
}));
```

That tree root is an ancestor of every other task's output directory in the build. In a multi-module build where a sibling module writes inside the root directory — another module's Jenkins work directory, an npm install directory — Gradle reports the launch task as consuming those outputs without a dependency:

```
Some problems were found with the configuration of task ':a:testServer' (type 'TestServerTask').
Property has implicit dependency
  Gradle detected a problem with the following location: '<root directory>'
    Task ':a:testServer' uses this output of task ':b:prepareServer' without declaring
    an explicit or implicit dependency.
```

Gradle 9 fails the build for this. It surfaces only when the producing task actually executes earlier in the same build, so it looks intermittent and depends on `--max-workers` and task ordering.

Include/exclude patterns cannot fix it: the location Gradle records is the tree root, not the matched files. Declaring `dependsOn`/`mustRunAfter` on the producers (as the error suggests) would be wrong — the launch task does not consume those outputs, and it would couple every module's verification to every other module's `prepareServer`.

## Change

Enumerate the build-logic files instead of scanning the root directory:

- each project's build script and `gradle.properties`
- the root settings script and `buildSrc`'s own build/settings scripts and `gradle.properties`
- trees over `gradle/` (scripts, `*.versions.toml` catalogs) and `buildSrc/src`, neither of which holds task outputs

The fingerprint is equivalent for practical build logic, so both launch tasks stay cacheable and still rerun when a build script, `gradle.properties` or version catalog changes. Scripts applied from outside `gradle/` are no longer tracked; that is documented with the other cacheability caveats on `TestServerTask`.

## Verification

- New `MultiModuleIntegrationTest.testServerDoesNotClaimSiblingModuleOutputsAsItsOwnInputs` reproduces the exact `implicit dependency` failure on the previous code and passes with this change. It runs the sibling's `prepareServer` first with `--max-workers=1`, since Gradle only reports the overlap for output produced earlier in the same build.
- `SimpleBuildIntegrationTest` and `MultiModuleIntegrationTest` pass in full (19 tests), including `testServerInvalidatesOnBuildScriptChange`, `testHplRunInvalidatesOnBuildScriptChange` and the cacheability tests — caching behaviour is unchanged.
- Confirmed against a 34-module build with `jpi2` mode: the failure reproduces before the change and the full `testServer` graph succeeds after it.