### PR TITLE
fix(jpi2): install test-classpath plugin dependencies into `JenkinsRule`

### DIFF
--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/CopyTestPluginDependenciesTask.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/CopyTestPluginDependenciesTask.java
@@ -1,0 +1,83 @@
+package org.jenkinsci.gradle.plugins.jpi2;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.FileSystemOperations;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
+
+import javax.inject.Inject;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.LinkedHashSet;
+
+/**
+ * Copies the Jenkins plugin ({@code .hpi}/{@code .jpi}) dependencies resolved on the test
+ * classpath into the {@code test-dependencies} layout that jenkins-test-harness's
+ * {@code UnitTestSupportingPluginManager} reads at runtime: a {@code test-dependencies/index}
+ * file listing one plugin short name per line, alongside a {@code <shortName>.jpi} file for
+ * each.
+ */
+@CacheableTask
+public abstract class CopyTestPluginDependenciesTask extends DefaultTask {
+    /** Standard name under which this task is registered. */
+    public static final String NAME = "copyTestPluginDependencies";
+
+    @Inject
+    protected abstract FileSystemOperations getFileSystemOperations();
+
+    /** @return the resolved {@code .hpi}/{@code .jpi} artifact files to install */
+    @InputFiles
+    @PathSensitive(PathSensitivity.NONE)
+    public abstract ConfigurableFileCollection getPluginFiles();
+
+    /** @return mapping of each plugin file's name (e.g. {@code git-5.7.0.hpi}) to its short name (e.g. {@code git}) */
+    @Input
+    public abstract MapProperty<String, String> getFileNameToPluginId();
+
+    /** @return the {@code test-dependencies} directory to populate */
+    @OutputDirectory
+    public abstract DirectoryProperty getOutputDir();
+
+    @TaskAction
+    void copy() {
+        var lookup = getFileNameToPluginId().get();
+        var outputDir = getOutputDir().get().getAsFile();
+        var pluginIds = new LinkedHashSet<String>();
+
+        getFileSystemOperations().copy(spec -> {
+            spec.from(getPluginFiles());
+            spec.into(outputDir);
+            spec.rename(fileName -> {
+                var pluginId = lookup.get(fileName);
+                return pluginId == null ? fileName : pluginId + ".jpi";
+            });
+        });
+
+        getPluginFiles().forEach(file -> {
+            var pluginId = lookup.get(file.getName());
+            if (pluginId != null) {
+                pluginIds.add(pluginId);
+            }
+        });
+
+        try (BufferedWriter writer = Files.newBufferedWriter(outputDir.toPath().resolve("index"), StandardCharsets.UTF_8)) {
+            for (String pluginId : pluginIds) {
+                writer.write(pluginId);
+                writer.newLine();
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
@@ -31,6 +31,7 @@ import org.gradle.api.tasks.Sync;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.bundling.War;
+import org.gradle.api.tasks.testing.Test;
 import org.jenkinsci.gradle.plugins.jpi2.localization.LocalizationPlugin;
 import org.jenkinsci.gradle.plugins.jpi2.accmod.CheckAccessModifierTask;
 import org.jenkinsci.gradle.plugins.jpi2.accmod.PrefixedPropertiesProvider;
@@ -100,6 +101,12 @@ public class V2JpiPlugin implements Plugin<Project> {
         var testRuntimeClasspath = configurations.getByName("testRuntimeClasspath");
         testRuntimeClasspath.shouldResolveConsistentlyWith(jenkinsCore);
         testRuntimeClasspath.getAttributes().attribute(ARTIFACT_TYPE_ATTRIBUTE, project.getObjects().named(ArtifactType.class, ArtifactType.PLUGIN_JAR));
+
+        var testDefaultRuntime = configurations.create("testDefaultRuntime");
+        testDefaultRuntime.setCanBeConsumed(false);
+        testRuntimeClasspath.getExtendsFrom().forEach(testDefaultRuntime::extendsFrom);
+        testDefaultRuntime.shouldResolveConsistentlyWith(jenkinsCore);
+        testDefaultRuntime.getAttributes().attribute(ARTIFACT_TYPE_ATTRIBUTE, project.getObjects().named(ArtifactType.class, ArtifactType.DEFAULT));
 
         var defaultRuntime = configurations.create("defaultRuntime");
         runtimeClasspath.getExtendsFrom().forEach(defaultRuntime::extendsFrom);
@@ -267,6 +274,8 @@ public class V2JpiPlugin implements Plugin<Project> {
         dependencies.add("testImplementation", jenkinsTestHarnessCoordinate);
         dependencies.add("testImplementation", "org.junit.jupiter:junit-jupiter");
         dependencies.add("testRuntimeOnly", "org.junit.platform:junit-platform-launcher");
+
+        configureTestPluginDependencies(project, testDefaultRuntime);
 
         dependencies.add(jenkinsCore.getName(), jenkinsCoreCoordinate);
 
@@ -665,6 +674,41 @@ public class V2JpiPlugin implements Plugin<Project> {
     private static String getVersionFromProperties(@NotNull Project project, String propertyName, String defaultVersion) {
         Provider<String> myProperty = project.getProviders().gradleProperty(propertyName);
         return myProperty.getOrElse(defaultVersion);
+    }
+
+    /**
+     * Wires up {@link CopyTestPluginDependenciesTask} so that Jenkins plugin dependencies
+     * resolved on the test classpath (not just library jars) are installed into the
+     * {@code JenkinsRule} instance used by the {@code test} task, mirroring what JPI (v1)'s
+     * {@code copyTestPluginDependencies} task does.
+     */
+    private static void configureTestPluginDependencies(@NotNull Project project, @NotNull Configuration testDefaultRuntime) {
+        var testPluginDependenciesDir = project.getLayout().getBuildDirectory().dir("jpi-plugin/test");
+        var copyTestPluginDependencies = project.getTasks().register(
+                CopyTestPluginDependenciesTask.NAME,
+                CopyTestPluginDependenciesTask.class,
+                task -> {
+                    task.setGroup("Verification");
+                    task.setDescription("Copies Jenkins plugin dependencies on the test classpath into a directory " +
+                            "jenkins-test-harness reads to install them as plugins in JenkinsRule.");
+                    task.getPluginFiles().from(project.provider(() -> resolveTestPluginArtifacts(testDefaultRuntime).stream()
+                            .map(ResolvedArtifact::getFile)
+                            .collect(Collectors.toList())));
+                    task.getFileNameToPluginId().set(project.provider(() -> resolveTestPluginArtifacts(testDefaultRuntime).stream()
+                            .collect(Collectors.toMap(a -> a.getFile().getName(), ResolvedArtifact::getName, (a, b) -> a))));
+                    task.getOutputDir().set(testPluginDependenciesDir.map(dir -> dir.dir("test-dependencies")));
+                });
+        project.getTasks().named("test", Test.class, task -> {
+            task.getInputs().files(copyTestPluginDependencies);
+            task.setClasspath(task.getClasspath().plus(project.files(testPluginDependenciesDir)));
+        });
+    }
+
+    @NotNull
+    private static List<ResolvedArtifact> resolveTestPluginArtifacts(@NotNull Configuration testDefaultRuntime) {
+        return testDefaultRuntime.getResolvedConfiguration().getResolvedArtifacts().stream()
+                .filter(a -> "jpi".equals(a.getExtension()) || "hpi".equals(a.getExtension()))
+                .collect(Collectors.toList());
     }
 
     @Nullable

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/TestHarnessIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/TestHarnessIntegrationTest.java
@@ -6,7 +6,6 @@ import org.jenkinsci.gradle.plugins.jpi.IntegrationTestHelper;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.jar.Manifest;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -274,5 +273,45 @@ class TestHarnessIntegrationTest extends V2IntegrationTestBase {
         assertThat(result.getOutput())
                 .contains("org.jenkins-ci.main:jenkins-test-harness:2411.v1e79b_0dc94b_7")
                 .contains("org.jenkins-ci.main:jenkins-core:2.492.1");
+    }
+
+    @Test
+    void jpiDependenciesShouldBeInstalledAsPluginsNotJustOnClasspath() throws IOException {
+        // given
+        var ith = new IntegrationTestHelper(tempDir, "8.14");
+        initBuild(ith);
+        Files.writeString(ith.inProjectDir("build.gradle.kts").toPath(), getBasePluginConfig() + /* language=kotlin */ """
+                dependencies {
+                    implementation("org.jenkins-ci.plugins:git:5.7.0")
+                }
+                """);
+        ith.mkDirInProjectDir("src/test/java/com/example/plugin");
+        Files.writeString(ith.inProjectDir("src/test/java/com/example/plugin/PluginTest.java").toPath(), /* language=java */ """
+                package com.example.plugin;
+                import org.junit.jupiter.api.Test;
+                import org.jvnet.hudson.test.JenkinsRule;
+                import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+                import static org.junit.jupiter.api.Assertions.*;
+                @WithJenkins
+                public class PluginTest {
+                    /** @noinspection JUnitMalformedDeclaration*/
+                    @Test
+                    void test(JenkinsRule j) {
+                        // The git plugin is only usable at runtime if the Jenkins
+                        // instance under test actually has it installed, not merely
+                        // available on the classpath.
+                        assertNotNull(j.jenkins.getPluginManager().getPlugin("git"),
+                                "git plugin should be installed in the JenkinsRule instance");
+                    }
+                }
+                """);
+
+        GradleRunner gradleRunner = ith.gradleRunner();
+
+        // when
+        var result = gradleRunner.withArguments("test").build();
+
+        // then
+        assertThat(result.getOutput()).contains("BUILD SUCCESSFUL");
     }
 }


### PR DESCRIPTION
JPI2 resolved Jenkins plugin dependencies onto the test classpath but never registered them as installed plugins, so `JenkinsRule`-based tests
couldn't use them at runtime (e.g. pipeline steps backed by a plugin dependency would fail to find it).

Fixes #416
