### PR TITLE
Disable Git commit signing during testing

### DIFF
--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/VersionSourceIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/VersionSourceIntegrationTest.java
@@ -295,7 +295,7 @@ class VersionSourceIntegrationTest extends V2IntegrationTestBase {
         runGit(projectDir, "add", ".");
         runGit(projectDir, "config", "user.email", "test@test");
         runGit(projectDir, "config", "user.name", "Test");
-        runGit(projectDir, "commit", "-m", "Initial commit");
+        runGit(projectDir, "commit", "--no-gpg-sign", "-m", "Initial commit");
     }
 
     private static void runGit(File workDir, String... args) throws IOException, InterruptedException {


### PR DESCRIPTION
Ensure that unit tests can pass successfully without requiring Git commit signing, which may not be available in all testing environments.

This specifically affects me because Git signing is done through 1Password on my local computer, which requires manual intervention to release the key. If I am away from my computer, I can encounter spurious unit test failures when the commit is not able to be signed, which are not related to the tests at all.

<!-- Please describe your pull request here. -->

### Testing done

Tested locally by running tests and confirming I am not prompted for my signing key.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
