### PR TITLE
fix(jpi2): hold reserved testServer port open until process launch

### DIFF
--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/PortAllocationService.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/PortAllocationService.java
@@ -5,23 +5,34 @@ import org.gradle.api.services.BuildServiceParameters;
 
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * A Shared Gradle build service that provides port allocation functionality.
- * This service finds and reserves free ports for use during the build process.
+ * A shared Gradle build service that finds and reserves free TCP ports for use during the build,
+ * e.g. the Jenkins server port for {@code testServer}/{@code testHplRun}.
+ *
+ * <p>{@link #reservePort()} keeps the underlying {@link ServerSocket} open so the reservation is
+ * actually held: the OS cannot hand the same port to another concurrent reservation from this
+ * build (e.g. a sibling module's {@code testServer} task running in parallel) while it is
+ * outstanding. Callers must release it with {@link #releasePort(int)} once they are done with the
+ * number -- typically right before spawning the process that will actually bind it, since the
+ * socket can't be held open across that handoff. Any reservation a caller forgets to release is
+ * closed when the build service itself is closed at the end of the build.
  */
-public abstract class PortAllocationService implements BuildService<BuildServiceParameters.None> {
+public abstract class PortAllocationService implements BuildService<BuildServiceParameters.None>, AutoCloseable {
     private static final int RETRY_LIMIT = 3;
 
+    private final ConcurrentHashMap<Integer, ServerSocket> reservations = new ConcurrentHashMap<>();
+
     /**
-     * Finds and reserves a free port for use during the build.
+     * Reserves a free port, holding it open until {@link #releasePort(int)} is called.
      *
-     * @return a free port number
+     * @return a reserved port number
      * @throws IllegalStateException if no free port can be found after retrying
      */
-    public int findAndReserveFreePort() {
+    public int reservePort() {
         for (int attempt = 0; attempt < RETRY_LIMIT; attempt++) {
-            int port = findFreePort(attempt);
+            int port = tryReserve(attempt);
             if (port > 0) {
                 return port;
             }
@@ -30,16 +41,68 @@ public abstract class PortAllocationService implements BuildService<BuildService
         throw new IllegalStateException("Could not reserve a free port after " + RETRY_LIMIT + " attempts");
     }
 
-    private int findFreePort(int attempt) {
-        try (ServerSocket socket = new ServerSocket(0)) {
+    /**
+     * Releases a port previously obtained from {@link #reservePort()}, closing the socket that was
+     * holding it open. Safe to call more than once, or with a port that was never reserved -- both
+     * are no-ops.
+     *
+     * @param port The port to release
+     */
+    public void releasePort(int port) {
+        closeQuietly(reservations.remove(port));
+    }
+
+    /**
+     * Finds a free port and releases it again before returning, for callers that don't hold a
+     * long-lived reservation. Because the socket is closed before this method returns, the port
+     * can be claimed by anything else on the machine before the caller gets around to using it;
+     * prefer {@link #reservePort()} paired with {@link #releasePort(int)} kept open across the
+     * handoff to another process, which closes that window as much as a TCP port reservation can.
+     *
+     * @return a free port number
+     * @throws IllegalStateException if no free port can be found after retrying
+     */
+    public int findAndReserveFreePort() {
+        int port = reservePort();
+        releasePort(port);
+        return port;
+    }
+
+    /**
+     * Closes any reservations that were never explicitly released, so a caller that fails between
+     * {@link #reservePort()} and {@link #releasePort(int)} doesn't leak an open socket for the rest
+     * of the build. Called automatically by Gradle when the build service is closed.
+     */
+    @Override
+    public void close() {
+        reservations.keySet().forEach(this::releasePort);
+    }
+
+    private int tryReserve(int attempt) {
+        ServerSocket socket;
+        try {
+            socket = new ServerSocket(0);
             socket.setReuseAddress(true);
-            return socket.getLocalPort();
         } catch (IOException e) {
             if (attempt == RETRY_LIMIT - 1) {
                 throw new IllegalStateException("Could not find a free port after " + RETRY_LIMIT + " attempts. Exception at server socket creation.", e);
             }
             return -1;
         }
+
+        int port = socket.getLocalPort();
+        reservations.put(port, socket);
+        return port;
+    }
+
+    private static void closeQuietly(ServerSocket socket) {
+        if (socket == null) {
+            return;
+        }
+        try {
+            socket.close();
+        } catch (IOException ignored) {
+            // Best effort: the port is being released either way.
+        }
     }
 }
-

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/TestServerTask.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/TestServerTask.java
@@ -267,7 +267,7 @@ public abstract class TestServerTask extends DefaultTask {
      * successful start or the timeout. A fresh work directory and port are used per attempt.
      */
     private LaunchResult attemptLaunch(Path workDir, int timeout) throws IOException, InterruptedException {
-        var process = launchProcess(getCommandLine(workDir));
+        var process = launchWithReservedPort(workDir);
         var timedOut = new java.util.concurrent.atomic.AtomicBoolean(false);
 
         var timerThread = new Thread(() -> {
@@ -330,6 +330,29 @@ public abstract class TestServerTask extends DefaultTask {
     @NotNull
     private Process launchProcess(List<String> commandLine) throws IOException {
         return new ProcessBuilder(commandLine).directory(new File(getRootDir().get())).redirectErrorStream(true).start();
+    }
+
+    /**
+     * Reserves the Jenkins server port and holds it open (see {@link PortAllocationService})
+     * while the command line is assembled, releasing it as late as possible -- immediately before
+     * the nested Gradle build is spawned to actually bind it -- to keep the window in which
+     * another process could steal the port as small as possible. See
+     * <a href="https://github.com/jenkinsci/gradle-jpi-plugin/issues/344">#344</a>.
+     */
+    @NotNull
+    private Process launchWithReservedPort(Path workDir) throws IOException {
+        var portAllocationService = getPortAllocationService().get();
+        int port = portAllocationService.reservePort();
+        try {
+            var commandLine = getCommandLine(workDir, port);
+            portAllocationService.releasePort(port);
+            return launchProcess(commandLine);
+        } finally {
+            // Safety net: if reservePort() succeeded but something above threw before the
+            // explicit release, don't leak the held socket for the rest of the build. A no-op if
+            // the port was already released on the success path.
+            portAllocationService.releasePort(port);
+        }
     }
 
     /**
@@ -402,7 +425,7 @@ public abstract class TestServerTask extends DefaultTask {
     }
 
     @NotNull
-    private List<String> getCommandLine(@NotNull Path workDir) {
+    private List<String> getCommandLine(@NotNull Path workDir, int serverPort) {
         List<String> commandLine = new ArrayList<>();
         commandLine.add(slashify(getGradleExecutable().get()));
         commandLine.add("-Dorg.gradle.java.home=" + slashify(getJavaHome().get()));
@@ -439,7 +462,7 @@ public abstract class TestServerTask extends DefaultTask {
         });
 
         commandLine.add(getServerTaskPath().get());
-        commandLine.add("-Pserver.port=" + getPortAllocationService().get().findAndReserveFreePort());
+        commandLine.add("-Pserver.port=" + serverPort);
         commandLine.add("-P" + WorkDirectorySettings.PROPERTY + "=" + slashify(workDir.toAbsolutePath().toString()));
         getLogger().info("Command: {}", commandLine);
         return commandLine;

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/PortAllocationServiceTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/PortAllocationServiceTest.java
@@ -1,0 +1,120 @@
+package org.jenkinsci.gradle.plugins.jpi2;
+
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.net.BindException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.util.ArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Covers <a href="https://github.com/jenkinsci/gradle-jpi-plugin/issues/344">#344</a>: a port
+ * allocated for the Jenkins test server could be stolen by another process before it was
+ * actually used, because the {@link ServerSocket} used to find a free port was closed the instant
+ * it was found.
+ */
+class PortAllocationServiceTest {
+
+    private final PortAllocationService service =
+            ProjectBuilder.builder().build().getObjects().newInstance(PortAllocationService.class);
+
+    @Test
+    void findAndReserveFreePortReleasesImmediately_soItCanStillBeStolen() throws Exception {
+        // findAndReserveFreePort() is kept only as a convenience for callers that don't need a
+        // held reservation; it's still just as vulnerable to being stolen as before.
+        int port = service.findAndReserveFreePort();
+
+        try (ServerSocket thief = new ServerSocket()) {
+            thief.setReuseAddress(true);
+            thief.bind(new InetSocketAddress(port));
+
+            assertThatThrownBy(() -> new ServerSocket(port))
+                    .isInstanceOf(BindException.class)
+                    .hasMessageContaining("Address already in use");
+        }
+    }
+
+    @Test
+    void reservePortHoldsTheSocketUntilReleased() throws Exception {
+        int port = service.reservePort();
+
+        // While the reservation is outstanding, nothing else -- including a concurrent
+        // reservation from a sibling module's testServer task -- can bind that port.
+        assertThatThrownBy(() -> new ServerSocket(port))
+                .isInstanceOf(BindException.class)
+                .hasMessageContaining("Address already in use");
+
+        service.releasePort(port);
+
+        // Once released, the port is free again for the caller to actually hand to the process
+        // that will bind it.
+        assertThatCode(() -> {
+            try (ServerSocket bound = new ServerSocket(port)) {
+                bound.setReuseAddress(true);
+            }
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    void everyOutstandingReservationStaysHeld() {
+        // The guarantee #344 needs: every port handed out is still held while its reservation is
+        // outstanding, so the OS cannot hand the same one to a sibling module's testServer task
+        // under org.gradle.parallel=true. Asserting "all distinct" would NOT catch the old bug --
+        // the OS cycles ephemeral ports, so the pre-fix code produced no duplicates in practice.
+        // Asserting each one is genuinely unbindable does: pre-fix, every port here was free.
+        var reserved = new ArrayList<Integer>();
+        try {
+            for (int i = 0; i < 20; i++) {
+                reserved.add(service.reservePort());
+            }
+
+            assertThat(reserved).allSatisfy(port ->
+                    assertThatThrownBy(() -> new ServerSocket(port))
+                            .as("reservation for port %s must still be held", port)
+                            .isInstanceOf(BindException.class));
+        } finally {
+            reserved.forEach(service::releasePort);
+        }
+    }
+
+    @Test
+    void releasedPortsCanBeHandedOutAgain() {
+        // The flip side: releasing must actually return the port to the pool, otherwise a long
+        // build would exhaust the ephemeral range instead of recycling.
+        int first = service.reservePort();
+        service.releasePort(first);
+
+        int second = service.reservePort();
+        try {
+            // Not necessarily the same number, but reserving must keep working after a release.
+            assertThat(second).isGreaterThan(0);
+        } finally {
+            service.releasePort(second);
+        }
+    }
+
+    @Test
+    void releasePortIsIdempotentAndToleratesUnknownPorts() {
+        int port = service.reservePort();
+
+        service.releasePort(port);
+        assertThatCode(() -> service.releasePort(port)).doesNotThrowAnyException();
+        assertThatCode(() -> service.releasePort(65535)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void closeReleasesAnyReservationsLeftOutstanding() throws Exception {
+        int port = service.reservePort();
+
+        service.close();
+
+        try (ServerSocket bound = new ServerSocket(port)) {
+            bound.setReuseAddress(true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `PortAllocationService.findAndReserveFreePort()` found a free port by opening a `ServerSocket`, reading the port, and closing it right away — releasing it back to the OS before the nested Gradle build's Jetty actually bound it.
- Under `org.gradle.parallel=true`, a sibling module's `testServer`/`testHplRun` task could grab the same port in that window, causing `BindException: Address already in use`.
- Added `reservePort()` / `releasePort(int)` to `PortAllocationService`, which hold the underlying socket open until explicitly released, backed by a `ConcurrentHashMap`. `findAndReserveFreePort()` is kept as a backward-compatible convenience wrapper for callers that don't need the guarantee. The service also implements `AutoCloseable` so any leaked reservation is cleaned up when the build ends.
- `TestServerTask` now reserves the port early and releases it as late as possible — immediately before spawning the nested Gradle process — with a `finally`-block safety net release.

Fixes #344.

I verified this with a repro test (`PortAllocationServiceTest`) that demonstrates the original race by stealing a "reserved" port before use, plus new tests for the hold/release/idempotency/cleanup behavior. Ran the full `jpi2` test suite (100 tests, including the real `testServer`/`testHplRun`/multi-module integration tests that launch actual nested Jenkins servers) — all pass.