### PR TITLE
fix(jpi2): exclude platforms from consistent resolution with jenkinsCore

### DIFF
--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/ConsistentResolution.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/ConsistentResolution.java
@@ -1,0 +1,87 @@
+package org.jenkinsci.gradle.plugins.jpi2;
+
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.DependencySet;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.artifacts.result.ResolvedComponentResult;
+import org.gradle.api.artifacts.result.ResolvedVariantResult;
+import org.gradle.api.attributes.Category;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+/**
+ * Pins configurations to the module versions Jenkins core resolves, so that a plugin is built and
+ * tested against the libraries it will actually get at runtime.
+ *
+ * <p>This is {@link Configuration#shouldResolveConsistentlyWith(Configuration)} minus platforms.
+ * Gradle's own consistent resolution pins every node in the source graph, including artifact-less
+ * platform (BOM) nodes. Third-party libraries leak BOMs into their published runtime metadata -
+ * {@code jenkins-core} pulls in {@code com.github.spotbugs:spotbugs-annotations}, which drags in
+ * {@code org.junit:junit-bom} - and a strict pin on such a BOM makes it impossible to upgrade any
+ * module that BOM governs, because the upgraded modules bring the newer BOM along with them.
+ * Skipping platform nodes costs nothing: they carry no artifacts, and every real module core
+ * resolves is still pinned strictly.
+ *
+ * @see <a href="https://github.com/jenkinsci/gradle-jpi-plugin/issues/429">#429</a>
+ */
+final class ConsistentResolution {
+
+    private ConsistentResolution() {
+    }
+
+    /**
+     * Creates the configuration that carries Jenkins core's resolved versions as strict
+     * constraints. Configurations that should follow core's versions extend from it.
+     *
+     * @param project the project to create the configuration in
+     * @param source  the configuration whose resolved versions win
+     * @return the alignment configuration
+     */
+    @NotNull
+    static Configuration createAlignment(@NotNull Project project, @NotNull Configuration source) {
+        var constraints = project.getDependencies().getConstraints();
+        var reason = "version resolved in configuration ':" + source.getName() + "' by consistent resolution";
+        var alignment = project.getConfigurations().create("jenkinsCoreAlignment");
+        alignment.setCanBeConsumed(false);
+        alignment.setCanBeResolved(false);
+        alignment.setDescription("Strict version constraints matching what Jenkins core resolves.");
+        // Deferred to resolution time: resolving `source` while declaring the alignment would force
+        // every consumer to know the Jenkins version before the build script has finished configuring.
+        alignment.withDependencies(new Action<>() {
+            @Override
+            public void execute(@NotNull DependencySet dependencies) {
+                if (!alignment.getDependencyConstraints().isEmpty()) {
+                    return; // withDependencies runs once per resolution of each extending configuration
+                }
+                source.getIncoming().getResolutionResult().getAllComponents().stream()
+                        .filter(component -> component.getId() instanceof ModuleComponentIdentifier)
+                        .filter(component -> !isPlatform(component))
+                        .map(ResolvedComponentResult::getModuleVersion)
+                        .filter(Objects::nonNull)
+                        .forEach(module -> alignment.getDependencyConstraints().add(
+                                constraints.create(module.getGroup() + ":" + module.getName(), constraint -> {
+                                    constraint.version(version -> version.strictly(module.getVersion()));
+                                    constraint.because(reason);
+                                })));
+            }
+        });
+        return alignment;
+    }
+
+    private static boolean isPlatform(@NotNull ResolvedComponentResult component) {
+        return component.getVariants().stream().allMatch(ConsistentResolution::isPlatform);
+    }
+
+    private static boolean isPlatform(@NotNull ResolvedVariantResult variant) {
+        var attributes = variant.getAttributes();
+        // Attributes of published components come back desugared to String, so match by name.
+        return attributes.keySet().stream()
+                .filter(key -> Category.CATEGORY_ATTRIBUTE.getName().equals(key.getName()))
+                .map(key -> String.valueOf(attributes.getAttribute(key)))
+                .anyMatch(category -> Category.REGULAR_PLATFORM.equals(category)
+                        || Category.ENFORCED_PLATFORM.equals(category));
+    }
+}

