### PR TITLE
Fix deprecated Gradle 10 properties usage in PrefixedPropertiesProvider

### DIFF
--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
@@ -442,7 +442,7 @@ public class V2JpiPlugin implements Plugin<Project> {
             });
         });
 
-        var propertyProvider = project.provider(new PrefixedPropertiesProvider(project, CheckAccessModifierTask.PREFIX));
+        var propertyProvider = PrefixedPropertiesProvider.gradlePropertiesPrefixedBy(project, CheckAccessModifierTask.PREFIX);
         var checkAccessModifier = project.getTasks().register(CheckAccessModifierTask.NAME, CheckAccessModifierTask.class, task -> {
             task.setGroup("Verification");
             task.setDescription("Checks if Jenkins restricted apis are used (https://tiny.cc/jenkins-restricted).");

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/accmod/CheckAccess.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/accmod/CheckAccess.java
@@ -42,7 +42,7 @@ public abstract class CheckAccess implements WorkAction<CheckAccessParameters> {
         URLClassLoader loader = new URLClassLoader(urls, getClass().getClassLoader());
         InternalErrorListener listener = new InternalErrorListener();
         Properties props = new Properties();
-        getParameters().getPropertiesForAccessModifier().get().forEach(props::put);
+        props.putAll(getParameters().getPropertiesForAccessModifier().get());
 
         try {
             Checker checker = new Checker(loader, listener, props, new MavenLoggingBridge());

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/accmod/CheckAccessModifierTask.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/accmod/CheckAccessModifierTask.java
@@ -29,7 +29,7 @@ public abstract class CheckAccessModifierTask extends DefaultTask {
 
     private final WorkerExecutor workerExecutor;
     private final ConfigurableFileCollection accessModifierClasspath;
-    private final MapProperty<String, Object> accessModifierProperties;
+    private final MapProperty<String, String> accessModifierProperties;
     private final ConfigurableFileCollection compileClasspath;
     private final ConfigurableFileCollection compilationDirs;
     private final Property<Boolean> ignoreFailures;
@@ -46,7 +46,7 @@ public abstract class CheckAccessModifierTask extends DefaultTask {
         this.workerExecutor = workerExecutor;
         var objects = getProject().getObjects();
         this.accessModifierClasspath = objects.fileCollection();
-        this.accessModifierProperties = objects.mapProperty(String.class, Object.class);
+        this.accessModifierProperties = objects.mapProperty(String.class, String.class);
         this.compileClasspath = objects.fileCollection();
         this.compilationDirs = objects.fileCollection();
         this.ignoreFailures = objects.property(Boolean.class);
@@ -61,7 +61,7 @@ public abstract class CheckAccessModifierTask extends DefaultTask {
 
     /** @return additional properties forwarded to the checker (e.g. project-property overrides) */
     @Input
-    public MapProperty<String, Object> getAccessModifierProperties() {
+    public MapProperty<String, String> getAccessModifierProperties() {
         return accessModifierProperties;
     }
 

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/accmod/CheckAccessParameters.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/accmod/CheckAccessParameters.java
@@ -12,7 +12,7 @@ import org.gradle.workers.WorkParameters;
  */
 public interface CheckAccessParameters extends WorkParameters {
     /** @return extra properties forwarded to {@code kohsuke.accmod.Checker} */
-    MapProperty<String, Object> getPropertiesForAccessModifier();
+    MapProperty<String, String> getPropertiesForAccessModifier();
 
     /** @return full classpath (compiled classes + compile deps) for type resolution during scanning */
     ConfigurableFileCollection getClasspathToScan();

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/accmod/PrefixedPropertiesProvider.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/accmod/PrefixedPropertiesProvider.java
@@ -1,39 +1,31 @@
 package org.jenkinsci.gradle.plugins.jpi2.accmod;
 
 import org.gradle.api.Project;
+import org.gradle.api.provider.Provider;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
 
 /**
  * Extracts Gradle project properties that share a common prefix and strips that prefix,
  * making them available as a plain map to the access-modifier checker.
  */
-public class PrefixedPropertiesProvider implements Callable<Map<String, Object>> {
-    private final Project project;
-    private final String prefix;
+public class PrefixedPropertiesProvider {
+    private PrefixedPropertiesProvider() {
+    }
 
     /**
      * @param project the Gradle project whose properties are scanned
      * @param prefix  only properties with this prefix are included; the prefix is stripped from the keys
+     * @return a provider with a map of properties with the given prefix, with the prefix stripped from the keys
      */
-    public PrefixedPropertiesProvider(Project project, String prefix) {
-        this.project = project;
-        this.prefix = prefix;
-    }
-
-    @Override
-    public Map<String, Object> call() {
-        Map<String, Object> filtered = new LinkedHashMap<>();
-        for (Map.Entry<String, ?> entry : project.getProperties().entrySet()) {
-            Object value = entry.getValue();
-            String key = entry.getKey();
-            if (key.startsWith(prefix) && value != null) {
-                String trimmed = key.substring(prefix.length());
-                filtered.put(trimmed, value);
-            }
-        }
-        return filtered;
+    public static Provider<Map<String, String>> gradlePropertiesPrefixedBy(Project project, String prefix) {
+        return project.getProviders().gradlePropertiesPrefixedBy(prefix).map(properties ->
+                properties.entrySet().stream()
+                        .filter(e -> e.getValue() != null)
+                        .collect(Collectors.toMap(
+                                e -> e.getKey().substring(prefix.length()),
+                                Map.Entry::getValue))
+        );
     }
 }


### PR DESCRIPTION
Gradle 10 will deprecate getting all properties from the `Project` instance in favour of methods to get specific property names or types. Switch to the new method for getting all properties starting with a given prefix, as this is what this method was attempting to do anyway.

Also refactor the uses of this class, as it was getting a map from a `Provider` instance and then re-wrapping it in a `Provider`. Instead, use the `Provider.map` method to transform the map directly, which is more efficient and avoids the need to create a new `Provider` instance.

<!-- Please describe your pull request here. -->

### Testing done

None specifically run. Existing unit tests confirmed as passing.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