--- a/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
+++ b/jpi2/src/main/java/org/jenkinsci/gradle/plugins/jpi2/V2JpiPlugin.java
@@ -93,24 +93,25 @@ public class V2JpiPlugin implements Plugin<Project> {
         var jenkinsTestHarnessCoordinate = testHarnessVersion.map(version -> "org.jenkins-ci.main:jenkins-test-harness:" + version);
 
         var jenkinsCore = configurations.create("jenkinsCore");
+        var jenkinsCoreAlignment = ConsistentResolution.createAlignment(project, jenkinsCore);
 
         var runtimeClasspath = configurations.getByName("runtimeClasspath");
-        runtimeClasspath.shouldResolveConsistentlyWith(jenkinsCore);
+        runtimeClasspath.extendsFrom(jenkinsCoreAlignment);
         runtimeClasspath.getAttributes().attribute(ARTIFACT_TYPE_ATTRIBUTE, project.getObjects().named(ArtifactType.class, ArtifactType.PLUGIN_JAR));
 
         var testRuntimeClasspath = configurations.getByName("testRuntimeClasspath");
-        testRuntimeClasspath.shouldResolveConsistentlyWith(jenkinsCore);
+        testRuntimeClasspath.extendsFrom(jenkinsCoreAlignment);
         testRuntimeClasspath.getAttributes().attribute(ARTIFACT_TYPE_ATTRIBUTE, project.getObjects().named(ArtifactType.class, ArtifactType.PLUGIN_JAR));
 
         var testDefaultRuntime = configurations.create("testDefaultRuntime");
         testDefaultRuntime.setCanBeConsumed(false);
         testRuntimeClasspath.getExtendsFrom().forEach(testDefaultRuntime::extendsFrom);
-        testDefaultRuntime.shouldResolveConsistentlyWith(jenkinsCore);
+        testDefaultRuntime.extendsFrom(jenkinsCoreAlignment);
         testDefaultRuntime.getAttributes().attribute(ARTIFACT_TYPE_ATTRIBUTE, project.getObjects().named(ArtifactType.class, ArtifactType.DEFAULT));
 
         var defaultRuntime = configurations.create("defaultRuntime");
         runtimeClasspath.getExtendsFrom().forEach(defaultRuntime::extendsFrom);
-        defaultRuntime.shouldResolveConsistentlyWith(jenkinsCore);
+        defaultRuntime.extendsFrom(jenkinsCoreAlignment);
         defaultRuntime.getAttributes().attribute(ARTIFACT_TYPE_ATTRIBUTE, project.getObjects().named(ArtifactType.class, ArtifactType.DEFAULT));
 
         var pomFiles = resolvePomFiles(project, defaultRuntime);
@@ -130,7 +131,7 @@ public class V2JpiPlugin implements Plugin<Project> {
         });
 
         var testCompileClasspath = configurations.getByName("testCompileClasspath");
-        testCompileClasspath.shouldResolveConsistentlyWith(jenkinsCore);
+        testCompileClasspath.extendsFrom(jenkinsCoreAlignment);
 
         JavaPluginExtension ext = project.getExtensions().getByType(JavaPluginExtension.class);
         SourceSetContainer sourceSets = ext.getSourceSets();
@@ -263,7 +264,7 @@ public class V2JpiPlugin implements Plugin<Project> {
         project.getDependencies().add("lastAnnotationProcessor", "net.java.sezpoz:sezpoz:1.13");
         project.getDependencies().add("lastAnnotationProcessor", jenkinsCoreCoordinate);
         project.getConfigurations().getByName("annotationProcessor").extendsFrom(lastAnnotationProcessor);
-        lastAnnotationProcessor.shouldResolveConsistentlyWith(jenkinsCore);
+        lastAnnotationProcessor.extendsFrom(jenkinsCoreAlignment);
 
         dependencies.add("compileOnly", jenkinsCoreCoordinate);
         dependencies.add("compileOnly", "jakarta.servlet:jakarta.servlet-api:5.0.0");

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/ArtifactoryInteropIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/ArtifactoryInteropIntegrationTest.java
@@ -1,0 +1,58 @@
+package org.jenkinsci.gradle.plugins.jpi2;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import org.jenkinsci.gradle.plugins.jpi.IntegrationTestHelper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Reproduces <a href="https://github.com/jenkinsci/gradle-jpi-plugin/issues/429">#429</a>: a plugin
+ * that upgraded JUnit past the version jenkins-core drags in transitively could not resolve its
+ * test classpath at all, and applying {@code com.jfrog.artifactory} replaced Gradle's conflict
+ * report with an opaque "dependency has no dependents and is not root" from its own resolution
+ * listener.
+ */
+class ArtifactoryInteropIntegrationTest extends V2IntegrationTestBase {
+
+    /**
+     * jenkins-core 2.541.1 pulls org.junit:junit-bom:5.14.0 in transitively via spotbugs-annotations.
+     * Since a BOM carries no artifacts, aligning it with core buys nothing and only blocks upgrades.
+     */
+    private static final String NEWER_THAN_JENKINS_CORE = "5.14.4";
+
+    @Test
+    void allowsUpgradingJunitPastTheVersionJenkinsCoreBringsIn() throws IOException {
+        var ith = new IntegrationTestHelper(tempDir, "8.14");
+        initBuild(ith);
+        Files.writeString(ith.inProjectDir("gradle.properties").toPath(), /* language=properties */ """
+                jenkins.version=2.541.1
+                """);
+        Files.writeString(ith.inProjectDir("build.gradle.kts").toPath(), /* language=kotlin */ """
+                plugins {
+                    id("org.jenkins-ci.jpi2")
+                    id("com.jfrog.artifactory") version "5.2.5"
+                }
+                repositories {
+                    mavenCentral()
+                    jenkinsPublic()
+                }
+                group = "com.example"
+                version = "1.0.0"
+                dependencies {
+                    testImplementation(platform("org.junit:junit-bom:%s"))
+                }
+                """.formatted(NEWER_THAN_JENKINS_CORE));
+
+        var result = ith.gradleRunner()
+                .withArguments("dependencyInsight", "--configuration", "testDefaultRuntime",
+                        "--dependency", "org.junit.jupiter:junit-jupiter-api")
+                .build();
+
+        assertThat(result.getOutput())
+                .contains("BUILD SUCCESSFUL")
+                .contains("org.junit.jupiter:junit-jupiter-api:" + NEWER_THAN_JENKINS_CORE);
+    }
+
+}

--- a/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/DependencyResolutionIntegrationTest.java
+++ b/jpi2/src/test/java/org/jenkinsci/gradle/plugins/jpi2/DependencyResolutionIntegrationTest.java
@@ -192,4 +192,40 @@ class DependencyResolutionIntegrationTest extends V2IntegrationTestBase {
                         "test-plugin-1.0.0.jar",
                         "commons-math3-3.6.1.jar");
     }
+
+    /**
+     * Libraries Jenkins core ships are strictly pinned to core's version, so a plugin cannot build
+     * or test against a version it will not get at runtime.
+     */
+    @Test
+    void stillPinsLibrariesJenkinsCoreShipsToCoreVersion() throws IOException {
+        var ith = new IntegrationTestHelper(tempDir, "8.14");
+        initBuild(ith);
+        Files.writeString(ith.inProjectDir("gradle.properties").toPath(), /* language=properties */ """
+                jenkins.version=2.541.1
+                """);
+        Files.writeString(ith.inProjectDir("build.gradle.kts").toPath(), /* language=kotlin */ """
+                plugins {
+                    id("org.jenkins-ci.jpi2")
+                }
+                repositories {
+                    mavenCentral()
+                    jenkinsPublic()
+                }
+                group = "com.example"
+                version = "1.0.0"
+                dependencies {
+                    testImplementation("commons-io:commons-io:2.21.0")
+                }
+                """);
+
+        var result = ith.gradleRunner()
+                .withArguments("copyTestPluginDependencies")
+                .buildAndFail();
+
+        assertThat(result.getOutput())
+                .contains("Cannot find a version of 'commons-io:commons-io' that satisfies the version constraints")
+                .contains("commons-io:commons-io:{strictly 2.20.0}")
+                .contains("by consistent resolution");
+    }
 }


### PR DESCRIPTION
Fixes #429.

## Problem

`shouldResolveConsistentlyWith(jenkinsCore)` pins every node in core's graph, including artifact-less platform (BOM) nodes. `jenkins-core` pulls `com.github.spotbugs:spotbugs-annotations:4.9.8`, whose Gradle module metadata declares `org.junit:junit-bom` in `runtimeElements`:

```
org.junit:junit-bom:5.14.0                          (org.gradle.category = platform)
\--- com.github.spotbugs:spotbugs-annotations:4.9.8
     \--- org.jenkins-ci.main:jenkins-core:2.568.2
          \--- jenkinsCore
```

So junit-bom was pinned to `strictly 5.14.0`, and any JUnit upgrade brings the newer BOM along and is rejected:

```
Cannot find a version of 'org.junit:junit-bom' that satisfies the version constraints:
  --> 'org.junit:junit-bom:5.14.4'
  Constraint: 'org.junit:junit-bom:{strictly 5.14.0}' because of: version resolved
             in configuration ':jenkinsCore' by consistent resolution
```

Applying `com.jfrog.artifactory` replaces that report with an opaque `dependency has no dependents and is not root` from its own resolution listener, which is what the issue reports.

This is not version-specific: 2.541.1, 2.555.3 and 2.568.2 all pin spotbugs-annotations 4.9.8 and leak the same junit-bom 5.14.0, so upgrading to the latest LTS does not help. It is also not JUnit-specific — any dependency that leaks a BOM into published runtime metadata reproduces it.

## Fix

Replace `shouldResolveConsistentlyWith(jenkinsCore)` with a `jenkinsCoreAlignment` configuration carrying the same strict constraints, built from core's resolution result but skipping platform nodes. Constraints are populated in `withDependencies`, so declaring the alignment still does not resolve `jenkinsCore` eagerly. They live in a shared declarable configuration because Gradle forbids declaring constraints directly on resolution-only configurations such as `testRuntimeClasspath`.

Skipping platforms costs nothing: BOMs carry no artifacts, and every real module core resolves is still pinned `strictly`.

## Verified

- `./gradlew check` — 98 tests
- Reproduction of the issue (junit-bom 5.14.4 + `com.jfrog.artifactory`) now resolves, with jupiter at 5.14.4, on both 2.541.1 and 2.568.2
- `commons-io:2.21.0` against core's 2.20.0 still fails with `{strictly 2.20.0} ... by consistent resolution`, so the alignment itself is unchanged
- The golden `runtimeClasspath.txt` / `compileClasspath.txt` dependency trees are unchanged
- A downstream multi-module Jenkins plugin build passes against this branch via `--include-build`

## Note

This is a deliberate loosening: a plugin can now upgrade modules governed by a BOM that leaks into core's graph. That BOM is an accident of a third party's metadata rather than something Jenkins ships, so this seems right, but it is a behaviour change worth a look.

New tests: `ArtifactoryInteropIntegrationTest.allowsUpgradingJunitPastTheVersionJenkinsCoreBringsIn` and `DependencyResolutionIntegrationTest.stillPinsLibrariesJenkinsCoreShipsToCoreVersion`.